### PR TITLE
Ensure double-import trap doesn't catch entrypoint execution

### DIFF
--- a/pysoa/server/standalone.py
+++ b/pysoa/server/standalone.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import sys
 
 
-if sys.path[0]:
+if sys.path[0] and sys.path[0] not in ('/usr/bin', '/usr/local/bin'):
     print(
         'ERROR: You have triggered a double-import trap (see '
         'http://python-notes.curiousefficiency.org/en/latest/python_concepts/import_traps.html#the-double-import-trap '


### PR DESCRIPTION
The double-import trap in the standalone helpers, meant to ensure that services' `standalone.py` files aren't called directly as runnable Python files, accidentally also trapped calls to the entrypoint executables. This fixes that.