### PR TITLE
Ensure logging context works with local services by using a stack

### DIFF
--- a/pysoa/server/logging.py
+++ b/pysoa/server/logging.py
@@ -22,12 +22,17 @@ class PySOALogContextFilter(logging.Filter):
 
     @classmethod
     def set_logging_request_context(cls, **context):
-        cls._logging_context.context = context
+        if not getattr(cls._logging_context, 'context_stack', None):
+            cls._logging_context.context_stack = []
+        cls._logging_context.context_stack.append(context)
 
     @classmethod
     def clear_logging_request_context(cls):
-        del cls._logging_context.context
+        if getattr(cls._logging_context, 'context_stack', None):
+            cls._logging_context.context_stack.pop()
 
     @classmethod
     def get_logging_request_context(cls):
-        return getattr(cls._logging_context, 'context', None)
+        if getattr(cls._logging_context, 'context_stack', None):
+            return cls._logging_context.context_stack[-1]
+        return None

--- a/tests/server/test_logging.py
+++ b/tests/server/test_logging.py
@@ -8,6 +8,16 @@ from pysoa.server.logging import PySOALogContextFilter
 
 
 class TestPySOALogContextFilter(unittest.TestCase):
+    def tearDown(self):
+        # Make sure that if anything goes wrong with these tests, that it doesn't affect any other tests
+        PySOALogContextFilter.clear_logging_request_context()
+        PySOALogContextFilter.clear_logging_request_context()
+        PySOALogContextFilter.clear_logging_request_context()
+        PySOALogContextFilter.clear_logging_request_context()
+        PySOALogContextFilter.clear_logging_request_context()
+        PySOALogContextFilter.clear_logging_request_context()
+        PySOALogContextFilter.clear_logging_request_context()
+
     def test_threading(self):
         thread_data = {}
 
@@ -69,7 +79,8 @@ class TestPySOALogContextFilter(unittest.TestCase):
         self.assertEqual('', record.correlation_id)
         self.assertEqual('', record.request_id)
 
-        PySOALogContextFilter.set_logging_request_context(foo='bar', **{'baz': 'qux'})
+        PySOALogContextFilter.set_logging_request_context(filter='mine', **{'logger': 'yours'})
+        self.assertEqual({'filter': 'mine', 'logger': 'yours'}, PySOALogContextFilter.get_logging_request_context())
 
         record.reset_mock()
 
@@ -78,6 +89,10 @@ class TestPySOALogContextFilter(unittest.TestCase):
         self.assertEqual('', record.request_id)
 
         PySOALogContextFilter.set_logging_request_context(request_id=4321, **{'correlation_id': 'abc1234'})
+        self.assertEqual(
+            {'request_id': 4321, 'correlation_id': 'abc1234'},
+            PySOALogContextFilter.get_logging_request_context()
+        )
 
         record.reset_mock()
 
@@ -86,6 +101,16 @@ class TestPySOALogContextFilter(unittest.TestCase):
         self.assertEqual(4321, record.request_id)
 
         PySOALogContextFilter.clear_logging_request_context()
+        self.assertEqual({'filter': 'mine', 'logger': 'yours'}, PySOALogContextFilter.get_logging_request_context())
+
+        record.reset_mock()
+
+        self.assertTrue(log_filter.filter(record))
+        self.assertEqual('', record.correlation_id)
+        self.assertEqual('', record.request_id)
+
+        PySOALogContextFilter.clear_logging_request_context()
+        self.assertIsNone(PySOALogContextFilter.get_logging_request_context())
 
         record.reset_mock()
 


### PR DESCRIPTION
The logging context added in 157b6e8 works great for remote services. It even works for calling a local service from something other than another service. However, when a local or remote service calls a local service (such as when unit testing a service that calls another service and stubbing that other service), it results in an attribute error in the outer call. To properly support local services, which could be called more than one level deep, the logging context should be a stack, not an absolute value, to ensure that we properly step into and out of each context for logging purposes, so that logging calls include the correct details for our current position in the nested PySOA call stack.