### PR TITLE
LocalTransportSchema server class can be a path or a class object

### DIFF
--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -114,7 +114,8 @@ class LocalTransportSchema(BasicClassSchema):
     contents = {
         'path': fields.UnicodeString(),
         'kwargs': fields.Dictionary({
-            'server_class': fields.UnicodeString(),
+            # server class can be an import path or a class object
+            'server_class': fields.Any(fields.UnicodeString(), fields.ObjectInstance(six.class_types)),
             # No deeper validation because the Server will perform its own validation
             'server_settings': fields.SchemalessDictionary(key_type=fields.UnicodeString()),
         }),


### PR DESCRIPTION
Restricting the `server_class` setting to a path was making it difficult to write unit tests using `ServerTestCase`, because we could not define a test server class inline and use it in the test case. This is a simple way to make it easier to write such tests without breaking existing uses of `LocalClientTransport`.