### PR TITLE
Use compatible versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ from pysoa import __version__
 install_requires = [
     'conformity~=1.6',
     'msgpack-python>=0.4.8',
-    'six>=1.10',
-    'attrs>=16.3',
+    'six~=1.10.0',
+    'attrs~=16.3',
     'asgi_redis~=1.4',
     'currint~=1.6',
 ]


### PR DESCRIPTION
Make version requirements use compatible versions rather than using `>=`.