### PR TITLE
[MAJOR] Add support for setting a custom timeout when sending a request

### DIFF
--- a/pysoa/client/middleware.py
+++ b/pysoa/client/middleware.py
@@ -1,8 +1,42 @@
 class ClientMiddleware(object):
-    """Base middleware class for the Client."""
+    """
+    Base middleware class for client middleware. Not required, but provides some helpful stubbed methods and
+    documentation that you should follow for creating your middleware classes. If you extend this class, you may
+    override either one or both of the methods.
+
+    Middleware must have two callable attributes, `request` and `response`, that, when called with the next level down,
+    return a callable that takes the appropriate arguments and returns the appropriate value.
+    """
 
     def request(self, send_request):
+        """
+        In sub-classes, used for creating a wrapper around `send_request`. In this simple implementation, just returns
+        `send_request`.
+
+        :param send_request: A callable that accepts a request ID int, meta `dict`, `JobRequest` object, and message
+                             expiry int and returns nothing
+        :type send_request: callable(int, dict, JobRequest, int): undefined
+
+        :return: A callable that accepts a request ID int, meta `dict`, `JobRequest` object, and message expiry int and
+                 returns nothing.
+        :rtype: callable(int, dict, JobRequest, int): undefined
+        """
+
+        # Remove ourselves from the stack
         return send_request
 
     def response(self, get_response):
+        """
+        In sub-classes, used for creating a wrapper around `get_response`. In this simple implementation, just returns
+        `get_response`.
+
+        :param get_response: A callable that accepts a timeout int and returns tuple of request ID int and
+                             `JobResponse` object
+        :type get_response: callable(int): tuple<int, JobResponse>
+
+        :return: A callable that accepts a timeout int and returns tuple of request ID int and `JobResponse` object.
+        :rtype: callable(int): tuple<int, JobResponse>
+        """
+
+        # Remove ourselves from the stack
         return get_response

--- a/pysoa/common/metrics.py
+++ b/pysoa/common/metrics.py
@@ -1,17 +1,21 @@
 from __future__ import unicode_literals
 
+import abc
 import enum
 
 from conformity import fields
+import six
 
 from pysoa.common.schemas import BasicClassSchema
 
 
+@six.add_metaclass(abc.ABCMeta)
 class Counter(object):
     """
     Defines an interface for incrementing a counter.
     """
 
+    @abc.abstractmethod
     def increment(self, amount=1):
         """
         Increments the counter.
@@ -27,17 +31,20 @@ class TimerResolution(enum.IntEnum):
     NANOSECONDS = 10**9
 
 
+@six.add_metaclass(abc.ABCMeta)
 class Timer(object):
     """
     Defines an interface for timing activity. Can be used as a context manager to time wrapped activity.
     """
 
+    @abc.abstractmethod
     def start(self):
         """
         Starts the timer.
         """
         raise NotImplementedError()
 
+    @abc.abstractmethod
     def stop(self):
         """
         Stops the timer.
@@ -52,6 +59,7 @@ class Timer(object):
         return False
 
 
+@six.add_metaclass(abc.ABCMeta)
 class MetricsRecorder(object):
     """
     Defines an interface for recording metrics. All metrics recorders registered with PySOA must implement this
@@ -59,6 +67,7 @@ class MetricsRecorder(object):
     timers to also have associated counters, your implementation of this recorder must take care of filling that gap.
     """
 
+    @abc.abstractmethod
     def counter(self, name, **kwargs):
         """
         Returns a counter that can be incremented. Implementations do not have to return an instance of `Counter`, but
@@ -72,6 +81,7 @@ class MetricsRecorder(object):
         """
         raise NotImplementedError()
 
+    @abc.abstractmethod
     def timer(self, name, resolution=TimerResolution.MILLISECONDS, **kwargs):
         """
         Returns a timer that can be started and stopped. Implementations do not have to return an instance of `Timer`,

--- a/pysoa/common/serializer/base.py
+++ b/pysoa/common/serializer/base.py
@@ -1,26 +1,31 @@
+import abc
 
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
 class Serializer(object):
 
+    @abc.abstractmethod
     def dict_to_blob(self, message_dict):
         """
-        Take a message in the form of a dict and return a serialized message
-        in the form of bytes (string).
+        Take a message in the form of a dict and return a serialized message in the form of bytes (string).
 
         Returns:
             string
         Raises:
             InvalidField
         """
-        raise NotImplementedError
+        raise NotImplementedError()
 
+    @abc.abstractmethod
     def blob_to_dict(self, blob):
         """
