### PR TITLE
Fix improper type for logging logger propagate setting

### DIFF
--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -19,7 +19,7 @@ from pysoa.server.middleware import ServerMiddleware
 _logger_schema = fields.Dictionary(
     {
         'level': fields.UnicodeString(),
-        'propagate': fields.UnicodeString(),
+        'propagate': fields.Any(fields.Boolean(), fields.UnicodeString()),  # TODO change to just Boolean() > 2018-03-01
         'filters': fields.List(fields.UnicodeString()),
         'handlers': fields.List(fields.UnicodeString()),
     },


### PR DESCRIPTION
Using `fields.Any(fields.Boolean(), fields.UnicodeString())` for now so that this change is backwards-compatible. Whill change it to `fields.Boolean()` at a later date.