### PR TITLE
Fix #22: Missing key issue when client and server on different Python versions

### DIFF
--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -10,6 +10,7 @@ from pysoa.common.types import (
     ActionRequest,
     JobRequest,
     JobResponse,
+    UnicodeKeysDict,
 )
 
 
@@ -52,7 +53,7 @@ class ServiceHandler(object):
     def _base_send_request(self, request_id, meta, job_request):
         with self.metrics.timer('client.send.excluding_middleware'):
             if isinstance(job_request, JobRequest):
-                job_request = attr.asdict(job_request)
+                job_request = attr.asdict(job_request, dict_factory=UnicodeKeysDict)
             message = self.serializer.dict_to_blob(job_request)
             self.transport.send_request_message(request_id, meta, message)
 

--- a/pysoa/common/types.py
+++ b/pysoa/common/types.py
@@ -1,4 +1,13 @@
 import attr
+import six
+
+
+class UnicodeKeysDict(dict):
+    def __setitem__(self, key, value):
+        super(UnicodeKeysDict, self).__setitem__(six.text_type(key), value)
+
+    def setdefault(self, key, default=None):
+        super(UnicodeKeysDict, self).setdefault(six.text_type(key), default)
 
 
 @attr.s(frozen=True)

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -22,6 +22,7 @@ from pysoa.common.types import (
     ActionResponse,
     Error,
     JobResponse,
+    UnicodeKeysDict,
 )
 from pysoa.server.internal.types import RequestSwitchSet
 from pysoa.server.errors import (
@@ -95,12 +96,12 @@ class Server(object):
         # Send the JobResponse
         response_dict = {}
         try:
-            response_dict = attr.asdict(job_response)
+            response_dict = attr.asdict(job_response, dict_factory=UnicodeKeysDict)
             response_message = self.serializer.dict_to_blob(response_dict)
         except Exception as e:
             self.metrics.counter('server.error.serialization_failure').increment()
             job_response = self.handle_error(e, variables={'job_response': response_dict})
-            response_dict = attr.asdict(job_response)
+            response_dict = attr.asdict(job_response, dict_factory=UnicodeKeysDict)
             response_message = self.serializer.dict_to_blob(response_dict)
         self.transport.send_response_message(request_id, meta, response_message)
         self.job_logger.info("Job response: %s", response_dict)

--- a/tests/common_tests/test_test.py
+++ b/tests/common_tests/test_test.py
@@ -1,10 +1,13 @@
 from __future__ import unicode_literals
 
-from pysoa.common.constants import ERROR_CODE_INVALID
-from pysoa.test.stub_service import StubClient
+from unittest import TestCase
 
 import attr
-from unittest import TestCase
+
+from pysoa.common.constants import ERROR_CODE_INVALID
+from pysoa.common.types import UnicodeKeysDict
+from pysoa.test.stub_service import StubClient
+
 
 
 SERVICE_NAME = 'test_service'
@@ -156,4 +159,6 @@ class TestStubClient(TestCase):
                 # Errors are returned as the Error type, so convert them to dict first
                 self.assertEqual(action_response.body, responses[action_response.action]['body'])
                 self.assertEqual(
-                    [attr.asdict(e) for e in action_response.errors], responses[action_response.action]['errors'])
+                    [attr.asdict(e, dict_factory=UnicodeKeysDict) for e in action_response.errors],
+                    responses[action_response.action]['errors'],
+                )

--- a/tests/common_tests/test_test.py
+++ b/tests/common_tests/test_test.py
@@ -9,7 +9,6 @@ from pysoa.common.types import UnicodeKeysDict
 from pysoa.test.stub_service import StubClient
 
 
-
 SERVICE_NAME = 'test_service'
 
 


### PR DESCRIPTION
This fixes issue #22. 

If the SOA client is on Python 2 while the server is on Python 3, or vice versa, they would not be able to communicate due to missing key errors, because the message keys on the Python 2 side would be serialized as non-unicode, while the keys on the Python 3 side would be expected to be unicode and would actually be bytes.

Here's the log output from the server running on Python 2 before the change:

```
2017-11-08 09:50:10,193    INFO: Job request: {'control': {u'continue_on_error': False}, 'context': {u'switches': [3], u'correlation_id': u'9895bc50c49e11e7bbad0242ac120029', u'caller': u'get_ip_location_from_request'}, 'actions': [{u'action': u'get_location_from_ip', u'body': {u'ip_address': u'172.18.0.1'}}]}
2017-11-08 09:50:10,195    INFO: Job response: {'errors': [], 'actions': [{u'action': u'get_location_from_ip', u'body': {u'location': {}}, u'errors': []}]}
```

And from the server running on Python 3 before the change:
```
2017-11-08 09:52:41,701    INFO: Job request: {b'control': {'continue_on_error': False}, b'context': {'switches': [3], 'correlation_id': '8a23b900c49f11e7bbad0242ac120029', 'caller': 'get_ip_location_from_request'}, b'actions': [{'action': 'get_location_from_ip', 'body': {'ip_address': '172.18.0.1'}}]}
<response was error about missing keys 'control', 'context', and 'actions' in the request>
```

Notice that the very top-level dicts have non-unicode as the keys, while everything else is unicode like it should be. This is what caused the problem. In Python 3, `bytes` (what `b'something'` is) apparently do not have the same hash as equivalent `str`, or otherwise are not properly supported as dictionary keys. Thus, the validation could not find the top level keys `control`, `context`, and `actions`.

The cause of this issue is that the `attr` library uses the Python-provided attribute names as keys in the dict when converting an `attr` object to a dict with `attr.asdict`. In Python 2, the attribute names supplied by Python are `str`, not `unicode`, thus causing these top-level dict keys to be non-unicode when `attr.asdict` is called on Python 2. The solution was simple: Provide `attr.asdict` a dictionary factory that ensures keys are unicode.

Here is Python 2 after the change:

```
2017-11-08 10:05:15,237    INFO: Job request: {u'control': {u'continue_on_error': False}, u'context': {u'switches': [3], u'correlation_id': u'88d81910c49f11e7bbad0242ac120029', u'caller': u'get_ip_location_from_request'}, u'actions': [{u'action': u'get_location_from_ip', u'body': {u'ip_address': u'172.18.0.1'}}]}
2017-11-08 10:05:15,240    INFO: Job response: {u'errors': [], u'actions': [{u'action': u'get_location_from_ip', u'body': {u'location': {}}, u'errors': []}]}
```

And Python 3 after the change:

```
2017-11-08 10:08:34,077    INFO: Job request: {'control': {'continue_on_error': False}, 'context': {'switches': [3], 'correlation_id': '8b162eb0c49f11e7bbad0242ac120029', 'caller': 'get_ip_location_from_request'}, 'actions': [{'action': 'get_location_from_ip', 'body': {'ip_address': '172.18.0.1'}}]}
2017-11-08 10:08:34,079    INFO: Job response: {'errors': [], 'actions': [{'action': 'get_location_from_ip', 'body': {'location': {}}, 'errors': []}]}
```