### PR TITLE
Ensure actionless job request causes validation error

### DIFF
--- a/pysoa/server/schemas.py
+++ b/pysoa/server/schemas.py
@@ -35,6 +35,6 @@ JobRequestSchema = Dictionary(
     {
         'control': ControlHeaderSchema,
         'context': ContextHeaderSchema,
-        'actions': List(ActionRequestSchema),
+        'actions': List(ActionRequestSchema, min_length=1),
     },
 )

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -172,4 +172,5 @@ class TestJobRequestSchema:
     def test_empty_actions(self, job):
         job['actions'] = []
         errors = JobRequestSchema.errors(job)
-        assert not errors
+        assert len(errors) == 1
+        assert errors[0].pointer == 'actions'


### PR DESCRIPTION
A job request without actions is not valid. It should trigger a validation error.