### PR TITLE
Asgi transport overhaul

### DIFF
--- a/pysoa/common/transport/asgi/core.py
+++ b/pysoa/common/transport/asgi/core.py
@@ -1,10 +1,13 @@
 from __future__ import unicode_literals
 
-import time
 import random
-from redis import StrictRedis
-from asgi_redis import RedisChannelLayer
+import six
+import time
+import logging
+
 import attr
+from asgi_redis import RedisChannelLayer
+import redis
 
 from pysoa.common.transport.exceptions import (
     MessageTooLarge,
@@ -22,6 +25,8 @@ from .constants import (
     ASGI_CHANNEL_TYPES_REDIS,
 )
 
+logger = logging.getLogger('pysoa.common.transport')
+
 
 def valid_channel_type(instance, attribute, value):
     if not value or value not in ASGI_CHANNEL_TYPES:
@@ -33,61 +38,102 @@ class ASGITransportCore(object):
     """Handles communication with the ASGI channel layer. Supports Redis and local backends."""
 
     asgi_channel_type = attr.ib(validator=valid_channel_type)
-    asgi_channel_redis_host = attr.ib(default='localhost')
-    asgi_channel_redis_port = attr.ib(default=6379)
-    asgi_channel_redis_db = attr.ib(default=0)
-    channel_full_retries = attr.ib(default=10)
+    redis_hosts = attr.ib(
+        default=['localhost'],
+        validator=attr.validators.instance_of((list, tuple)),
+    )
+    redis_port = attr.ib(
+        default=6379,
+        convert=int,
+    )
+    sentinel_refresh_interval = attr.ib(
+        default=30,
+        convert=int,
+    )
+    redis_db = attr.ib(
+        default=0,
+        convert=int,
+    )
+    channel_full_retries = attr.ib(
+        default=10,
+        convert=int,
+    )
 
     EXPONENTIAL_BACKOFF_FACTOR = 4.0
     BODY_MAX_SIZE = 1024 * 100
 
-    _channel_layer = None
+    def __attrs_post_init__(self):
+        # set the hosts property after all attrs are validated
+        final_hosts = []
+        for host in self.redis_hosts:
+            if isinstance(host, tuple) and len(host) == 2:
+                final_hosts.append(host)
+            elif isinstance(host, six.string_types):
+                final_hosts.append((host, self.redis_port))
+            else:
+                raise Exception('redis_hosts must be a list of strings or tuples of (host, port)')
+        self.hosts = final_hosts
+        self.channel_layer = None
+        self._last_sentinel_refresh = 0
+        self._last_sentinel_ring_size = None
 
-    @property
-    def channel_layer(self):
-        if self._channel_layer is None:
+    def _get_masters_from_sentinel(self):
+        """
+        Get a list of Redis masters from Sentinel. Tries Sentinel hosts until one succeeds; if none succeed,
+        raises a ConnectionError.
+
+        Returns: list of tuples of (host, port)
+        """
+        master_info_list = []
+        connection_errors = []
+        for host in random.shuffle(self.hosts):
             try:
-                self._channel_layer = self._make_asgi_channel_layer()
-            except Exception as e:
-                raise ConnectionError(*e.args)
-        return self._channel_layer
-
-    def _make_asgi_channel_layer(self):
-        """
-        Make an ASGI channel layer for either Redis or local backend. In the Redis case, get master
-        configuration from Sentinel if it is available.
-        """
-        if self.asgi_channel_type in ASGI_CHANNEL_TYPES_REDIS:
-            redis_host = self.asgi_channel_redis_host
-            redis_port = self.asgi_channel_redis_port
-            redis_db = self.asgi_channel_redis_db
-            if self.asgi_channel_type == ASGI_CHANNEL_TYPE_REDIS_SENTINEL:
-                # Get active Redis master host/port from Sentinel
-                redis_client = StrictRedis(
-                    host=redis_host,
-                    port=redis_port,
+                redis_client = redis.StrictRedis(
+                    host=host[0],
+                    port=host[1],
                 )
-                master_info = redis_client.execute_command(
-                    'SENTINEL',
-                    'MASTERS',
-                    parse='SENTINEL_INFO',
+                master_info_list = redis_client.sentinel_masters()
+                break
+            except redis.ConnectionError as e:
+                connection_errors.append(
+                    'Failed to connect to redis://%s:%d: %s' %
+                    (host[0], host[1], str(e))
                 )
-                redis_host = master_info[0]['ip']
-                redis_port = master_info[0]['port']
+                continue
+        if not master_info_list:
+            raise ConnectionError('Could not get master info from sentinel\n{}.'.format('\n'.join(connection_errors)))
+        if self._last_sentinel_ring_size is None:
+            self._last_sentinel_ring_size = len(master_info_list)
+        elif self._last_sentinel_ring_size != len(master_info_list):
+            # If this happens, you have an Ops problem
+            logger.warning('Number of Redis masters changed since last refresh! Messages may be lost.')
+        # Sort the masters just in case the order changes
+        return sorted([(info['ip'], info['port']) for info in master_info_list])
 
-            redis_uri = 'redis://{}:{}/{}/'.format(
-                redis_host,
-                redis_port,
-                redis_db,
-            )
-            return RedisChannelLayer(
-                hosts=[redis_uri],
-            )
-        elif self.asgi_channel_type == ASGI_CHANNEL_TYPE_LOCAL:
-            from asgiref.inmemory import channel_layer
-            return channel_layer
+    def _should_refresh_channel_layer(self):
+        if self.channel_layer is None:
+            return True
+        elif self.asgi_channel_type == ASGI_CHANNEL_TYPE_REDIS_SENTINEL:
+            return (time.time() - self._last_sentinel_refresh) > self.sentinel_refresh_interval
+        return False
+
+    def _refresh_channel_layer(self):
+        """Make an ASGI channel layer for either Redis or local backend."""
+        if self._should_refresh_channel_layer():
+            if self.asgi_channel_type in ASGI_CHANNEL_TYPES_REDIS:
+                if self.asgi_channel_type == ASGI_CHANNEL_TYPE_REDIS_SENTINEL:
+                    hosts = self._get_masters_from_sentinel()
+                else:
+                    hosts = self.hosts
+                host_urls = ['redis://{}:{}/{}'.format(h[0], h[1], self.redis_db) for h in hosts]
+                self.channel_layer = RedisChannelLayer(hosts=host_urls)
+
+            elif self.asgi_channel_type == ASGI_CHANNEL_TYPE_LOCAL:
+                from asgiref.inmemory import channel_layer
+                self.channel_layer = channel_layer
 
     def send_message(self, channel, request_id, meta, body):
+        self._refresh_channel_layer()
         if request_id is None:
             raise InvalidMessageError('No request ID')
         if len(body) > self.BODY_MAX_SIZE:
@@ -110,6 +156,7 @@ class ASGITransportCore(object):
             channel=channel, retries=self.channel_full_retries))
 
     def receive_message(self, channel):
+        self._refresh_channel_layer()
         try:
             # returns message or None if no new messages within timeout (5s by default)
             _, message = self.channel_layer.receive([channel], block=True)

--- a/pysoa/common/transport/asgi/core.py
+++ b/pysoa/common/transport/asgi/core.py
@@ -83,7 +83,8 @@ class SentinelMasterConnectionList(object):
         if self._master_connection_list and len(self._master_connection_list) != len(master_info_list):
             # If this happens, you have an Ops problem
             logger.warning('Number of Redis masters changed since last refresh! Messages may be lost.')
-        return sorted(['redis://{}:{}/0'.format(info['ip'], info['port']) for info in master_info_list])
+        self._master_connection_list = sorted(
+            ['redis://{}:{}/0'.format(info['ip'], info['port']) for info in master_info_list])
 
     def __iter__(self):
         self._refresh_masters()

--- a/pysoa/common/transport/asgi/core.py
+++ b/pysoa/common/transport/asgi/core.py
@@ -46,12 +46,9 @@ class SentinelMasterConnectionList(object):
         self._maybe_refresh_masters()
 
     def _maybe_refresh_masters(self):
-        if self._should_refresh_masters():
+        if (time.time() - self._last_sentinel_refresh) > self.sentinel_refresh_interval:
             hosts = self._get_master_info()
             self._master_connection_list = [redis.Redis.from_url(host, **self.redis_kwargs) for host in hosts]
-
-    def _should_refresh_masters(self):
-        return (time.time() - self._last_sentinel_refresh) > self.sentinel_refresh_interval
 
     def _get_master_info(self):
         """

--- a/pysoa/common/transport/asgi/core.py
+++ b/pysoa/common/transport/asgi/core.py
@@ -22,7 +22,7 @@ from .constants import (
     ASGI_CHANNEL_TYPES,
     ASGI_CHANNEL_TYPE_LOCAL,
     ASGI_CHANNEL_TYPE_REDIS_SENTINEL,
-    ASGI_CHANNEL_TYPES_REDIS,
+    ASGI_CHANNEL_TYPE_REDIS,
 )
 
 logger = logging.getLogger('pysoa.common.transport')
@@ -31,6 +31,81 @@ logger = logging.getLogger('pysoa.common.transport')
 def valid_channel_type(instance, attribute, value):
     if not value or value not in ASGI_CHANNEL_TYPES:
         raise ValueError('asgi_channel_type must be one of {}, got {}'.format(ASGI_CHANNEL_TYPES, value))
+
+
+class SentinelMasterConnectionList(object):
+
+    def __init__(self, hosts, redis_kwargs=None, sentinel_refresh_interval=30):
+        self.hosts = hosts
+        self.sentinel_refresh_interval = sentinel_refresh_interval
+        if redis_kwargs is None:
+            redis_kwargs = {}
+        self.redis_kwargs = redis_kwargs
+        self._master_connection_list = []
+        self._last_sentinel_refresh = 0
+        self._refresh_masters()
+
+    def _refresh_masters(self):
+        if self._should_refresh_masters():
+            hosts = self._get_master_info()
+            self._master_connection_list = [redis.Redis.from_url(host, **self.redis_kwargs) for host in hosts]
+
+    def _should_refresh_masters(self):
+        return (time.time() - self._last_sentinel_refresh) > self.sentinel_refresh_interval
+
+    def _get_master_info(self):
+        """
+        Get a list of Redis masters from Sentinel. Tries Sentinel hosts until one succeeds; if none succeed,
+        raises a ConnectionError.
+
+        Returns: list of tuples of (host, port)
+        """
+        master_info_list = []
+        connection_errors = []
+        for host in random.shuffle(self.hosts):
+            try:
+                redis_client = redis.StrictRedis(
+                    host=host[0],
+                    port=host[1],
+                )
+                master_info_list = redis_client.sentinel_masters()
+                break
+            except redis.ConnectionError as e:
+                connection_errors.append(
+                    'Failed to connect to redis://%s:%d: %s' %
+                    (host[0], host[1], str(e))
+                )
+                continue
+        if not master_info_list:
+            raise ConnectionError('Could not get master info from sentinel\n{}.'.format('\n'.join(connection_errors)))
+        self._last_sentinel_refresh = time.time()
+        # Check that the number of hosts returned by Sentinel is the same as last time
+        if self._master_connection_list and len(self._master_connection_list) != len(master_info_list):
+            # If this happens, you have an Ops problem
+            logger.warning('Number of Redis masters changed since last refresh! Messages may be lost.')
+        return sorted(['redis://{}:{}/0'.format(info['ip'], info['port']) for info in master_info_list])
+
+    def __iter__(self):
+        self._refresh_masters()
+        return iter(self._master_connection_list)
+
+    def __getitem__(self, key):
+        self._refresh_masters()
+        return self._master_connection_list[key]
+
+    def __len__(self):
+        self._refresh_masters()
+        return len(self._master_connection_list)
+
+
+class SentinelRedisChannelLayer(RedisChannelLayer):
+
+    def __init__(self, *args, **kwargs):
+        super(SentinelRedisChannelLayer, self).__init__(*args, **kwargs)
+        self.ring_size = len(self._connection_list)
+
+    def _generate_connections(self, redis_kwargs):
+        return SentinelMasterConnectionList(self.hosts, redis_kwargs)
 
 
 @attr.s()
@@ -73,67 +148,26 @@ class ASGITransportCore(object):
             else:
                 raise Exception('redis_hosts must be a list of strings or tuples of (host, port)')
         self.hosts = final_hosts
-        self.channel_layer = None
-        self._last_sentinel_refresh = 0
-        self._last_sentinel_ring_size = None
+        self._channel_layer = None
 
-    def _get_masters_from_sentinel(self):
-        """
-        Get a list of Redis masters from Sentinel. Tries Sentinel hosts until one succeeds; if none succeed,
-        raises a ConnectionError.
+    @property
+    def channel_layer(self):
+        if self._channel_layer is None:
+            self._make_channel_layer()
+        return self._channel_layer
 
-        Returns: list of tuples of (host, port)
-        """
-        master_info_list = []
-        connection_errors = []
-        for host in random.shuffle(self.hosts):
-            try:
-                redis_client = redis.StrictRedis(
-                    host=host[0],
-                    port=host[1],
-                )
-                master_info_list = redis_client.sentinel_masters()
-                break
-            except redis.ConnectionError as e:
-                connection_errors.append(
-                    'Failed to connect to redis://%s:%d: %s' %
-                    (host[0], host[1], str(e))
-                )
-                continue
-        if not master_info_list:
-            raise ConnectionError('Could not get master info from sentinel\n{}.'.format('\n'.join(connection_errors)))
-        if self._last_sentinel_ring_size is None:
-            self._last_sentinel_ring_size = len(master_info_list)
-        elif self._last_sentinel_ring_size != len(master_info_list):
-            # If this happens, you have an Ops problem
-            logger.warning('Number of Redis masters changed since last refresh! Messages may be lost.')
-        # Sort the masters just in case the order changes
-        return sorted([(info['ip'], info['port']) for info in master_info_list])
-
-    def _should_refresh_channel_layer(self):
-        if self.channel_layer is None:
-            return True
-        elif self.asgi_channel_type == ASGI_CHANNEL_TYPE_REDIS_SENTINEL:
-            return (time.time() - self._last_sentinel_refresh) > self.sentinel_refresh_interval
-        return False
-
-    def _refresh_channel_layer(self):
+    def _make_channel_layer(self):
         """Make an ASGI channel layer for either Redis or local backend."""
-        if self._should_refresh_channel_layer():
-            if self.asgi_channel_type in ASGI_CHANNEL_TYPES_REDIS:
-                if self.asgi_channel_type == ASGI_CHANNEL_TYPE_REDIS_SENTINEL:
-                    hosts = self._get_masters_from_sentinel()
-                else:
-                    hosts = self.hosts
-                host_urls = ['redis://{}:{}/{}'.format(h[0], h[1], self.redis_db) for h in hosts]
-                self.channel_layer = RedisChannelLayer(hosts=host_urls)
-
-            elif self.asgi_channel_type == ASGI_CHANNEL_TYPE_LOCAL:
-                from asgiref.inmemory import channel_layer
-                self.channel_layer = channel_layer
+        if self.asgi_channel_type == ASGI_CHANNEL_TYPE_REDIS_SENTINEL:
+            self._channel_layer = SentinelRedisChannelLayer(self.hosts)
+        elif self.asgi_channel_type == ASGI_CHANNEL_TYPE_REDIS:
+            host_urls = ['redis://{}:{}/{}'.format(h[0], h[1], self.redis_db) for h in self.hosts]
+            self._channel_layer = RedisChannelLayer(host_urls)
+        elif self.asgi_channel_type == ASGI_CHANNEL_TYPE_LOCAL:
+            from asgiref.inmemory import channel_layer
+            self._channel_layer = channel_layer
 
     def send_message(self, channel, request_id, meta, body):
-        self._refresh_channel_layer()
         if request_id is None:
             raise InvalidMessageError('No request ID')
         if len(body) > self.BODY_MAX_SIZE:
@@ -156,7 +190,6 @@ class ASGITransportCore(object):
             channel=channel, retries=self.channel_full_retries))
 
     def receive_message(self, channel):
-        self._refresh_channel_layer()
         try:
             # returns message or None if no new messages within timeout (5s by default)
             _, message = self.channel_layer.receive([channel], block=True)

--- a/pysoa/common/transport/asgi/core.py
+++ b/pysoa/common/transport/asgi/core.py
@@ -46,11 +46,11 @@ class SentinelMasterConnectionList(object):
         self._maybe_refresh_masters()
 
     def _maybe_refresh_masters(self):
-        if self._should_maybe_refresh_masters():
+        if self._should_refresh_masters():
             hosts = self._get_master_info()
             self._master_connection_list = [redis.Redis.from_url(host, **self.redis_kwargs) for host in hosts]
 
-    def _should_maybe_refresh_masters(self):
+    def _should_refresh_masters(self):
         return (time.time() - self._last_sentinel_refresh) > self.sentinel_refresh_interval
 
     def _get_master_info(self):


### PR DESCRIPTION
Sentinel support has been improved. The transport will now refresh masters from Sentinel on a configurable cooldown, defaulting to 30 seconds. After each refresh, it recreates the channel layer if the masters have changed. It also takes into account the edge cases where Sentinel returns the wrong number of masters or returns masters out of order, both of which would break the channel layer's consistent hash sharding.

This code could be easily integrated into asgi-redis, but the ideal situation would be to patch redis-py to support the notion of "all masters" in its Sentinel class.