### PR TITLE
Refactor expansion

### DIFF
--- a/tests/client_tests/test_expansions.py
+++ b/tests/client_tests/test_expansions.py
@@ -8,7 +8,7 @@ from pysoa.client.client import Client
 class TestClientWithExpansions(TestCase):
 
     def setUp(self):
-        expansions = {
+        expansion_config = {
             'type_routes': {
                 'bar': {
                     'service': 'bar',
@@ -182,7 +182,7 @@ class TestClientWithExpansions(TestCase):
             },
         }
 
-        self.client = Client(config=config, expansions=expansions)
+        self.client = Client(config=config, expansion_config=expansion_config)
 
     def test_call_actions_with_expansions(self):
         expected_foo_response = {


### PR DESCRIPTION
- Refactor out expansion method in client
- renaming to differentiate expansion_config init v.s. expansion_query from request
- When make request, the `body` takes `[value]` instead of `value`, assuming we always call batch endpoints
- When expand, the initial `exp_service_requests` set to empty, because the upstream `service` has been called before this method.