### PR TITLE
Add support for recording metrics directly within SOA clients, servers, and transports

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -559,7 +559,7 @@ The Redis Gateway transport takes the following extra keyword arguments for conf
 
 - ``backend_layer_kwargs``: A dictionary of arguments to pass to the backend layer
 
-  + ``connection_kwargs``: A dictionary of arguments to pass to the underlying Redis client
+  + ``connection_kwargs``: A dictionary of arguments to pass to the underlying Redis client (see the documentation for the Redis-Py library)
 
   + ``hosts``: A list of strings (host names / IP addresses) or tuples (host names / IP addresses and ports) for Redis hosts or sentinels to which to connect (will use "localhost" by default)
 
@@ -571,13 +571,13 @@ The Redis Gateway transport takes the following extra keyword arguments for conf
 
   + ``sentinel_services``: Which Sentinel services to use (only for type "redis.sentinel") (will be auto-discovered from the Sentinel by default)
 
-- ``message_expiry_in_seconds``: How long a message may remain in the queue before it is considered expired and discarded
+- ``message_expiry_in_seconds``: How long a message may remain in the queue before it is considered expired and discarded (defaults to 60 seconds)
 
 - ``queue_capacity``: The maximum number of messages a given Redis queue may hold before the transport should stop pushing messages to it (defaults to 10,000)
 
 - ``queue_full_retries``: The number of times the transport should retry sending to a Redis queue that is at capacity before it raises an error and stops trying (defaults to 10)
 
-- ``receive_timeout_in_seconds``: How long the transport should block waiting to receive a message before giving up (on the server, this controls how often the server request-process loops; on the client, this controls how long before it raises an error for waiting too long for a response)
+- ``receive_timeout_in_seconds``: How long the transport should block waiting to receive a message before giving up (on the server, this controls how often the server request-process loops; on the client, this controls how long before it raises an error for waiting too long for a response) (defaults to 5 seconds)
 
 - ``serializer_config``: A standard serializer configuration as described in `Serializer configuration`_ (defaults to Msgpack)
 

--- a/pysoa/common/metrics.py
+++ b/pysoa/common/metrics.py
@@ -1,0 +1,131 @@
+from __future__ import unicode_literals
+
+from conformity import fields
+
+from pysoa.common.schemas import BasicClassSchema
+
+
+class Counter(object):
+    """
+    Defines an interface for incrementing a counter.
+    """
+
+    def increment(self, amount=1):
+        """
+        Increments the counter.
+
+        :param amount: The amount by which to increment the counter, which must default to 1.
+        """
+        raise NotImplementedError()
+
+
+class Timer(object):
+    """
+    Defines an interface for timing activity. Can be used as a context manager to time wrapped activity.
+    """
+
+    def start(self):
+        """
+        Starts the timer.
+        """
+        raise NotImplementedError()
+
+    def stop(self):
+        """
+        Stops the timer.
+        """
+        raise NotImplementedError()
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, *_, **__):
+        self.stop()
+        return False
+
+
+class MetricsRecorder(object):
+    """
+    Defines an interface for recording metrics. All metrics recorders registered with PySOA must implement this
+    interface. Note that counters and timers with the same name will not be recorded. If your metrics backend needs
+    timers to also have associated counters, your implementation of this recorder must take care of filling that gap.
+    """
+
+    def counter(self, name, **kwargs):
+        """
+        Returns a counter that can be incremented. Implementations do not have to return an instance of `Counter`, but
+        they must at least return an object that matches the interface for `Counter`.
+
+        :param name: The name of the counter
+        :param kwargs: Any other arguments that may be needed
+
+        :return: a counter object.
+        :rtype: Counter
+        """
+        raise NotImplementedError()
+
+    def timer(self, name, **kwargs):
+        """
+        Returns a timer that can be started and stopped. Implementations do not have to return an instance of `Timer`,
+        but they must at least return an object that matches the interface for `Timer`, including serving as a context
+        manager.
+
+        :param name: The name of the timer
+        :param kwargs: Any other arguments that may be needed
+
+        :return: a timer object
+        :rtype: Timer
+        """
+        raise NotImplementedError()
+
+    def commit(self):
+        """
+        Commits the recorded metrics, if necessary, to the storage medium in which they reside. Can simply be a
+        no-op if metrics are recorded immediately.
+        """
+
+
+class NoOpMetricsRecorder(MetricsRecorder):
+    class NoOpCounter(Counter):
+        def increment(self, amount=1):
+            pass
+
+    class NoOpTimer(Timer):
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    _counter = NoOpCounter()
+    _timer = NoOpTimer()
+
+    def __init__(self, **__):
+        pass
+
+    def counter(self, name, **kwargs):
+        return self._counter
+
+    def timer(self, name, **kwargs):
+        return self._timer
+
+    def commit(self):
+        pass
+
+
+class MetricsSchema(BasicClassSchema):
+    contents = {
+        'path': fields.UnicodeString(description='The module.name:ClassName path to the metrics recorder'),
+        'kwargs': fields.Dictionary(
+            {
+                'config': fields.SchemalessDictionary(),
+            },
+            optional_keys=[
+                'config',
+            ],
+            allow_extra_keys=True,
+            description='The keyword arguments that will be passed to the constructed metrics recorder',
+        ),
+    }
+
+    object_type = MetricsRecorder

