### PR TITLE
Add support for controlling request log logging level

### DIFF
--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -26,6 +26,8 @@ _logger_schema = fields.Dictionary(
     optional_keys=('level', 'propagate', 'filters', 'handlers'),
 )
 
+_log_level_schema = fields.Constant('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+
 
 class ServerSettings(SOASettings):
     """
@@ -104,6 +106,8 @@ class ServerSettings(SOASettings):
                 ),
             },
         ),
+        'request_log_success_level': _log_level_schema,
+        'request_log_error_level': _log_level_schema,
     }
 
     defaults = {
@@ -131,6 +135,8 @@ class ServerSettings(SOASettings):
             'timeout': 300,
             'shutdown_grace': 30,
         },
+        'request_log_success_level': 'INFO',
+        'request_log_error_level': 'INFO',
     }
 
 


### PR DESCRIPTION
For more verbose services, logging every request can get very expensive. However, request logging is on-or-off, which will hide the request log for requests that fail. This change permits separate logging levels for successful and failed requests.