-        Take a serialized message in the form of bytes (string) and return a
-        dict.
+        Take a serialized message in the form of bytes (string) and return a dict.
 
         Returns:
             dict
         Raises:
             InvalidMessage
         """
-        raise NotImplementedError
+        raise NotImplementedError()

--- a/pysoa/common/transport/redis_gateway/backend/base.py
+++ b/pysoa/common/transport/redis_gateway/backend/base.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import abc
 import binascii
 import itertools
 import random
@@ -44,6 +45,7 @@ redis.call('expire', KEYS[1], ARGV[1])
         self._call(keys=[queue_key], args=[expiry, capacity, message], connection=connection)
 
 
+@six.add_metaclass(abc.ABCMeta)
 class BaseRedisClient(object):
     DEFAULT_RECEIVE_TIMEOUT = 5
     RESPONSE_QUEUE_SPECIFIER = '!'
@@ -69,6 +71,7 @@ class BaseRedisClient(object):
             # It's a request queue, so use a random connection
             return self._get_connection(next(self._connection_index_generator))
 
+    @abc.abstractmethod
     def _get_connection(self, index=None):
         """
         Returns the correct connection for the current thread. Pass `index` to use a server based on consistent hashing

--- a/pysoa/server/action/base.py
+++ b/pysoa/server/action/base.py
@@ -1,10 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
+import abc
+
+import six
+
 from pysoa.common.constants import ERROR_CODE_INVALID
 from pysoa.common.types import ActionResponse, Error
 from pysoa.server.errors import ActionError, ResponseValidationError
 
 
+@six.add_metaclass(abc.ABCMeta)
 class Action(object):
     """
     Base class from which all SOA Service Actions inherit.
@@ -30,6 +35,7 @@ class Action(object):
         """
         self.settings = settings
 
+    @abc.abstractmethod
     def run(self, request):
         """
         Override this to perform your business logic, and either return a dict

--- a/pysoa/server/action/status.py
+++ b/pysoa/server/action/status.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import abc
 import platform
 import sys
 
@@ -36,13 +37,11 @@ class BaseStatusAction(Action):
     """
 
     def __init__(self, *args, **kwargs):
-        if self.__class__ is BaseStatusAction:
-            raise RuntimeError('You cannot use BaseStatusAction directly; it must be subclassed')
         super(BaseStatusAction, self).__init__(*args, **kwargs)
 
         self.diagnostics = {}
 
-    @property
+    @abc.abstractproperty
     def _version(self):
         raise NotImplementedError('version must be defined using StatusActionFactory')
 

--- a/pysoa/server/autoreload.py
+++ b/pysoa/server/autoreload.py
@@ -91,7 +91,8 @@ def _clean_files(file_list):
     return file_names
 
 
-class AbstractReloader(six.with_metaclass(abc.ABCMeta, object)):
+@six.add_metaclass(abc.ABCMeta)
+class AbstractReloader(object):
     """
     This is the abstract base reloader, which handles most of the code associated with watching files for changes and
     reloading the application when changes are detected. All base classes must implement the logic for actually

--- a/pysoa/server/middleware.py
+++ b/pysoa/server/middleware.py
@@ -1,17 +1,42 @@
 class ServerMiddleware(object):
     """
-    Base middleware class for server middleware. Not required, but gives you
-    some helpful utility functions.
+    Base middleware class for server middleware. Not required, but provides some helpful stubbed methods and
+    documentation that you should follow for creating your middleware classes. If you extend this class, you may
+    override either one or both of the methods.
 
