### PR TITLE
Improve error handling in `call_actions`

### DIFF
--- a/pysoa/client/expander.py
+++ b/pysoa/client/expander.py
@@ -123,6 +123,7 @@ class ExpansionNode(TypeNode):
         action,
         request_field,
         response_field,
+        raise_action_errors=True,
     ):
         """
         Create a new ExpansionNode instance.
@@ -138,6 +139,8 @@ class ExpansionNode(TypeNode):
             action (str): name of the action that satisfies the expansion.
             request_field (str): field name for the expansion's ActionRequest body.
             response_field (str): field name for the expansion's ActionResponse body.
+            raise_action_errors (bool): tells the Client not to raise an exception if the
+                expansion action returns an error response.
 
         Returns:
             An ExpansionNode instance.
@@ -150,6 +153,7 @@ class ExpansionNode(TypeNode):
         self.action = action
         self.request_field = request_field
         self.response_field = response_field
+        self.raise_action_errors = raise_action_errors
 
     def to_strings(self):
         """
@@ -236,6 +240,7 @@ class ExpansionConverter(object):
                     "type": "<expansion type>",
                     "source_field": "<source field name>",
                     "dest_field": "<destination field name>",
+                    "raise_action_errors": <bool>
                 },
                 ...
             },
@@ -286,6 +291,7 @@ class ExpansionConverter(object):
                             action=type_route['action'],
                             request_field=type_route['request_field'],
                             response_field=type_route['response_field'],
+                            raise_action_errors=type_expansion.get('raise_action_errors', False),
                         )
                         expansion_node.add_expansion(child_expansion_node)
                     expansion_node = child_expansion_node


### PR DESCRIPTION
This change does two things:

- Add the keyword argument `raise_action_errors` to `call_actions`, which defaults to `True`. If it is `True`, `call_actions` raises an exception when a response contains an action with errors, as before. If it is `False`, no exception will be raised.
- Add the option `raise_action_errors` to `ExpansionNode`, which defaults to `False`. It works the same way as the keyword argument, but at the level of expansions. This option is set in the `type_expansions` configuration, so that it can be configured on a field-by-field basis.

I've also added unit tests for all the new functionality.