### PR TITLE
Support `in` keyword for SOA settings

### DIFF
--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -140,6 +140,9 @@ class Settings(object):
     def __getitem__(self, key):
         return self._data[key]
 
+    def __contains__(self, key):
+        return key in self._data
+
 
 class SOASettings(Settings):
     """


### PR DESCRIPTION
Support the `in` keyword for SOA settings so that you can easily check if a setting is present.