### PR TITLE
Client transport schema validation

### DIFF
--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -5,7 +5,7 @@ import six
 import attr
 
 from pysoa.client.expander import ExpansionConverter
-from pysoa.client.settings import ASGIClientSettings
+from pysoa.client.settings import PolymorphicClientSettings
 from pysoa.common.types import (
     ActionRequest,
     JobRequest,
@@ -109,7 +109,7 @@ class ServiceHandler(object):
 class Client(object):
     """The Client provides a simple interface for calling actions on Servers."""
 
-    settings_class = ASGIClientSettings
+    settings_class = PolymorphicClientSettings
     handler_class = ServiceHandler
 
     def __init__(self, config, expansions=None, settings_class=None, context=None):

--- a/pysoa/client/settings.py
+++ b/pysoa/client/settings.py
@@ -1,28 +1,56 @@
 from __future__ import unicode_literals
 
 from pysoa.common.settings import SOASettings
+from pysoa.common.transport.asgi.settings import ASGITransportSchema
+from pysoa.common.transport.local import LocalTransportSchema
+from pysoa.common.settings import BasicClassSchema
+
+from conformity import fields
 
 
 class ClientSettings(SOASettings):
-    """Settings specifically for clients."""
-    pass
+    """Generic settings for a Client."""
 
 
 class ASGIClientSettings(ClientSettings):
-    """Standard settings class for ASGI Clients."""
-
+    """Settings for an ASGI-only Client."""
     defaults = {
         'transport': {
             'path': 'pysoa.common.transport.asgi:ASGIClientTransport',
         }
     }
+    schema = {
+        'transport': ASGITransportSchema(),
+    }
 
 
 class LocalClientSettings(ClientSettings):
-    """Standard settings for local Clients."""
-
     defaults = {
         'transport': {
             'path': 'pysoa.common.transport.local:LocalClientTransport',
         }
+    }
+    schema = {
+        'transport': LocalTransportSchema(),
+    }
+
+
+class PolymorphicClientSettings(ClientSettings):
+    """Settings for Clients that can use any type of transport, while performing validation on certain transport types."""
+    defaults = {
+        'transport': {
+            'path': 'pysoa.common.transport.asgi:ASGIClientTransport',
+        }
+    }
+    schema = {
+        'transport': fields.Polymorph(
+            switch_field='path',
+            contents_map={
+                'pysoa.common.transport.asgi:ASGIClientTransport': ASGITransportSchema(),
+                'pysoa.common.transport:ASGIClientTransport': ASGITransportSchema(),
+                'pysoa.common.transport.local:LocalClientTransport': LocalTransportSchema(),
+                'pysoa.common.transport:LocalClientTransport': LocalTransportSchema(),
+                '__default__': BasicClassSchema(),
+            }
+        ),
     }

--- a/pysoa/common/transport/asgi/settings.py
+++ b/pysoa/common/transport/asgi/settings.py
@@ -1,0 +1,36 @@
+from pysoa.common.settings import BasicClassSchema
+from pysoa.common.transport.asgi.constants import ASGI_CHANNEL_TYPES
+
+from conformity import fields
+
+
+class ASGITransportSchema(BasicClassSchema):
+    contents = {
+        'path': fields.UnicodeString(),
+        'kwargs': fields.Dictionary(
+            {
+                'asgi_channel_type': fields.Constant(*ASGI_CHANNEL_TYPES),
+                'redis_hosts': fields.List(
+                    fields.Any(
+                        fields.Tuple(fields.UnicodeString(), fields.Integer()),
+                        fields.UnicodeString(),
+                    )
+                ),
+                'redis_port': fields.Integer(),
+                'sentinel_refresh_interval': fields.Integer(),
+                'redis_db': fields.Integer(),
+                'sentinel_services': fields.List(fields.UnicodeString()),
+                'channel_layer_kwargs': fields.SchemalessDictionary(),
+                'channel_full_retries': fields.Integer(),
+            },
+            optional_keys=[
+                'redis_port',
+                'sentinel_refresh_interval',
+                'redis_db',
+                'sentinel_services',
+                'channel_layer_kwargs',
+                'channel_full_retries',
+            ],
+            allow_extra_keys=True,
+        ),
+    }

--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -2,12 +2,17 @@ from __future__ import unicode_literals
 from collections import deque
 
 import six
+from conformity import fields
 
-from pysoa.common.settings import resolve_python_path
+from pysoa.common.settings import (
+    resolve_python_path,
+    BasicClassSchema,
+)
 from .base import (
     ClientTransport,
     ServerTransport,
 )
+
 
 
 class LocalClientTransport(ClientTransport):
@@ -103,3 +108,14 @@ class LocalServerTransport(ServerTransport):
     Empty class that we use as an import stub for local transport before
     we swap in the Client transport instance to do double duty.
     """
+
+
+class LocalTransportSchema(BasicClassSchema):
+    contents = {
+        'path': fields.UnicodeString(),
+        'kwargs': fields.Dictionary({
+            'server_class': fields.UnicodeString(),
+            # No deeper validation because the Server will perform its own validation
+            'server_settings': fields.SchemalessDictionary(key_type=fields.UnicodeString()),
+        }),
+    }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pysoa import __version__
 
 
 install_requires = [
-    'conformity~=1.5',
+    'conformity~=1.6',
     'msgpack-python>=0.4.8',
     'six>=1.10',
     'attrs>=16.3',


### PR DESCRIPTION
Added back schema validation for ASGI transports, and added a new schema for local transports. 

Also added a new combined schema that works for any transport type and performs validation on ASGI or local transport settings, using a `Polymorph` field switched by the transport `'path'` value. This combined schema, called `PolymorphicClientSettings`, is the new default for the `Client` class. It still defaults to an ASGI transport when no path is provided.