### PR TITLE
Attempt number two at removing duplicate serialization from the client

### DIFF
--- a/pysoa/common/transport/redis_gateway/core.py
+++ b/pysoa/common/transport/redis_gateway/core.py
@@ -215,7 +215,7 @@ class RedisTransportCore(object):
                 self._get_counter('send.error.unknown').increment()
                 raise MessageSendError(
                     'Unknown error sending message for service {}'.format(self.service_name),
-                    six.text_type(type(e)),
+                    six.text_type(type(e).__name__),
                     *e.args
                 )
 
@@ -246,7 +246,7 @@ class RedisTransportCore(object):
             self._get_counter('receive.error.unknown').increment()
             raise MessageReceiveError(
                 'Unknown error receiving message for service {}'.format(self.service_name),
-                six.text_type(type(e)),
+                six.text_type(type(e).__name__),
                 *e.args
             )
 


### PR DESCRIPTION
We're currently serializing/deserializing the request/response in the client/server and then serializing/deserializing the entire message payload in the transport. There's no need to serialize in both places. This removes serialization from the client. The server will continue to support either, and then a future change will remove serialization from the server.

Our previous attempt to do this had to be rolled back because it was incompatible with the old ASGI transport. Now, nothing is using the old ASGI transport, so we can proceed with this.