### PR TITLE
Add support for server introspection

### DIFF
--- a/pysoa/server/__init__.py
+++ b/pysoa/server/__init__.py
@@ -1,4 +1,7 @@
-from .server import Server
+from __future__ import absolute_import, unicode_literals
+
+from pysoa.server.server import Server
+
 
 __all__ = [
     'Server',

--- a/pysoa/server/action/base.py
+++ b/pysoa/server/action/base.py
@@ -21,6 +21,13 @@ class Action(object):
     response_schema = None
 
     def __init__(self, settings=None):
+        """
+        Construct a new action. Concrete classes can override this and define a different interface, but they must
+        still pass the server settings to this base constructor.
+
+        :param settings: The server settings object
+        :type settings: dict
+        """
         self.settings = settings
 
     def run(self, request):

--- a/pysoa/server/action/introspection.py
+++ b/pysoa/server/action/introspection.py
@@ -1,0 +1,160 @@
+from __future__ import absolute_import, unicode_literals
+
+from conformity import fields
+import six
+
+from pysoa.common.constants import ERROR_CODE_INVALID
+from pysoa.common.types import Error
+from pysoa.server.action.base import Action
+from pysoa.server.action.status import BaseStatusAction
+from pysoa.server.errors import ActionError
+from pysoa.server.server import Server
+
+
+class IntrospectionAction(Action):
+    """
+    This action returns detailed information about the service's defined actions and the request and response schemas
+    for each action, along with any documentation defined for the action or for the service itself. It can be passed
+    a single action name to return information limited to that single action. Otherwise, it will return information for
+    all of the service's actions.
+
+    This action will be added to your service on your behalf if you do not define an action with name `introspect`.
+
+    Making your services and actions capable of being introspected is simple. If your server class has a `description`
+    attribute, that will be the service's documentation that introspection returns. If your server class does not have
+    this attribute but does have a docstring, introspection will use the docstring. The same rule applies to action
+    classes: Introspection first looks for a `description` attribute and then uses the docstring, if any. If neither of
+    these are found, the applicable service or action documentation will be done.
+
+    Introspection then looks at the `request_schema` and `response_schema` attributes for each of your actions, and
+    includes the details about these schemas in the returned information for each action. Be sure you include field
+    descriptions in your schema for the most effective documentation possible.
+    """
+    description = (
+        "This action returns detailed information about the service's defined actions and the request and response "
+        "schemas for each action, along with any documentation defined for the action or for the service itself. It "
+        "can be passed a single action name to return information limited to that single action. Otherwise, it will "
+        "return information for all of the service's actions."
+    )
+
+    request_schema = fields.Dictionary(
+        {
+            'action_name': fields.UnicodeString(
+                min_length=1,
+                allow_blank=False,
+                description='Specify this to limit your introspection to a single action. It will be the only action '
+                            'present in the `actions` response attribute. If the requested action does not exist, an '
+                            'error will be returned.',
+            ),
+        },
+        optional_keys=('action_name', ),
+    )
+
+    response_schema = fields.Dictionary(
+        {
+            'documentation': fields.Nullable(fields.UnicodeString(
+                description='The documentation for the server, unless `action_name` is specified in the request body, '
+                            'in which case this is omitted.',
+            )),
+            'action_names': fields.List(
+                fields.UnicodeString(description='The name of an action.'),
+                description='An alphabetized list of every action name included in `actions`.',
+            ),
+            'actions': fields.SchemalessDictionary(
+                key_type=fields.UnicodeString(description='The name of the action.'),
+                value_type=fields.Dictionary(
+                    {
+                        'documentation': fields.Nullable(
+                            fields.UnicodeString(description='The documentation for the action'),
+                        ),
+                        'request_schema': fields.Nullable(fields.Anything(
+                            description='A description of the expected request schema, including any documentation '
+                                        'specified in the schema definition.',
+                        )),
+                        'response_schema': fields.Nullable(fields.Anything(
+                            description='A description of the guaranteed response schema, including any documentation '
+                                        'specified in the schema definition.',
+                        )),
+                    },
+                    description='A introspection of a single action',
+                ),
+                description='A dict mapping action names to action description dictionaries. This contains details '
+                            'about every action in the service unless `action_name` is specified in the request body, '
+                            'in which case it contains details only for that action.',
+            ),
+        },
+        optional_keys=('documentation', ),
+    )
+
+    def __init__(self, server):
+        """
+        Construct a new introspection action. Unlike its base class, which accepts a server settings object, this
+        must be passed a `pysoa.server.server.Server` object, from which it will obtain a settings object.
+
+        :param server: A PySOA server instance
+        :type server: pysoa.server.server.Server
+        """
+        if not isinstance(server, Server):
+            raise TypeError('First argument (server) must be a Server instance')
+
+        super(IntrospectionAction, self).__init__(server.settings)
+
+        self.server = server
+
+    def run(self, request):
+        if request.body.get('action_name'):
+            action_name = request.body['action_name']
+            if action_name not in self.server.action_class_map and action_name not in ('status', 'introspect'):
+                raise ActionError(errors=[
+                    Error(code=ERROR_CODE_INVALID, message='Action not defined in service', field='action_name'),
+                ])
+
+            if action_name in self.server.action_class_map:
+                action_class = self.server.action_class_map[action_name]
+            elif action_name == 'introspect':
+                action_class = self.__class__
+            else:
+                action_class = BaseStatusAction
+
+            return {
+                'action_names': [action_name],
+                'actions': {action_name: self._introspect_action(action_class)}
+            }
+
+        response = {
+            'actions': {},
+            'action_names': [],
+            'documentation': getattr(self.server.__class__, 'description', self.server.__class__.__doc__) or None,
+        }
+
+        if 'introspect' not in self.server.action_class_map:
+            response['action_names'].append('introspect')
+            response['actions']['introspect'] = self._introspect_action(self.__class__)
+
+        if 'status' not in self.server.action_class_map:
+            response['action_names'].append('status')
+            response['actions']['status'] = self._introspect_action(BaseStatusAction)
+
+        for action_name, action_class in six.iteritems(self.server.action_class_map):
+            response['action_names'].append(action_name)
+            response['actions'][action_name] = self._introspect_action(action_class)
+
+        response['action_names'] = list(sorted(response['action_names']))
+
+        return response
+
+    @staticmethod
+    def _introspect_action(action_class):
+        action = {
+            'documentation': getattr(action_class, 'description', action_class.__doc__) or None,
+            'request_schema': None,
+            'response_schema': None,
+        }
+
+        if getattr(action_class, 'request_schema', None):
+            action['request_schema'] = action_class.request_schema.introspect()
+
+        if getattr(action_class, 'response_schema', None):
+            action['response_schema'] = action_class.response_schema.introspect()
+
+        return action

--- a/tests/server/action/test_introspection.py
+++ b/tests/server/action/test_introspection.py
@@ -1,0 +1,236 @@
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+from conformity import fields
+
+from pysoa.common.constants import ERROR_CODE_INVALID
+from pysoa.server.action.introspection import IntrospectionAction
+from pysoa.server.action.status import (
+    BaseStatusAction,
+    StatusActionFactory,
+)
+from pysoa.server.errors import ActionError
+from pysoa.server.server import Server
+from pysoa.server.types import EnrichedActionRequest
+
+
+class FakeActionOne(object):
+    """Test action documentation"""
+
+    description = 'The real documentation'
+
+
+class FakeActionTwo(object):
+    """Test action documentation"""
+
+    request_schema = fields.UnicodeString(description='Be weird.')
+
+    response_schema = fields.Dictionary(
+        {
+            'okay': fields.Boolean(description='Whether it is okay'),
+            'reason': fields.Nullable(fields.UnicodeString(description='Why it is not okay')),
+        }
+    )
+
+
+class FakeServerOne(Server):
+    """This is the documentation we should get"""
+
+    action_class_map = {
+        'status': StatusActionFactory('1.2.3'),
+        'one': FakeActionOne,
+    }
+
+    settings = {}
+
+    # noinspection PyMissingConstructor
+    def __init__(self):
+        pass  # Do not call super
+
+
+class FakeServerTwo(Server):
+    """This is NOT the documentation we should get"""
+
+    description = 'Instead, we should get this documentation'
+
+    action_class_map = {
+        'introspect': IntrospectionAction,
+        'one': FakeActionOne,
+        'two': FakeActionTwo,
+    }
+
+    settings = {}
+
+    # noinspection PyMissingConstructor
+    def __init__(self):
+        pass  # Do not call super
+
+
+class TestIntrospectionAction(unittest.TestCase):
+    def test_null_action_name(self):
+        action = IntrospectionAction(FakeServerOne())
+
+        with self.assertRaises(ActionError) as error_context:
+            action(EnrichedActionRequest(action='introspect', body={'action_name': None}))
+
+        self.assertEqual(1, len(error_context.exception.errors))
+        self.assertEqual(ERROR_CODE_INVALID, error_context.exception.errors[0].code)
+        self.assertEqual('action_name', error_context.exception.errors[0].field)
+
+    def test_invalid_action_name(self):
+        action = IntrospectionAction(FakeServerOne())
+
+        with self.assertRaises(ActionError) as error_context:
+            action(EnrichedActionRequest(action='introspect', body={'action_name': 'not_a_defined_action'}))
+
+        self.assertEqual(1, len(error_context.exception.errors))
+        self.assertEqual(ERROR_CODE_INVALID, error_context.exception.errors[0].code)
+        self.assertEqual('action_name', error_context.exception.errors[0].field)
+
+    def test_single_action_simple(self):
+        action = IntrospectionAction(FakeServerOne())
+
+        response = action(EnrichedActionRequest(action='introspect', body={'action_name': 'one'}))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual(
+            {
+                'action_names': ['one'],
+                'actions': {
+                    'one': {
+                        'documentation': 'The real documentation',
+                        'request_schema': None,
+                        'response_schema': None,
+                    },
+                },
+            },
+            response.body,
+        )
+
+    def test_single_action_complex(self):
+        action = IntrospectionAction(FakeServerTwo())
+
+        response = action(EnrichedActionRequest(action='introspect', body={'action_name': 'two'}))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual(
+            {
+                'action_names': ['two'],
+                'actions': {
+                    'two': {
+                        'documentation': 'Test action documentation',
+                        'request_schema': FakeActionTwo.request_schema.introspect(),
+                        'response_schema': FakeActionTwo.response_schema.introspect(),
+                    },
+                },
+            },
+            response.body,
+        )
+
+    def test_single_action_introspect_default(self):
+        action = IntrospectionAction(FakeServerOne())
+
+        response = action(EnrichedActionRequest(action='introspect', body={'action_name': 'introspect'}))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual(
+            {
+                'action_names': ['introspect'],
+                'actions': {
+                    'introspect': {
+                        'documentation': IntrospectionAction.description,
+                        'request_schema': IntrospectionAction.request_schema.introspect(),
+                        'response_schema': IntrospectionAction.response_schema.introspect(),
+                    },
+                },
+            },
+            response.body,
+        )
+
+    def test_single_action_status_default(self):
+        action = IntrospectionAction(FakeServerTwo())
+
+        response = action(EnrichedActionRequest(action='introspect', body={'action_name': 'status'}))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual(
+            {
+                'action_names': ['status'],
+                'actions': {
+                    'status': {
+                        'documentation': BaseStatusAction.description,
+                        'request_schema': BaseStatusAction.request_schema.introspect(),
+                        'response_schema': BaseStatusAction.response_schema.introspect(),
+                    },
+                },
+            },
+            response.body,
+        )
+
+    def test_whole_server_simple(self):
+        action = IntrospectionAction(FakeServerOne())
+
+        response = action(EnrichedActionRequest(action='introspect', body={}))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual(
+            {
+                'documentation': 'This is the documentation we should get',
+                'action_names': ['introspect', 'one', 'status'],
+                'actions': {
+                    'introspect': {
+                        'documentation': IntrospectionAction.description,
+                        'request_schema': IntrospectionAction.request_schema.introspect(),
+                        'response_schema': IntrospectionAction.response_schema.introspect(),
+                    },
+                    'status': {
+                        'documentation': BaseStatusAction.description,
+                        'request_schema': BaseStatusAction.request_schema.introspect(),
+                        'response_schema': BaseStatusAction.response_schema.introspect(),
+                    },
+                    'one': {
+                        'documentation': 'The real documentation',
+                        'request_schema': None,
+                        'response_schema': None,
+                    },
+                },
+            },
+            response.body
+        )
+
+    def test_whole_server_complex(self):
+        action = IntrospectionAction(FakeServerTwo())
+
+        response = action(EnrichedActionRequest(action='introspect', body={}))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual(
+            {
+                'documentation': 'Instead, we should get this documentation',
+                'action_names': ['introspect', 'one', 'status', 'two'],
+                'actions': {
+                    'introspect': {
+                        'documentation': IntrospectionAction.description,
+                        'request_schema': IntrospectionAction.request_schema.introspect(),
+                        'response_schema': IntrospectionAction.response_schema.introspect(),
+                    },
+                    'status': {
+                        'documentation': BaseStatusAction.description,
+                        'request_schema': BaseStatusAction.request_schema.introspect(),
+                        'response_schema': BaseStatusAction.response_schema.introspect(),
+                    },
+                    'one': {
+                        'documentation': 'The real documentation',
+                        'request_schema': None,
+                        'response_schema': None,
+                    },
+                    'two': {
+                        'documentation': 'Test action documentation',
+                        'request_schema': FakeActionTwo.request_schema.introspect(),
+                        'response_schema': FakeActionTwo.response_schema.introspect(),
+                    },
+                },
+            },
+            response.body
+        )

--- a/tests/server/action/test_status.py
+++ b/tests/server/action/test_status.py
@@ -4,12 +4,14 @@ import platform
 import unittest
 
 import conformity
+from conformity.fields.basic import Boolean
 import six
 
 import pysoa
 from pysoa.common.types import ActionResponse
 from pysoa.server.action.status import (
     BaseStatusAction,
+    make_default_status_action_class,
     StatusActionFactory,
 )
 from pysoa.server.types import EnrichedActionRequest
@@ -152,3 +154,20 @@ class TestBaseStatusAction(unittest.TestCase):
             },
             response.body,
         )
+
+    def test_make_default_status_action_class(self):
+        action_class = make_default_status_action_class(ActionResponse)
+        self.assertIsNotNone(action_class)
+        self.assertTrue(issubclass(action_class, BaseStatusAction))
+
+        action = action_class({})
+        self.assertEqual(six.text_type(pysoa.__version__), action._version)
+        self.assertIsNone(action._build)
+
+        action_class = make_default_status_action_class(Boolean)
+        self.assertIsNotNone(action_class)
+        self.assertTrue(issubclass(action_class, BaseStatusAction))
+
+        action = action_class({})
+        self.assertEqual(six.text_type(conformity.__version__), action._version)
+        self.assertIsNone(action._build)


### PR DESCRIPTION
This commit creates a new stock introspection action, which returns information about the service and its actions and their request and response schemas, and uses it by default if the server does not define an `introspect` action. As a related feature, it also ensures that every server responds to `status` if the server does not define a `status` action. Finally, it ensures the status action is adequately documented, so that it can be introspected well.