-    Middleware must have two callables, `job` and `action`, that when called
-    with the next level down, return a callable that takes a request and
-    either returns a response or errors.
+    Middleware must have two callable attributes, `job` and `action`, that, when called with the next level down,
+    return a callable that takes the appropriate arguments and returns the appropriate value.
     """
 
     def job(self, process_job):
+        """
+        In sub-classes, used for creating a wrapper around `process_job`. In this simple implementation, just returns
+        'process_job`.
+
+        :param process_job: A callable that accepts a job request `dict` and returns a job response `dict`, or errors
+        :type process_job: callable(dict): dict
+
+        :return: A callable that accepts a job request `dict` and returns a job response `dict`, or errors, by calling
+                 the provided `process_job` and possibly doing other things.
+        :rtype: callable(dict): dict
+        """
+
         # Remove ourselves from the stack
         return process_job
 
     def action(self, process_action):
+        """
+        In sub-classes, used for creating a wrapper around `process_action`. In this simple implementation, just
+        returns `process_action`.
+
+        :param process_action: A callable that accepts an `ActionRequest` object and returns an `ActionResponse`
+                               object, or errors
+        :type process_action: callable(ActionRequest): ActionResponse
+
+        :return: A callable that accepts an `ActionRequest` object and returns an `ActionResponse` object, or errors,
+                 by calling the provided `process_action` and possibly doing other things.
+        :rtype: callable(ActionRequest): ActionResponse
+        """
+
         # Remove ourselves from the stack
         return process_action

--- a/pysoa/test/factories.py
+++ b/pysoa/test/factories.py
@@ -14,7 +14,7 @@ class ServerSettingsFactory(factory.Factory):
 
     data = factory.Dict({
         'transport': {
-            'path': 'pysoa.common.transport.base:ServerTransport',
+            'path': 'pysoa.common.transport.local:LocalServerTransport',
         },
     })
 
@@ -25,7 +25,7 @@ class ServerSettingsFactory(factory.Factory):
         kwargs['data'] = dict(
             kwargs['data'],
             transport={
-                'path': 'pysoa.common.transport.base:ServerTransport',
+                'path': 'pysoa.common.transport.local:LocalServerTransport',
             },
         )
         return kwargs

--- a/tests/common/transport/redis_gateway/test_client.py
+++ b/tests/common/transport/redis_gateway/test_client.py
@@ -48,7 +48,8 @@ class TestClientTransport(unittest.TestCase):
                     thread_id=get_hex_thread_id(),
                 ),
             },
-            message
+            message,
+            None,
         )
 
     def test_send_request_message_another_service(self, mock_core):
@@ -57,7 +58,7 @@ class TestClientTransport(unittest.TestCase):
         request_id = uuid.uuid4().hex
         message = {'another': 'message'}
 
-        transport.send_request_message(request_id, {}, message)
+        transport.send_request_message(request_id, {}, message, 25)
 
         mock_core.return_value.send_message.assert_called_once_with(
             'service.geo',
@@ -68,7 +69,8 @@ class TestClientTransport(unittest.TestCase):
                     thread_id=get_hex_thread_id(),
                 ),
             },
-            message
+            message,
+            25,
         )
 
     def test_receive_response_message(self, mock_core):
@@ -92,6 +94,7 @@ class TestClientTransport(unittest.TestCase):
                 client_id=transport.client_id,
                 thread_id=get_hex_thread_id(),
             ),
+            None,
         )
 
     def test_receive_response_message_another_service(self, mock_core):
@@ -104,7 +107,7 @@ class TestClientTransport(unittest.TestCase):
 
         mock_core.return_value.receive_message.return_value = request_id, meta, message
 
-        response = transport.receive_response_message()
+        response = transport.receive_response_message(15)
 
         self.assertEqual(request_id, response[0])
         self.assertEqual(meta, response[1])
@@ -115,6 +118,7 @@ class TestClientTransport(unittest.TestCase):
                 client_id=transport.client_id,
                 thread_id=get_hex_thread_id(),
             ),
+            15,
         )
 
     def test_requests_outstanding(self, mock_core):

--- a/tests/server/action/test_status.py
+++ b/tests/server/action/test_status.py
@@ -41,18 +41,8 @@ class _ComplexStatusAction(BaseStatusAction):
 
 class TestBaseStatusAction(unittest.TestCase):
     def test_cannot_instantiate_base_action(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             BaseStatusAction()
-
-    def test_build_implemented_version_not_implemented(self):
-        class _Action(BaseStatusAction):
-            pass
-
-        action = _Action()
-        self.assertIsNone(action._build)
-
-        with self.assertRaises(NotImplementedError):
-            print(action._version)
 
     def test_basic_status_works(self):
         action_request = EnrichedActionRequest(action='status', body={}, switches=None)


### PR DESCRIPTION
This adds support for setting a custom timeout when sending a request, so that users can shorten or lengthen the time the client will block waiting for a response. As part of this major refactor, we add proper `ABCMeta` to several class hierarchies.