### PR TITLE
Use master_for correctly to reduce number of Redis connections

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -576,8 +576,6 @@ The Redis Gateway transport takes the following extra keyword arguments for conf
 
   + ``sentinel_failover_retries``: How many times to retry (with a delay) getting a connection from the Sentinel when a master cannot be found (cluster is in the middle of a failover) (only for type "redis.sentinel") (fails on the first error by default)
 
-  + ``sentinel_refresh_interval``: How often, in seconds, master/slave data should be refreshed from the Sentinel (only for type "redis.sentinel") (refreshes every connection by default)
-
   + ``sentinel_services``: Which Sentinel services to use (only for type "redis.sentinel") (will be auto-discovered from the Sentinel by default)
 
 - ``message_expiry_in_seconds``: How long a message may remain in the queue before it is considered expired and discarded (defaults to 60 seconds)
@@ -713,7 +711,7 @@ Which metrics are recorded
 These are all the metrics recorded in PySOA:
 
 - ``server.transport.redis_gateway.backend.initialize``: A timer indicating how long it took the Redis Gateway server transport to initialize a backend Redis client
-- ``server.transport.redis_gateway.backend.sentinel.populate_masters``: A counter incremented each time the Redis Gateway server transport Sentinel backend populates its masters cache (only happens if sentinel_refresh_interval is enabled)
+- ``server.transport.redis_gateway.backend.sentinel.populate_master_client``: A counter incremented each time the Redis Gateway server transport Sentinel backend has to get a new master client for any given service (shard)
 - ``server.transport.redis_gateway.backend.sentinel.master_not_found_retry``: A counter incremented each time the Redis Gateway server transport Sentinel backend retries getting master info due to master failover (only happens if sentinel_failover_retries is enabled)
 - ``server.transport.redis_gateway.send``: A timer indicating how long it takes the Redis Gateway server transport to send a response
 - ``server.transport.redis_gateway.send.error.missing_reply_queue``: A counter incremented each time the Redis Gateway server transport is unable to send a response because the message metadata is missing the required ``reply_to`` attribute
@@ -744,7 +742,7 @@ These are all the metrics recorded in PySOA:
 - ``client.middleware.initialize``: A timer indicating how long it took to initialize all middleware when creating a new client handler
 - ``client.transport.initialize``: A timer indicating how long it took to initialize the transport when creating a new client handler
 - ``client.transport.redis_gateway.backend.initialize``: Client metric has same meaning as server metric
-- ``client.transport.redis_gateway.backend.sentinel.populate_masters``: Client metric has same meaning as server metric
+- ``client.transport.redis_gateway.backend.sentinel.populate_master_client``: Client metric has same meaning as server metric
 - ``client.transport.redis_gateway.backend.sentinel.master_not_found_retry``: Client metric has same meaning as server metric
 - ``client.transport.redis_gateway.send``: A timer indicating how long it took the Redis Gateway client transport to send a request
 - ``client.transport.redis_gateway.send.serialize``: Client metric has same meaning as server metric

--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -14,6 +14,7 @@ from pysoa.common.types import (
     JobResponse,
     UnicodeKeysDict,
 )
+from pysoa.utils import dict_to_hashable
 
 
 class ServiceHandler(object):
@@ -61,7 +62,7 @@ class ServiceHandler(object):
         """
             Caches configured transports for up to cache_time_in_seconds to prevent the bottleneck.
             """
