### PR TITLE
Rewrite local transport to be threadsafe and inlined more

### DIFF
--- a/pysoa/common/transport/__init__.py
+++ b/pysoa/common/transport/__init__.py
@@ -3,13 +3,13 @@ from .asgi import (
     ASGIServerTransport,
 )
 from .local import (
-    ThreadlocalClientTransport,
-    ThreadlocalServerTransport,
+    LocalClientTransport,
+    LocalServerTransport,
 )
 
 __all__ = [
     'ASGIClientTransport',
     'ASGIServerTransport',
-    'ThreadlocalClientTransport',
-    'ThreadlocalServerTransport',
+    'LocalClientTransport',
+    'LocalServerTransport',
 ]

--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -11,10 +11,12 @@ from .base import (
 )
 
 
-class ThreadlocalClientTransport(ClientTransport):
+class LocalClientTransport(ClientTransport):
 
     def __init__(self, service_name, server_class_or_path, server_settings):
-        super(ThreadlocalClientTransport, self).__init__(service_name)
+        super(LocalClientTransport, self).__init__(service_name)
+
+        # If the server is specified as a path, resolve it to a class
         if isinstance(server_class_or_path, basestring):
             try:
                 server_class = resolve_python_path(server_class_or_path)
@@ -23,6 +25,7 @@ class ThreadlocalClientTransport(ClientTransport):
         else:
             server_class = server_class_or_path
 
+        # Make sure the client and the server match names
         if server_class.service_name != service_name:
             raise Exception('Server {} service name "{}" does not match "{}"'.format(
                 server_class,
@@ -30,6 +33,7 @@ class ThreadlocalClientTransport(ClientTransport):
                 service_name,
             ))
 
+        # See if the server settings is actually a string to the path for settings
         if isinstance(server_settings, basestring):
             try:
                 settings_dict = resolve_python_path(server_settings)
@@ -40,43 +44,64 @@ class ThreadlocalClientTransport(ClientTransport):
 
         # Patch settings_dict to use ThreadlocalServerTransport
         settings_dict['transport'] = {
-            'path': 'pysoa.common.transport.local:ThreadlocalServerTransport',
+            'path': 'pysoa.common.transport.local:LocalServerTransport',
         }
+
+        # Set an empty queued request; we'll use this later
+        self._current_request = None
+
+        # Set up a deque for responses for just this client
+        self.response_messages = deque()
 
         # Create and setup Server instance
         self.server_settings = server_class.settings_class(settings_dict)
         self.server = server_class(self.server_settings)
+        self.server.transport = self
         self.server.setup()
 
     def send_request_message(self, request_id, meta, message_string):
-        self.server.transport.request_messages.append(
-            (
-                request_id,
-                meta,
-                message_string,
-            )
-        )
-        self.server.handle_next_request()
-
-    def receive_response_message(self):
-        if self.server.transport.response_messages:
-            return self.server.transport.response_messages.popleft()
-        return (None, None, None)
-
-
-class ThreadlocalServerTransport(ServerTransport):
-
-    def __init__(self, *args, **kwargs):
-        super(ThreadlocalServerTransport, self).__init__(*args, **kwargs)
-        self.request_messages = deque([])
-        self.response_messages = deque([])
+        """
+        Receives a request from the client and handles and dispatches in
+        in-thread.
+        """
+        self._current_request = (request_id, meta, message_string)
+        try:
+            self.server.handle_next_request()
+        finally:
+            self._current_request = None
 
     def receive_request_message(self):
-        if self.request_messages:
-            return self.request_messages.popleft()
-        raise MessageReceiveTimeout
+        """
+        Gives the server the current request (we are actually inside the stack
+        of send_request_message so we know this is OK)
+        """
+        if self._current_request:
+            try:
+                return self._current_request
+            finally:
+                self._current_request = None
+        else:
+            raise RuntimeError("Local server tried to receive message more than once")
 
     def send_response_message(self, request_id, meta, message_string):
+        """
+        Add the response to the deque
+        """
         self.response_messages.append(
             (request_id, meta, message_string,)
         )
+
+    def receive_response_message(self):
+        """
+        Give them a message from the deque
+        """
+        if self.response_messages:
+            return self.response_messages.popleft()
+        return (None, None, None)
+
+
+class LocalServerTransport(ServerTransport):
+    """
+    Empty class that we use as an import stub for local transport before
+    we swap in the Client transport instance to do double duty.
+    """

--- a/pysoa/test/server.py
+++ b/pysoa/test/server.py
@@ -3,7 +3,7 @@ import unittest
 
 from pysoa.client import Client
 from pysoa.common.serializer import MsgpackSerializer
-from pysoa.common.transport.local import ThreadlocalClientTransport
+from pysoa.common.transport.local import LocalClientTransport
 
 
 class ServerTestCase(unittest.TestCase):
@@ -39,7 +39,7 @@ class ServerTestCase(unittest.TestCase):
                     )
 
         # Set up a transport with a local server
-        self.transport = ThreadlocalClientTransport(
+        self.transport = LocalClientTransport(
             self.server_class.service_name,
             self.server_class,
             server_settings=settings,

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -4,7 +4,7 @@ import re
 
 from pysoa.client import Client
 from pysoa.common.types import Error
-from pysoa.common.transport.local import ThreadlocalClientTransport
+from pysoa.common.transport.local import LocalClientTransport
 from pysoa.server import Server
 from pysoa.server.settings import ServerSettings
 from pysoa.server.action import (
@@ -62,7 +62,7 @@ class StubClient(Client):
         self.transport.stub_action(action, body=body, errors=errors)
 
 
-class StubClientTransport(ThreadlocalClientTransport):
+class StubClientTransport(LocalClientTransport):
     """A transport that incorporates an automatically-configured server for handling requests."""
 
     def __init__(self, service_name='test', action_class_map=None):


### PR DESCRIPTION
This changes from a pair of classes that share deques to a single class that is both client and server transport, and so can store the information on itself in a threadsafe manner.

It _does_ use a slightly nasty trick to put itself as the server transport, but short of changing how settings work this is hard not to do.