### PR TITLE
Make disable_existing_loggers default to False to allow module-level getLogger

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -834,7 +834,7 @@ Server settings:
 
     * ``incremental``: A Boolean for whether the configuration is to be interpreted as incremental to the existing configuration (Python defaults this to ``False``)
 
-    * ``disable_existing_loggers``: A Boolean for whether existing loggers are to be disabled (Python defaults this to ``True`` and ignores its value if ``incremental`` is ``True``)
+    * ``disable_existing_loggers``: A Boolean for whether existing loggers are to be disabled (Python defaults this to ``True`` and ignores its value if ``incremental`` is ``True``; PySOA defaults this value to ``False`` to allow module-level ``getLogger`` calls)
 
   + ``harakiri``: Settings for killing long-running jobs that may have run away or frozen, a dict with the following format:
 

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -26,7 +26,7 @@ _logger_schema = fields.Dictionary(
     optional_keys=('level', 'propagate', 'filters', 'handlers'),
 )
 
-_log_level_schema = fields.Constant('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+log_level_schema = fields.Constant('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
 
 
 class ServerSettings(SOASettings):
@@ -96,7 +96,6 @@ class ServerSettings(SOASettings):
                 'root',
                 'loggers',
                 'incremental',
-                'disable_existing_loggers',
             ),
             description='Settings for service logging, which should follow the standard Python logging configuration',
         ),
@@ -112,8 +111,8 @@ class ServerSettings(SOASettings):
                 ),
             },
         ),
-        'request_log_success_level': _log_level_schema,
-        'request_log_error_level': _log_level_schema,
+        'request_log_success_level': log_level_schema,
+        'request_log_error_level': log_level_schema,
     }
 
     defaults = {
@@ -142,6 +141,7 @@ class ServerSettings(SOASettings):
                 'handlers': ['console'],
                 'level': 'INFO',
             },
+            'disable_existing_loggers': False,
         },
         'harakiri': {
             'timeout': 300,


### PR DESCRIPTION
When configuring Python logging with `dictConfig` (which the PySOA server does on startup), the `disable_existing_loggers` setting defaults to `True` for backwards compatibility with <2.6 versions of Python. This is true even in Python 3.6. The problem with this is that it is incompatible with code that instantiates a logger with `logging.getLogger` at the top of a module. When this code is first imported at startup, all loggers are initialized with a default config. When the new config is installed, all loggers not specifically mentioned in the new config are disabled (so they don't trickle to the root logger). This change sets `disable_existing_loggers` to `False` by default if not specified intentionally as `True`, which means that module-level `getLogger` calls triggered at import will not cause logging to break.

It should be noted that this change also mirrors Django behavior, which specifically defaults `disable_existing_loggers` to `False` unless the settings module has its value intentionally set to `True`.