-        cache_key = repr((service_name, settings))
+        cache_key = (service_name, dict_to_hashable(settings))
         if cache_key not in cls._transport_cache or cls._transport_cache[cache_key][0] < time.time():
             cls._transport_cache[cache_key] = (
                 time.time() + cache_time_in_seconds,

--- a/pysoa/common/transport/redis_gateway/settings.py
+++ b/pysoa/common/transport/redis_gateway/settings.py
@@ -36,8 +36,7 @@ class RedisTransportSchema(BasicClassSchema):
                                         'should only be used for Sentinel backend type'
                         ),
                         'sentinel_refresh_interval': fields.Integer(
-                            description='How often (seconds) Redis Sentinel should refresh master info (defaults to '
-                                        'every request); should only be used for Sentinel backend type',
+                            description='Deprecated; unused; to be removed before final release.',
                         ),
                         'sentinel_services': fields.List(
                             fields.UnicodeString(),

--- a/pysoa/utils.py
+++ b/pysoa/utils.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+from __future__ import absolute_import, unicode_literals
+
+import six
+
+
+def dict_to_hashable(d):
+    """
+    Takes a dict and returns an immutable, hashable version of that dict that can be used as a key in dicts or as a
+    set value. Any two dicts passed in with the same content are guaranteed to return the same value. Any two dicts
+    passed in with different content are guaranteed to return different values. Performs comparatively to `repr`.
+
+    >> %timeit repr(d1)
+    The slowest run took 5.76 times longer than the fastest. This could mean that an intermediate result is being cached
+    100000 loops, best of 3: 3.48 µs per loop
+
+    >> %timeit dict_to_hashable(d1)
+    The slowest run took 4.16 times longer than the fastest. This could mean that an intermediate result is being cached
+    100000 loops, best of 3: 4.07 µs per loop
+
+    :param d: The dict
+    :return: The hashable representation of the dict
+    """
+    return frozenset({
+        (k, tuple(v) if isinstance(v, list) else (dict_to_hashable(v) if isinstance(v, dict) else v))
+        for k, v in six.iteritems(d)
+    })

--- a/tests/common_tests/transport/redis_gateway/backend/test_sentinel.py
+++ b/tests/common_tests/transport/redis_gateway/backend/test_sentinel.py
@@ -62,9 +62,10 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
 
     @mock.patch('redis.sentinel.Sentinel')
     def test_master_not_found_no_retry(self, mock_sentinel):
-        mock_sentinel.return_value.sentinels = (MockSentinelRedis(), MockSentinelRedis(), MockSentinelRedis())
+        mock_sentinel.return_value.master_for.return_value = MockSentinelRedis()
 
-        client = self._set_up_client()
+        client = self._set_up_client(sentinel_services=['service1', 'service2', 'service3'])
+        client.reset_clients()
 
         mock_sentinel.return_value.master_for.reset_mock()
         mock_sentinel.return_value.master_for.side_effect = redis.sentinel.MasterNotFoundError
@@ -77,9 +78,10 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
 
     @mock.patch('redis.sentinel.Sentinel')
     def test_master_not_found_max_retries(self, mock_sentinel):
-        mock_sentinel.return_value.sentinels = (MockSentinelRedis(), MockSentinelRedis(), MockSentinelRedis())
+        mock_sentinel.return_value.master_for.return_value = MockSentinelRedis()
 
-        client = self._set_up_client(sentinel_failover_retries=2)
+        client = self._set_up_client(sentinel_failover_retries=2, sentinel_services=['service1', 'service2'])
+        client.reset_clients()
 
         mock_sentinel.return_value.master_for.reset_mock()
         mock_sentinel.return_value.master_for.side_effect = redis.sentinel.MasterNotFoundError
@@ -103,9 +105,10 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
 
     @mock.patch('redis.sentinel.Sentinel')
     def test_master_not_found_worked_after_retries(self, mock_sentinel):
-        mock_sentinel.return_value.sentinels = (MockSentinelRedis(), MockSentinelRedis(), MockSentinelRedis())
+        mock_sentinel.return_value.master_for.return_value = MockSentinelRedis()
 
-        client = self._set_up_client(sentinel_failover_retries=2)
+        client = self._set_up_client(sentinel_failover_retries=2, sentinel_services=['service1', 'service2'])
+        client.reset_clients()
 
         mock_sentinel.return_value.master_for.reset_mock()
         mock_sentinel.return_value.master_for.side_effect = (
@@ -198,8 +201,8 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
         self.assertEqual(payload, msgpack.unpackb(message, encoding='utf-8'))
 
     @mock.patch('redis.sentinel.Sentinel', new=MockSentinel)
-    def test_refresh_interval_hashed_server_send_receive(self):
-        client = self._set_up_client(sentinel_refresh_interval=10)
+    def test_hashed_server_send_receive(self):
+        client = self._set_up_client()
 
         payload1 = {'test': 'some value'}
 

--- a/tests/common_tests/transport/redis_gateway/test_core.py
+++ b/tests/common_tests/transport/redis_gateway/test_core.py
@@ -35,6 +35,9 @@ class MockSerializer(object):
 
 @mock.patch('redis.Redis', new=mockredis.mock_redis_client)
 class TestRedisTransportCore(unittest.TestCase):
+    def setUp(self):
+        RedisTransportCore._backend_layer_cache = {}
+
     def test_invalid_backend_type(self):
         with self.assertRaises(ValueError):
             RedisTransportCore(backend_type='hello')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import, unicode_literals
+
+from unittest import TestCase
+
+from pysoa.utils import dict_to_hashable
+
+
+class TestDictToHashable(TestCase):
+    def test_that_it_works(self):
+        d1 = {
+            u'hosts': [u'1.2.3.4', u'5.6.7.8', u'9.10.11.12'],
+            u'connection_kwargs': {u'password': u'abc123meta', u'socket_connect_timeout': 20},
+            u'sentinel_services': [u'service1', u'service2'],
+            u'sentinel_failover_retries': 6,
+        }
+        d2 = {
+            u'sentinel_services': [u'service1', u'service2'],
+            u'sentinel_failover_retries': 6,
+            u'connection_kwargs': {u'password': u'abc123meta', u'socket_connect_timeout': 20},
+            u'hosts': [u'1.2.3.4', u'5.6.7.8', u'9.10.11.12'],
+        }
+        d3 = {
+            u'connection_kwargs': {u'socket_connect_timeout': 20, u'password': u'abc123meta'},
+            u'sentinel_services': [u'service1', u'service2'],
+            u'sentinel_failover_retries': 6,
+            u'hosts': [u'1.2.3.4', u'5.6.7.8', u'9.10.11.12'],
+        }
+        d4 = {
+            u'connection_kwargs': {u'socket_connect_timeout': 20, u'password': u'abc123meta'},
+            u'sentinel_services': [u'service1', u'service2'],
+            u'sentinel_failover_retries': 6,
+            u'hosts': [u'1.2.3.4', u'5.6.7.8', u'9.10.11.1'],  # <- only difference is here
+        }
+
+        self.assertEqual(d1, d2)
+        self.assertEqual(d1, d3)
+        self.assertNotEqual(d1, d4)
+        self.assertNotEqual(d2, d4)
+        self.assertNotEqual(d3, d4)
+
+        self.assertEqual(dict_to_hashable(d1), dict_to_hashable(d2))
+        self.assertEqual(dict_to_hashable(d1), dict_to_hashable(d3))
+        self.assertNotEqual(dict_to_hashable(d1), dict_to_hashable(d4))
+        self.assertNotEqual(dict_to_hashable(d2), dict_to_hashable(d4))
+        self.assertNotEqual(dict_to_hashable(d3), dict_to_hashable(d4))
+
+        cache = {dict_to_hashable(d1): 'hello'}
+        self.assertIn(dict_to_hashable(d1), cache)
+        self.assertIn(dict_to_hashable(d2), cache)
+        self.assertIn(dict_to_hashable(d3), cache)
+        self.assertNotIn(dict_to_hashable(d4), cache)
+
+        cache[dict_to_hashable(d4)] = 'goodbye'
+        self.assertIn(dict_to_hashable(d1), cache)
+        self.assertIn(dict_to_hashable(d2), cache)
+        self.assertIn(dict_to_hashable(d3), cache)
+        self.assertIn(dict_to_hashable(d4), cache)
+
+        self.assertEqual('hello', cache[dict_to_hashable(d1)])
+        self.assertEqual('hello', cache[dict_to_hashable(d2)])
+        self.assertEqual('hello', cache[dict_to_hashable(d3)])
+        self.assertEqual('goodbye', cache[dict_to_hashable(d4)])
+
+        self.assertEqual(2, len(cache))
+
+        cache = {('a_type', dict_to_hashable(d1)): 'hello'}
+        self.assertIn(('a_type', dict_to_hashable(d1)), cache)
+        self.assertIn(('a_type', dict_to_hashable(d2)), cache)
+        self.assertIn(('a_type', dict_to_hashable(d3)), cache)
+        self.assertNotIn(('b_type', dict_to_hashable(d1)), cache)
+        self.assertNotIn(('a_type', dict_to_hashable(d4)), cache)
+
+        cache[('a_type', dict_to_hashable(d4))] = 'goodbye'
+        self.assertIn(('a_type', dict_to_hashable(d1)), cache)
+        self.assertIn(('a_type', dict_to_hashable(d2)), cache)
+        self.assertIn(('a_type', dict_to_hashable(d3)), cache)
+        self.assertNotIn(('b_type', dict_to_hashable(d1)), cache)
+        self.assertIn(('a_type', dict_to_hashable(d4)), cache)
+
+        self.assertEqual('hello', cache[('a_type', dict_to_hashable(d1))])
+        self.assertEqual('hello', cache[('a_type', dict_to_hashable(d2))])
+        self.assertEqual('hello', cache[('a_type', dict_to_hashable(d3))])
+        self.assertEqual('goodbye', cache[('a_type', dict_to_hashable(d4))])
+
+        self.assertEqual(2, len(cache))


### PR DESCRIPTION
For other Redis-consuming projects, we have traditionally used the `sentinel_sharded_redis` library, which has a `sentinel_refresh_interval` setting. This setting controls how often `sentinel_sharded_redis` reaches out to Sentinel to get the latest information about Redis masters.

When consuming the `redis-py` library in this project, we applied the same pattern, adding a `sentinel_refresh_interval` setting to the transport and using that to control how often `redis-py`'s `sentinel.master_for(...)` is called. This is not the way `sentinel.master_for(...)` was designed to be used.

`sentinel.master_for(...)` creates a whole new `StrictRedis` client with a whole new connection pool every time it is called. We are wasting connections that remain open and unused until garbage collection runs, and opening connections too often, by regularly calling `sentinel.master_for(...)`. This method was designed to be called in a startup or lazy-startup capacity, and the client it returns should be used indefinitely. The client it returns uses a special managed connection pool with special managed connections that keeps track of master information and automatically closes and re-opens connections if the master information changes.

In this change, we are removing the `sentinel_refresh_interval` setting (but it can still be included for a no-op for temporary backwards compatibility with existing settings). We will no longer call `sentinel.master_for(...)` regularly. Instead, we call it the first time we need a master client, and then we use that master client indefinitely.

- `master_for` behavior: https://github.com/andymccurdy/redis-py/blob/5109cb4f6b610e8d5949716a16435afbbf35075a/redis/sentinel.py#L246-L272
- Sentinel-managed connection pool behavior: https://github.com/andymccurdy/redis-py/blob/5109cb4f6b610e8d5949716a16435afbbf35075a/redis/sentinel.py#L99-L108
- Sentinel-managed connection behavior: https://github.com/andymccurdy/redis-py/blob/5109cb4f6b610e8d5949716a16435afbbf35075a/redis/sentinel.py#L33-L66
- An example of Flask using `redis-py` Sentinel the same way we're proposing in this change: https://github.com/exponea/flask-redis-sentinel/blob/9f0003345d3756c19ce913acb0e25b613f8368a6/flask_redis_sentinel.py#L62-L77