### PR TITLE
[MAJOR] Switch to microsecond resolution for metrics timers

### DIFF
--- a/pysoa/common/transport/redis_gateway/client.py
+++ b/pysoa/common/transport/redis_gateway/client.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import uuid
 
+from pysoa.common.metrics import TimerResolution
 from pysoa.common.transport.base import (
     ClientTransport,
     get_hex_thread_id,
@@ -37,12 +38,12 @@ class RedisClientTransport(ClientTransport):
             thread_id=get_hex_thread_id(),
         )
 
-        with self.metrics.timer('client.transport.redis_gateway.send'):
+        with self.metrics.timer('client.transport.redis_gateway.send', resolution=TimerResolution.MICROSECONDS):
             self.core.send_message(self._send_queue_name, request_id, meta, body)
 
     def receive_response_message(self):
         if self._requests_outstanding > 0:
-            with self.metrics.timer('client.transport.redis_gateway.receive'):
+            with self.metrics.timer('client.transport.redis_gateway.receive', resolution=TimerResolution.MICROSECONDS):
                 request_id, meta, response = self.core.receive_message('{receive_queue_name}{thread_id}'.format(
                     receive_queue_name=self._receive_queue_name,
                     thread_id=get_hex_thread_id(),

--- a/pysoa/common/transport/redis_gateway/core.py
+++ b/pysoa/common/transport/redis_gateway/core.py
@@ -12,6 +12,7 @@ import redis
 from pysoa.common.metrics import (
     MetricsRecorder,
     NoOpMetricsRecorder,
+    TimerResolution,
 )
 from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer
 from pysoa.common.transport.exceptions import (
@@ -284,4 +285,4 @@ class RedisTransportCore(object):
         return self.metrics.counter(self._get_metric_name(name))
 
     def _get_timer(self, name):
-        return self.metrics.timer(self._get_metric_name(name))
+        return self.metrics.timer(self._get_metric_name(name), resolution=TimerResolution.MICROSECONDS)

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from pysoa.common.metrics import TimerResolution
 from pysoa.common.transport.base import ServerTransport
 from pysoa.common.transport.exceptions import (
     InvalidMessageError,
@@ -18,7 +19,7 @@ class RedisServerTransport(ServerTransport):
         self.core = RedisTransportCore(service_name=service_name, metrics=metrics, metrics_prefix='server', **kwargs)
 
     def receive_request_message(self):
-        timer = self.metrics.timer('server.transport.redis_gateway.receive')
+        timer = self.metrics.timer('server.transport.redis_gateway.receive', resolution=TimerResolution.MICROSECONDS)
         timer.start()
         stop_timer = True
         try:
@@ -37,5 +38,5 @@ class RedisServerTransport(ServerTransport):
             self.metrics.counter('server.transport.redis_gateway.send.error.missing_reply_queue')
             raise InvalidMessageError('Missing reply queue name')
 
-        with self.metrics.timer('server.transport.redis_gateway.send'):
+        with self.metrics.timer('server.transport.redis_gateway.send', resolution=TimerResolution.MICROSECONDS):
             self.core.send_message(queue_name, request_id, meta, body)


### PR DESCRIPTION
Due to the miniscule amount of time consumed by many operations in PySOA, millisecond resolution is not sufficient for metrics timers. This commit changes PySOA timers to microsecond resolution.

Note that this is a breaking change not for existing services/code, but for existing metrics graphs and reports. Previously, the value these graphs and reports displayed represented a number with milliseconds units. Now, they will be a number with microseconds units. As such, without the context of this change in mind, performance will appear to get worse by three orders of magnitude across the board on all existing graphs after a release deployment.