### PR TITLE
Add context-chaining client router and move things into context

### DIFF
--- a/pysoa/client/router.py
+++ b/pysoa/client/router.py
@@ -6,6 +6,8 @@ class ClientRouter(object):
     Manages creating clients per service.
 
     Pass in a dictionary mapping service names to settings dicts for those services.
+
+    You may also pass in a `context` dictionary to pre-populate clients with it.
     """
 
     settings_class = ClientSettings
@@ -13,11 +15,12 @@ class ClientRouter(object):
     class ImproperlyConfigured(Exception):
         pass
 
-    def __init__(self, config, settings_class=None):
+    def __init__(self, config, settings_class=None, context=None):
         if settings_class:
             self.settings_class = settings_class
         self.cached_clients = {}
         self.settings = {}
+        self.context = context
         # We load the settings now, but do not make clients until requested
         for service_name, service_settings in config.items():
             self.settings[service_name] = self.settings_class(service_settings)
@@ -47,5 +50,6 @@ class ClientRouter(object):
             serializer=serializer_class(**settings['serializer'].get('kwargs', {})),
             middleware=[middleware_class(**middleware_kwargs)
                         for middleware_class, middleware_kwargs in settings['middleware']],
+            context=self.context,
             **client_kwargs
         )

--- a/pysoa/server/schemas.py
+++ b/pysoa/server/schemas.py
@@ -18,8 +18,14 @@ ActionRequestSchema = Dictionary(
 
 ControlHeaderSchema = Dictionary(
     {
-        'switches': List(Integer()),
         'continue_on_error': Boolean(),
+    },
+    allow_extra_keys=True,
+)
+
+ContextHeaderSchema = Dictionary(
+    {
+        'switches': List(Integer()),
         'correlation_id': UnicodeString(),
     },
     allow_extra_keys=True,
@@ -28,8 +34,7 @@ ControlHeaderSchema = Dictionary(
 JobRequestSchema = Dictionary(
     {
         'control': ControlHeaderSchema,
-        'context': SchemalessDictionary(key_type=UnicodeString()),
+        'context': ContextHeaderSchema,
         'actions': List(ActionRequestSchema),
     },
-    optional_keys=['context'],
 )

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -1,14 +1,11 @@
 from conformity import fields
 from pysoa.common.settings import SOASettings
-from pysoa.client.router import ClientRouter
 
 
 class ServerSettings(SOASettings):
     """
     Settings specific to servers
     """
-
-    client_router_class = ClientRouter
 
     schema = {
         "client_routing": fields.SchemalessDictionary(),
@@ -45,6 +42,3 @@ class ServerSettings(SOASettings):
             "shutdown_grace": 30,
         },
     }
-
-    def convert_client_routing(self, value):
-        return self.client_router_class(value)

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -14,3 +14,4 @@ class EnrichedActionRequest(ActionRequest):
     switches = attr.ib(default=attr.Factory(list))
     context = attr.ib(default=attr.Factory(dict))
     control = attr.ib(default=attr.Factory(dict))
+    client_router = attr.ib(default=None)


### PR DESCRIPTION
This provides a client_router object on both job requests and on action
request, and further moves everything that requires chaining from
control into context.