### PR TITLE
suppress expansion exception when request has invalid key

### DIFF
--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -188,6 +188,9 @@ class Client(object):
     class ImproperlyConfigured(Exception):
         pass
 
+    class InvalidExpansionKey(Exception):
+        pass
+
     class JobError(Exception):
         """
         Raised by Client.call_action(s) when a job response contains one or more job errors.
@@ -297,8 +300,12 @@ class Client(object):
     def _perform_expansion(self, skeleton_response, expansions):
         # Perform expansions
         if expansions and hasattr(self, 'expansion_converter'):
-            objs_to_expand = self._extract_candidate_objects(skeleton_response.actions, expansions)
-            self._expand_objects(objs_to_expand)
+            try:
+                objs_to_expand = self._extract_candidate_objects(skeleton_response.actions, expansions)
+            except KeyError as key_error:
+                raise self.InvalidExpansionKey("Invalid key in expansion request: {}".format(key_error.args[0]))
+            else:
+                self._expand_objects(objs_to_expand)
 
     def _extract_candidate_objects(self, actions, expansions):
         # Build initial list of objects to expand

--- a/tests/client/test_expansions.py
+++ b/tests/client/test_expansions.py
@@ -342,3 +342,25 @@ class TestClientWithExpansions(TestCase):
         self.assertEqual(err.code, 'INVALID')
         self.assertEqual(err.field, 'id')
         self.assertEqual(err.message, 'Invalid publisher ID')
+
+    def test_expansion_client_key_error(self):
+        errors = [{
+            'code': 'INVALID',
+            'field': 'id',
+            'message': 'Invalid author ID',
+        }]
+        self.client._get_handler('author_info_service').transport.stub_action('get_authors_by_ids', errors=errors)
+
+        with self.assertRaises(self.client.InvalidExpansionKey) as err:
+            self.client.call_action(
+                service_name='book_info_service',
+                action='get_book',
+                body={
+                    'id': 1,
+                },
+                expansions={
+                    'book_type': ['author_rule_typo_key'],
+                },
+            )
+        message, = err.exception.args
+        self.assertEqual(message, 'Invalid key in expansion request: author_rule_typo_key')


### PR DESCRIPTION
When doing expansion, a key exception should be silenced because it is a client error not a server error. Consequently return only the original skeleton_response.