### PR TITLE
Don't record receive timer in server if no message received

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
 ]
 
 tests_require = [
-    'pytest',
+    'pytest~=3.2.4',  # 3.3+ depends on attrs>=17.2.0
     'pytest-cov',
     'mock>=2.0',
     'factory_boy~=2.8.0',


### PR DESCRIPTION
This was causing metrics to be recorded even if no requests were being sent in.