### PR TITLE
Add exc_info option to logger.error statements

### DIFF
--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -171,7 +171,7 @@ class Server(object):
         except Exception:
             error_str, traceback_str = "Error formatting error", traceback.format_exc()
         # Log what happened
-        self.logger.exception(error, exc_info=True)
+        self.logger.exception(error)
         # Make a barebones job response
         error_dict = {
             'code': ERROR_CODE_SERVER_ERROR,
@@ -288,7 +288,7 @@ class Server(object):
                 # Get, process, and execute the next JobRequest
                 self.handle_next_request()
         except Exception:
-            self.logger.exception("Unhandled server error", exc_info=True)
+            self.logger.exception("Unhandled server error")
         finally:
             self.logger.info("Server shutting down")
 

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -171,7 +171,7 @@ class Server(object):
         except Exception:
             error_str, traceback_str = "Error formatting error", traceback.format_exc()
         # Log what happened
-        self.logger.error("Unhandled error: %s", traceback_str)
+        self.logger.error(error, exc_info=True)
         # Make a barebones job response
         error_dict = {
             'code': ERROR_CODE_SERVER_ERROR,
@@ -288,7 +288,7 @@ class Server(object):
                 # Get, process, and execute the next JobRequest
                 self.handle_next_request()
         except Exception:
-            self.logger.error("Unhandled server error: %s", traceback.format_exc())
+            self.logger.error("Unhandled server error", exc_info=True)
         finally:
             self.logger.info("Server shutting down")
 

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -171,7 +171,7 @@ class Server(object):
         except Exception:
             error_str, traceback_str = "Error formatting error", traceback.format_exc()
         # Log what happened
-        self.logger.error(error, exc_info=True)
+        self.logger.exception(error, exc_info=True)
         # Make a barebones job response
         error_dict = {
             'code': ERROR_CODE_SERVER_ERROR,
@@ -288,7 +288,7 @@ class Server(object):
                 # Get, process, and execute the next JobRequest
                 self.handle_next_request()
         except Exception:
-            self.logger.error("Unhandled server error", exc_info=True)
+            self.logger.exception("Unhandled server error", exc_info=True)
         finally:
             self.logger.info("Server shutting down")
 


### PR DESCRIPTION
This will still cause the logger to include traceback information in log lines, while allowing different loggers to handle tracebacks their way.

The use case that prompted this was the `SentryHandler` from `raven`, which cannot correctly format exception information in Sentry requests without `exc_info`.