--- a/pysoa/common/schemas.py
+++ b/pysoa/common/schemas.py
@@ -1,0 +1,28 @@
+from __future__ import unicode_literals
+
+from conformity import fields
+
+
+class BasicClassSchema(fields.Dictionary):
+    contents = {
+        'path': fields.UnicodeString(),
+        'kwargs': fields.SchemalessDictionary(key_type=fields.UnicodeString()),
+    }
+    optional_keys = ['kwargs']
+    object_type = None
+
+    def __init__(self, object_type=None, **kwargs):
+        super(BasicClassSchema, self).__init__(**kwargs)
+
+        if object_type:
+            assert isinstance(object_type, type)
+            self.object_type = object_type
+
+    def __repr__(self):
+        return '{class_name}({object_type})'.format(
+            class_name=self.__class__.__name__,
+            object_type='object_type={module_name}:{class_name}'.format(
+                module_name=self.object_type.__module__,
+                class_name=self.object_type.__name__,
+            ) if self.object_type else '',
+        )

--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -8,32 +8,9 @@ from conformity import fields
 from conformity.validator import validate
 import six
 
+from pysoa.common.metrics import MetricsSchema
+from pysoa.common.schemas import BasicClassSchema
 from pysoa.common.serializer.base import Serializer as BaseSerializer
-
-
-class BasicClassSchema(fields.Dictionary):
-    contents = {
-        'path': fields.UnicodeString(),
-        'kwargs': fields.SchemalessDictionary(key_type=fields.UnicodeString()),
-    }
-    optional_keys = ['kwargs']
-    object_type = None
-
-    def __init__(self, object_type=None, **kwargs):
-        super(BasicClassSchema, self).__init__(**kwargs)
-
-        assert object_type is None or isinstance(object_type, type)
-
-        self.object_type = object_type
-
-    def __repr__(self):
-        return '{class_name}({object_type})'.format(
-            class_name=self.__class__.__name__,
-            object_type='object_type={module_name}:{class_name}'.format(
-                module_name=self.object_type.__module__,
-                class_name=self.object_type.__name__,
-            ) if self.object_type else '',
-        )
 
 
 def resolve_python_path(path):
@@ -235,11 +212,13 @@ class SOASettings(Settings):
     schema = {
         # Paths to the classes to use and then kwargs to pass
         'transport': BasicClassSchema(),
-        'serializer': BasicClassSchema(object_type=BaseSerializer),
+        'serializer': BasicClassSchema(BaseSerializer),
         'middleware': fields.List(BasicClassSchema()),
+        'metrics': MetricsSchema(),
     }
 
     defaults = {
         'serializer': {'path': 'pysoa.common.serializer:MsgpackSerializer'},
         'middleware': [],
+        'metrics': {'path': 'pysoa.common.metrics:NoOpMetricsRecorder'},
     }

--- a/pysoa/common/transport/asgi/server.py
+++ b/pysoa/common/transport/asgi/server.py
@@ -12,8 +12,9 @@ from .core import ASGITransportCore
 
 class ASGIServerTransport(ServerTransport):
 
-    def __init__(self, service_name, response_channel_capacities=None, **kwargs):
-        self.service_name = service_name
+    def __init__(self, service_name, metrics, response_channel_capacities=None, **kwargs):
+        super(ASGIServerTransport, self).__init__(service_name, metrics)
+
         self.receive_channel_name = make_channel_name(service_name)
         if response_channel_capacities:
             # If response channel capacities are specified, add them to channel_capacities

--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -12,11 +12,12 @@ is not business logic. For example, if your implementation has multiple serializ
 types, the metadata may include a mime type to tell the endpoint receiving the message
 which type of serializer to use.
 """
+from pysoa.common.metrics import NoOpMetricsRecorder
 
 
 class ClientTransport(object):
 
-    def __init__(self, service_name, metrics):
+    def __init__(self, service_name, metrics=NoOpMetricsRecorder()):
         self.service_name = service_name
         self.metrics = metrics
 
@@ -50,7 +51,7 @@ class ClientTransport(object):
 
 class ServerTransport(object):
 
-    def __init__(self, service_name, metrics):
+    def __init__(self, service_name, metrics=NoOpMetricsRecorder()):
         self.service_name = service_name
         self.metrics = metrics
 

--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -9,15 +9,16 @@ backend code into a single class.
 All Transport methods either accept or return a metadata argument. This should be a
 dict that includes any information that is necessary for processing the message, but
 is not business logic. For example, if your implementation has multiple serializer
-types, the metadata may include a mimetype to tell the endpoint receiving the message
+types, the metadata may include a mime type to tell the endpoint receiving the message
 which type of serializer to use.
 """
 
 
 class ClientTransport(object):
 
