### PR TITLE
Add helpers to ServerTestCase to make calling actions and asserting errors easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 # Swap files
 *.swp
 .cache
+
+.idea
+.iml

--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -189,6 +189,7 @@ class Client(object):
         Returns the action response or raises an exception if the action response is an error.
 
         Args:
+            service_name: string
             action: string
             body: dict
             switches: list of ints
@@ -217,6 +218,7 @@ class Client(object):
         This method performs expansions if the Client is configured with an expansion converter.
 
         Args:
+            service_name: string
             actions: list of ActionRequest or dict
             switches: list
             context: dict
@@ -372,6 +374,7 @@ class Client(object):
         context and control headers, respectively.
 
         Args:
+            service_name: string
             actions: list of ActionRequest
             switches: list of int
             correlation_id: string

--- a/pysoa/test/server.py
+++ b/pysoa/test/server.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 import os
 import unittest
 
+import six
+
 from pysoa.client import Client
-from pysoa.common.serializer import MsgpackSerializer
-from pysoa.common.transport.local import LocalClientTransport
 
 
 class ServerTestCase(unittest.TestCase):
@@ -53,3 +53,113 @@ class ServerTestCase(unittest.TestCase):
                 },
             },
         )
+
+    def call_action(self, action, body=None, service_name=None, **kwargs):
+        # Using this enables tests that call the same action dozens of times to not have to code in the service name
+        # for every single action call (but they still can by passing in `service_name`)
+        return self.client.call_action(service_name or self.server_class.service_name, action, body=body, **kwargs)
+
+    def assertActionRunsWithAndReturnErrors(self, action, body, **kwargs):
+        try:
+            self.call_action(action, body, **kwargs)
+            # If we got here, it ran with no errors, so fail
+            raise self.failureException('Action ran without any of the expected errors')
+        except self.client.CallActionError as e:
+            return e.actions[0].errors
+
+    def assertActionRunsWithFieldErrors(self, action, body, field_errors, only=False, **kwargs):
+        raised_errors = self.assertActionRunsWithAndReturnErrors(action, body, **kwargs)
+
+        unexpected_errors = []
+        missing_errors = []
+
+        # Provide the flexibility for them to pass it a set or list of error codes, or a single code, per field
+        for field, errors in six.iteritems(field_errors):
+            if not isinstance(errors, set):
+                if isinstance(errors, list):
+                    field_errors[field] = set(errors)
+                else:
+                    field_errors[field] = {errors}
+
+        # Go through all the errors returned by the action, mark any that are unexpected, remove any that match
+        for error in raised_errors:
+            if not getattr(error, 'field', None):
+                unexpected_errors.append((error.code, error.message))
+                continue
+
+            if error.field not in field_errors:
+                unexpected_errors.append({error.field: (error.code, error.message)})
+                continue
+
+            if error.code not in field_errors[error.field]:
+                unexpected_errors.append({error.field: (error.code, error.message)})
+                continue
+
+            field_errors[error.field].remove(error.code)
+            if not field_errors[error.field]:
+                del field_errors[error.field]
+
+        # Go through all the remaining expected errors that weren't matched
+        for field, errors in six.iteritems(field_errors):
+            for error in errors:
+                missing_errors.append({field: error})
+
+        error_msg = ''
+        if missing_errors:
+            error_msg = 'Expected field errors not found in response: {}'.format(str(missing_errors))
+
+        if only and unexpected_errors:
+            if error_msg:
+                error_msg += '\n'
+            error_msg += 'Unexpected errors found in response: {}'.format(str(unexpected_errors))
+
+        if error_msg:
+            # If we have any cause to error, do so
+            raise self.failureException(error_msg)
+
+    def assertActionRunsWithOnlyFieldErrors(self, action, body, field_errors, **kwargs):
+        self.assertActionRunsWithFieldErrors(action, body, field_errors, only=True, **kwargs)
+
+    def assertActionRunsWithErrorCodes(self, action, body, error_codes, only=False, **kwargs):
+        raised_errors = self.assertActionRunsWithAndReturnErrors(action, body, **kwargs)
+
+        if not isinstance(error_codes, set):
+            if isinstance(error_codes, list):
+                error_codes = set(error_codes)
+            else:
+                error_codes = {error_codes}
+
+        unexpected_errors = []
+        missing_errors = []
+
+        # Go through all the errors returned by the action, mark any that are unexpected, remove any that match
+        for error in raised_errors:
+            if getattr(error, 'field', None):
+                unexpected_errors.append({error.field: (error.code, error.message)})
+                continue
+
+            if error.code not in error_codes:
+                unexpected_errors.append((error.code, error.message))
+                continue
+
+            error_codes.remove(error.code)
+
+        # Go through all the remaining expected errors that weren't matched
+        for error in error_codes:
+            missing_errors.append(error)
+
+        error_msg = ''
+        if missing_errors:
+            error_msg = 'Expected errors not found in response: {}'.format(str(missing_errors))
+
+        if only and unexpected_errors:
+            if error_msg:
+                error_msg += '\n'
+            error_msg += 'Unexpected errors found in response: {}'.format(str(unexpected_errors))
+
+        if error_msg:
+            # If we have any cause to error, do so
+            raise self.failureException(error_msg)
+
+    def assertActionRunsWithOnlyErrorCodes(self, action, body, error_codes, **kwargs):
+        self.assertActionRunsWithErrorCodes(action, body, error_codes, only=True, **kwargs)

--- a/tests/server_tests/test_actions.py
+++ b/tests/server_tests/test_actions.py
@@ -9,6 +9,8 @@ import pytest
 
 
 class TestAction(Action):
+    __test__ = False  # So that PyTest doesn't try to collect this and spit out a warning
+
     request_schema = fields.Dictionary({
         'string_field': fields.UnicodeString(),
     })


### PR DESCRIPTION
- Exclude PyCharm files using `.gitignore`.
- Fix a `pytest` warning when trying to collect a class that's not a test case.
- Add a `ServerTestCase#call_action` helper to make action calling easier within the scope of tests.
- Add `ServerTestCase` helpers `assertRunsWithErrorCodes`, `assertRunsWithOnlyErrorCodes`, `assertRunsWithFieldErrors`, and `assertRunsWithOnlyFieldErrors` to make asserting the presence of response errors much easier.