-    def __init__(self, service_name):
+    def __init__(self, service_name, metrics):
         self.service_name = service_name
+        self.metrics = metrics
 
     def send_request_message(self, request_id, meta, message_string):
         """
@@ -49,8 +50,9 @@ class ClientTransport(object):
 
 class ServerTransport(object):
 
-    def __init__(self, service_name):
+    def __init__(self, service_name, metrics):
         self.service_name = service_name
+        self.metrics = metrics
 
     def receive_request_message(self):
         """

--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -17,8 +17,8 @@ from .base import (
 class LocalClientTransport(ClientTransport):
     """A transport that incorporates a server for running a service and client in a single thread."""
 
-    def __init__(self, service_name, server_class, server_settings):
-        super(LocalClientTransport, self).__init__(service_name)
+    def __init__(self, service_name, metrics, server_class, server_settings):
+        super(LocalClientTransport, self).__init__(service_name, metrics)
 
         # If the server is specified as a path, resolve it to a class
         if isinstance(server_class, six.string_types):
@@ -99,9 +99,10 @@ class LocalClientTransport(ClientTransport):
         """
         if self.response_messages:
             return self.response_messages.popleft()
-        return (None, None, None)
+        return None, None, None
 
 
+# noinspection PyAbstractClass
 class LocalServerTransport(ServerTransport):
     """
     Empty class that we use as an import stub for local transport before

--- a/pysoa/common/transport/redis_gateway/core.py
+++ b/pysoa/common/transport/redis_gateway/core.py
@@ -217,7 +217,6 @@ class RedisTransportCore(object):
             raise MessageReceiveError(*e.args)
 
         if serialized_message is None:
-            self._get_counter('receive.error.no_message_received').increment()
             raise MessageReceiveTimeout('No message received')
 
         with self._get_timer('receive.deserialize'):
@@ -229,7 +228,7 @@ class RedisTransportCore(object):
 
         request_id = message.get('request_id')
         if request_id is None:
-            self._get_counter('receive.error.no_message_id').increment()
+            self._get_counter('receive.error.no_request_id').increment()
             raise InvalidMessageError('No request ID')
 
         return request_id, message.get('meta', {}), message.get('body')

--- a/tests/common_tests/transport/redis_gateway/test_client.py
+++ b/tests/common_tests/transport/redis_gateway/test_client.py
@@ -5,6 +5,7 @@ import uuid
 
 import mock
 
+from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.redis_gateway.client import RedisClientTransport
 
 
@@ -12,12 +13,17 @@ from pysoa.common.transport.redis_gateway.client import RedisClientTransport
 class TestClientTransport(unittest.TestCase):
     @staticmethod
     def _get_transport(service='my_service', **kwargs):
-        return RedisClientTransport(service, **kwargs)
+        return RedisClientTransport(service, NoOpMetricsRecorder(), **kwargs)
 
     def test_core_args(self, mock_core):
         transport = self._get_transport(hello='world', goodbye='earth')
 
-        mock_core.assert_called_once_with(hello='world', goodbye='earth')
+        mock_core.assert_called_once_with(
+            hello='world',
+            goodbye='earth',
+            metrics=transport.metrics,
+            metrics_prefix='client',
+        )
 
         self.assertRegexpMatches(transport.client_id, r'^[0-9a-fA-F]{32}$')
 

--- a/tests/common_tests/transport/redis_gateway/test_server.py
+++ b/tests/common_tests/transport/redis_gateway/test_server.py
@@ -5,6 +5,7 @@ import uuid
 
 import mock
 
+from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.exceptions import InvalidMessageError
 from pysoa.common.transport.redis_gateway.server import RedisServerTransport
 
@@ -13,12 +14,17 @@ from pysoa.common.transport.redis_gateway.server import RedisServerTransport
 class TestServerTransport(unittest.TestCase):
     @staticmethod
     def _get_transport(service='my_service', **kwargs):
-        return RedisServerTransport(service, **kwargs)
+        return RedisServerTransport(service, NoOpMetricsRecorder(), **kwargs)
 
     def test_core_args(self, mock_core):
-        self._get_transport(hello='world', goodbye='earth')
+        transport = self._get_transport(hello='world', goodbye='earth')
 
-        mock_core.assert_called_once_with(hello='world', goodbye='earth')
+        mock_core.assert_called_once_with(
+            hello='world',
+            goodbye='earth',
+            metrics=transport.metrics,
+            metrics_prefix='server',
+        )
 
     def test_receive_request_message(self, mock_core):
         transport = self._get_transport()


### PR DESCRIPTION
- Creates an interface for generic metrics recording
- Specifies a new configuration schema for setting up metrics that will be compatible with our current internal uses
- Integrates the recording of metrics into the server, client, and Redis transport. No effort is being expended on metricizing the ASGI transport, since it is being deprecated. No effort is being expended on metricizing the Local transport, as it has essentially no overhead compared to the client, which is metricized. 