### PR TITLE
[MAJOR] Support sending multiple requests to execute in parallel

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,12 +1,12 @@
+The PySOA API
+=============
+
+Services in ``pysoa`` are built around a client-server model with a simple service API. The core abstractions of this
+API are Jobs and Actions. An Action is a unit of work performed by a Server, and a Job is a container of Actions.
+
 .. contents:: Contents
    :depth: 3
    :backlinks: none
-
-
-Core concepts
--------------
-
-Services in ``pysoa`` are built around a client-server model with a simple service API. The core abstractions of this API are Jobs and Actions. An Action is a unit of work performed by a Server, and a Job is a container of Actions.
 
 
 Basic request flow
@@ -74,7 +74,7 @@ Error
 
 
 Servers
--------
++++++++
 
 
 The ``server`` module contains everything necessary to write a ``pysoa`` service. The ``Action`` class provides the parent class for your service's Actions, which are the main units of business logic, while ``Server`` class provides the framework for running a request-response loop.
@@ -87,7 +87,7 @@ The ``Action`` class provides an interface allowing subclasses to easily validat
 
 
 ``Server``
-++++++++++
+**********
 
 Properties:
 
@@ -102,7 +102,7 @@ Methods:
 
 
 ``Action``
-++++++++++
+**********
 
 Properties:
 
@@ -116,7 +116,7 @@ Methods:
 
 
 Server configuration
-++++++++++++++++++++
+********************
 
 The ``Server`` base class takes configuration in the form of a dict with the following format::
 
@@ -142,13 +142,13 @@ Key:
 
 
 Django integration
-++++++++++++++++++
+******************
 
 The ``Server`` class is able to get configuration from Django settings automatically. If the ``use_django`` property on the ``Server`` subclass is ``True``, the ``main`` method will automatically import the Django settings module and look for configuration under the name ``SOA_SERVER_SETTINGS``.
 
 
 Versioning using switches
-+++++++++++++++++++++++++
+*************************
 
 Switches are like a special argument that every action in a job gets. In terms of code, switches are simply integers passed by the Client in the control header of every ``JobRequest``, and then by the Server into every action in that job.
 
@@ -172,7 +172,7 @@ Switches came from a need to version individual service actions, rather than ver
 
 
 Clients
--------
++++++++
 
 Code that needs to call one or more services will do so using a ``Client``. A single ``Client`` can be configured to call any number of services.
 
@@ -180,13 +180,13 @@ The ``client`` submodule provides the ``Client`` class as well as base classes f
 
 
 ``Client``
-++++++++++
+**********
 
 Methods:
 
 - ``__init__`` - Args:
 
-  + ``config``: Configuration dict (see `Configuring Servers and Clients`_).
+  + ``config``: Configuration dict (see `Client configuration`_).
   + ``expansions`` (optional): A mapping of service name to expansion (see `Expansions`_).
   + ``settings_class`` (optional): A ``Settings`` subclass to use for configuration validation. Defaults to the class's ``settings_class`` property.
   + ``context``: A dict of context information that will be included in the ``JobRequest.context`` on every request.
@@ -215,7 +215,7 @@ Methods:
 
 
 Client configuration
-++++++++++++++++++++
+********************
 
 The ``Client`` class takes configuration in the form of a dict with the following format::
 
@@ -242,7 +242,7 @@ recommended, as connections will be re-established for every client without it.
 
 
 Expansions
-++++++++++
+**********
 
 Expansions allow ``Client.call_actions`` to automatically "expand" fields in a service response by making further service calls and adding those responses to the original response.
 
@@ -252,7 +252,7 @@ The ``Client.call_actions`` and ``Client.call_action`` methods take a keyword ar
 
 
 Configuring expansions
-**********************
+----------------------
 
 Expansions are configured on the ``Client`` instance by using the ``expansions`` argument on initialization. This argument accepts a dict with the following format::
 
@@ -311,7 +311,7 @@ Type expansions detail the expansions that are supported for each type. If a ``C
 
 
 Expansions example
-******************
+------------------
 
 Consider a ``Client`` with the following expansions config::
 
@@ -406,7 +406,7 @@ The ``bar_example`` response is added to the original response from the ``foo_ex
     
 
 Client exceptions
-+++++++++++++++++
+*****************
 
 - ``ImproperlyConfigured``: The ``Client`` tried to call a service for which it did not have configuration.
 
@@ -417,12 +417,12 @@ Client exceptions
 
 
 Serialization
--------------
++++++++++++++
 
 The ``Serializer`` class allows Clients and Servers to communicate using a common format. This library provides serializer classes for the JSON and msgpack formats, and the base ``Serializer`` class can be extended to use any format that a developer may wish to use. The ``Serializer`` interface is simple:
 
 ``Serializer``
-++++++++++++++
+**************
 
 Properties:
 
@@ -436,11 +436,11 @@ Methods:
 
 
 Provided serializers
-++++++++++++++++++++
+********************
 
 
 MessagePack Serializer
-**********************
+----------------------
 
 - Backend: `msgpack-python <https://pypi.python.org/pypi/msgpack-python>`_
 - Types supported: ``int``, ``str``, ``dict``, ``list``, ``tuple``, ``bytes`` (Python 3 only), ``date``, ``time``, ``datetime``, and ``currint.Amount``
@@ -448,7 +448,7 @@ MessagePack Serializer
 
 
 JSON Serializer
-***************
+---------------
 
 - Backend: `json <https://docs.python.org/2/library/json.html>`_
 - Types supported: ``int``, ``str``, ``dict``, ``list``, ``tuple``
@@ -456,7 +456,7 @@ JSON Serializer
 
 
 Serializer configuration
-++++++++++++++++++++++++
+************************
 
 The config schema for ``Serializer`` objects is just the basic ``pysoa`` plugin schema::
 
@@ -467,7 +467,7 @@ The config schema for ``Serializer`` objects is just the basic ``pysoa`` plugin 
 
 
 Serializer exceptions
-+++++++++++++++++++++
+*********************
 
 - ``InvalidField``: Raised when the serializer fails to serialize a message. Contains the arguments from the original exception raised by the serialization backend's encoding function.
 
@@ -476,12 +476,12 @@ Serializer exceptions
 
 
 Transport
----------
++++++++++
 
 The ``transport`` module provides an interface for sending messages between clients and servers. There are two base classes:
 
 ``ClientTransport``
-+++++++++++++++++++
+*******************
 
 Methods:
 
@@ -499,7 +499,7 @@ Methods:
 
 
 ``ServerTransport``
-+++++++++++++++++++
+*******************
 
 Methods:
 
@@ -517,7 +517,7 @@ Methods:
 
 
 Transport configuration
-+++++++++++++++++++++++
+***********************
 
 The config schema for ``Transport`` classes is the same as for other ``pysoa`` plugins::
 
@@ -528,7 +528,7 @@ The config schema for ``Transport`` classes is the same as for other ``pysoa`` p
 
 
 Transport exceptions
-++++++++++++++++++++
+********************
 
 - ``InvalidMessageError``: The transport tried to send or receive a message that was malformed.
 - ``MessageTooLarge``: The message passed to the transport exceeded the maximum size allowed by the transport.
@@ -540,21 +540,21 @@ Transport exceptions
 
 
 Redis Gateway Transport
-+++++++++++++++++++++++
+***********************
 
 The ``transport.redis_gateway`` module provides a transport implementation that uses Redis (in simple or Sentinel mode)
 for sending and receiving messages. This is the recommended transport for use with ``pysoa``, as it provides a
 convenient and performant backend for asynchronous service requests.
 
 Standard and Sentinel modes
-***************************
+---------------------------
 
 The Redis Gateway transport has two primary modes of operation: in "standard" mode, the channel layer will connect to a
 specified list of Redis hosts, while in "Sentinel" mode, the channel layer will connect to a list of Sentinel hosts and
 use Sentinel to find its Redis hosts.
 
 Configuration
-*************
+-------------
 
 The Redis Gateway transport takes the following extra keyword arguments for configuration:
 
@@ -586,13 +586,13 @@ The Redis Gateway transport takes the following extra keyword arguments for conf
 
 
 Middleware
-----------
+++++++++++
 
 Middleware for both ``Server`` and ``Client`` uses an onion calling pattern, where each middleware accepts a callable and returns a callable. Each middleware in the stack is called with the middleware below it, and the base level middleware is called with a base processing method from the ``Server`` or ``Client``.
 
 
 ``ServerMiddleware``
-++++++++++++++++++++
+********************
 
 The ``ServerMiddleware`` class has an interface that allows it to act at a Job level or at an Action level, or both, depending on which part(s) of the interface it implements:
 
@@ -604,7 +604,7 @@ Methods:
 
 
 ``ClientMiddleware``
-++++++++++++++++++++
+********************
 
 Client middleware works similarly to server middleware, using an onion calling pattern. Client middleware is built around the client request/response workflow. The ``ClientMiddleware`` class has two methods, ``request`` and ``response``, each of which wraps a callable that does the work of sending or receiving, respectively.
 
@@ -614,7 +614,7 @@ Client middleware works similarly to server middleware, using an onion calling p
 
 
 Middleware configuration
-++++++++++++++++++++++++
+************************
 
 ``Middleware`` classes are configured using the standard ``pysoa`` plugin schema::
 
@@ -625,14 +625,14 @@ Middleware configuration
 
 
 Metrics
--------
++++++++
 PySOA is capable of recording detailed metrics about the performance of its client and server transports and sending
 and receiving processes. If you wish to gather metrics about the performance of PySOA, you will need to enable this
 metrics recording in your server settings and/or in your client settings and provide an object which PySOA can use to
 record these metrics.
 
 ``MetricsRecorder``
-+++++++++++++++++++
+*******************
 
 Metrics in PySOA are recorded with an implementation of the ``MetricsRecorder`` abstract class. By default, PySOA ships
 with and uses a ``NoOpMetricsRecorder`` that performs no action recorder of metrics. In order to record metrics in your
@@ -641,7 +641,7 @@ record counters and timers. The documentation for ``Counter``, ``Timer``, and ``
 ``pysoa/common/metrics.py`` details how to implement these classes.
 
 Metrics configuration
-+++++++++++++++++++++
+*********************
 
 Metrics are configured using the standard ``pysoa`` plugin schema::
 
@@ -655,7 +655,7 @@ are recorded`_ below). We recommend your ``MetricsRecorder`` append some type of
 it so that you can group all PySOA metrics together.
 
 Which metrics are recorded
-++++++++++++++++++++++++++
+**************************
 
 These are all the metrics recorded in PySOA:
 
@@ -719,7 +719,7 @@ These are all the metrics recorded in PySOA:
 
 
 Customizing configuration
--------------------------
++++++++++++++++++++++++++
 
 The ``settings`` module provides classes that contain and validate settings for Clients and Servers. It has three primary functions: schema validation, defaults and import resolution.
 
@@ -788,7 +788,7 @@ The ``settings`` module provides classes that contain and validate settings for 
 
 
 Included ``Settings`` subclasses
-++++++++++++++++++++++++++++++++
+********************************
 
 ``pysoa.common.settings.SOASettings`` provides a schema that is shared by both Servers and Clients. It's schema:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+PySOA Documentation
+===================
+
+This directory and its contents contains the entire PySOA documentation. In it, you'll find details about the PySOA
+API, creating clients and servers, and testing PySOA servers and service-calling code.
+
+Contents
+--------
+
+- `The PySOA API <api.rst>`_
+- `Creating PySOA Servers <servers.rst>`_ *(coming soon)*
+- `Calling PySOA Services <clients.rst>`_ *(coming soon)*
+- `Testing with PySOA <testing.rst>`_

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,14 +1,13 @@
-.. contents:: Contents
-   :depth: 3
-   :backlinks: none
-
-
 Testing with PySOA
-------------------
+==================
 
 PySOA comes with several facilities for testing—both for testing services themselves and for testing code that interacts
 with PySOA services. This document describes these libraries and techniques. As always, all strings in the examples
 are unicode strings (the default in Python 3; use ``from __future__ import unicode_literals`` for Python 2).
+
+.. contents:: Contents
+   :depth: 3
+   :backlinks: none
 
 
 Using the ``ServerTestCase``

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,11 @@ from setuptools import setup, find_packages
 from pysoa import __version__
 
 
+def readme():
+    with open('README.rst') as f:
+        return f.read()
+
+
 install_requires = [
     'enum34;python_version<"3.4"',
     'six~=1.10',
@@ -31,13 +36,7 @@ setup(
     author='Eventbrite, Inc.',
     author_email='opensource@eventbrite.com',
     description='A Python library for writing (micro)services and their clients',
-    long_description=(
-        'A general-purpose library for writing Python (micro)services and their '
-        'clients, based on an RPC (remote procedure call) calling style. '
-        'Provides both a client and a server, which can be used directly by '
-        'themselves or, extended with extra functionality using middleware. '
-        'For more, see https://github.com/eventbrite/pysoa'
-    ),
+    long_description=readme(),
     url='http://github.com/eventbrite/pysoa',
     packages=list(map(str, find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']))),
     include_package_data=True,

--- a/tests/client/test_expansions.py
+++ b/tests/client/test_expansions.py
@@ -252,6 +252,108 @@ class TestClientWithExpansions(TestCase):
             expected_car_response,
         )
 
+    def test_call_actions_parallel_with_expansions(self):
+        expected_book_response = {
+            'book_obj': {
+                '_type': 'book_type',
+                'id': 1,
+                'author_id': 2,
+                'publish_id': 3,
+                'author_profile': {
+                    '_type': 'author_type',
+                    'id': 2,
+                    'stuff': 'things',
+                },
+                'publisher_profile': {
+                    '_type': 'publisher_type',
+                    'id': 3,
+                    'address_id': 4,
+                    'address_profile': {
+                        '_type': 'address_type',
+                        'id': 4,
+                    },
+                },
+            },
+        }
+        expected_car_response = {
+            'car_obj': {
+                '_type': 'car_type',
+                'id': 5,
+                'automaker_id': 6,
+                'automaker_profile': {
+                    '_type': 'auto_type',
+                    'id': 6,
+                },
+            },
+        }
+
+        actions = self.client.call_actions_parallel(
+            service_name='book_info_service',
+            actions=[
+                {'action': 'get_book', 'body': {'id': 1}},
+                {'action': 'get_car', 'body': {'id': 5}},
+            ],
+            expansions={
+                'book_type': ['author_rule', 'publisher_rule.address_rule'],
+                'car_type': ['automaker_rule'],
+            },
+        )
+
+        actions = list(actions)
+        self.assertEqual(2, len(actions))
+        self.assertEqual(expected_book_response, actions[0].body)
+        self.assertEqual(expected_car_response, actions[1].body)
+
+    def test_call_jobs_parallel_with_expansions(self):
+        expected_book_response = {
+            'book_obj': {
+                '_type': 'book_type',
+                'id': 1,
+                'author_id': 2,
+                'publish_id': 3,
+                'author_profile': {
+                    '_type': 'author_type',
+                    'id': 2,
+                    'stuff': 'things',
+                },
+                'publisher_profile': {
+                    '_type': 'publisher_type',
+                    'id': 3,
+                    'address_id': 4,
+                    'address_profile': {
+                        '_type': 'address_type',
+                        'id': 4,
+                    },
+                },
+            },
+        }
+        expected_car_response = {
+            'car_obj': {
+                '_type': 'car_type',
+                'id': 5,
+                'automaker_id': 6,
+                'automaker_profile': {
+                    '_type': 'auto_type',
+                    'id': 6,
+                },
+            },
+        }
+
+        job_responses = self.client.call_jobs_parallel(
+            jobs=[
+                {'service_name': 'book_info_service', 'actions': [{'action': 'get_book', 'body': {'id': 1}}]},
+                {'service_name': 'book_info_service', 'actions': [{'action': 'get_car', 'body': {'id': 5}}]},
+            ],
+            expansions={
+                'book_type': ['author_rule', 'publisher_rule.address_rule'],
+                'car_type': ['automaker_rule'],
+            },
+        )
+
+        self.assertEqual(2, len(job_responses))
+        self.assertEqual(expected_book_response, job_responses[0].actions[0].body)
+        self.assertEqual(expected_car_response, job_responses[1].actions[0].body)
+
     def test_call_action_with_expansions(self):
         expected_response = {
             'book_obj': {

--- a/tests/client/test_send_receive.py
+++ b/tests/client/test_send_receive.py
@@ -6,6 +6,13 @@ from pysoa.common.constants import (
     ERROR_CODE_INVALID,
     ERROR_CODE_SERVER_ERROR,
 )
+from pysoa.common.transport.base import (
+    ClientTransport,
+)
+from pysoa.common.transport.exceptions import (
+    MessageReceiveError,
+    MessageSendError,
+)
 from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
@@ -13,6 +20,7 @@ from pysoa.common.types import (
     Error,
 )
 from pysoa.server.errors import JobError
+from pysoa.server.server import Server
 
 import mock
 from unittest import TestCase
@@ -106,6 +114,33 @@ class CatchExceptionOnResponseMiddleware(ClientMiddleware):
         return handler
 
 
+class ErrorServer(Server):
+    service_name = 'error_service'
+
+    # noinspection PyTypeChecker
+    action_class_map = {
+        'job_error': lambda *_, **__: (_ for _ in ()).throw(
+            JobError(errors=[Error(code='BAD_JOB', message='You are a bad job')])
+        ),
+    }
+
+
+class SendErrorTransport(ClientTransport):
+    def send_request_message(self, request_id, meta, body, message_expiry_in_seconds=None):
+        raise MessageSendError('The message failed to send')
+
+    def receive_response_message(self, receive_timeout_in_seconds=None):
+        raise AssertionError('Something weird happened; receive should not have been called')
+
+
+class ReceiveErrorTransport(ClientTransport):
+    def send_request_message(self, request_id, meta, body, message_expiry_in_seconds=None):
+        pass  # We want this to silently do nothing
+
+    def receive_response_message(self, receive_timeout_in_seconds=None):
+        raise MessageReceiveError('Could not receive a message')
+
+
 class TestClientSendReceive(TestCase):
     """
     Test that the client send/receive methods return the correct types with the action responses
@@ -181,7 +216,7 @@ class TestClientSendReceive(TestCase):
         client = Client(self.client_settings)
 
         for actions in (action_request, [ActionRequest(**a) for a in action_request]):
-            response = client.call_actions(SERVICE_NAME, actions)
+            response = client.call_actions(SERVICE_NAME, actions, timeout=2)
             self.assertTrue(isinstance(response, JobResponse))
             self.assertTrue(all([isinstance(a, ActionResponse) for a in response.actions]))
             self.assertEqual(len(response.actions), 2)
@@ -293,6 +328,312 @@ class TestClientSendReceive(TestCase):
         self.assertTrue(isinstance(response, ActionResponse))
         self.assertEqual(response.action, 'action_1')
         self.assertEqual(response.body['foo'], 'bar')
+
+
+class TestClientParallelSendReceive(TestCase):
+    """
+    Test that the client parallel send/receive methods work as expected.
+    """
+    def setUp(self):
+        self.client = Client({
+            'service_1': {
+                'transport': {
+                    'path': 'pysoa.test.stub_service:StubClientTransport',
+                    'kwargs': {
+                        'action_map': {
+                            'action_1': {'body': {'foo': 'bar'}},
+                            'action_2': {'body': {'baz': 3}},
+                        },
+                    },
+                },
+            },
+            'service_2': {
+                'transport': {
+                    'path': 'pysoa.test.stub_service:StubClientTransport',
+                    'kwargs': {
+                        'action_map': {
+                            'action_3': {'body': {'cat': 'dog'}},
+                            'action_4': {'body': {'selected': True, 'count': 7}},
+                            'action_with_errors': {
+                                'errors': [Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo')],
+                            },
+                        },
+                    },
+                },
+            },
+            'error_service': {
+                'transport': {
+                    'path': 'pysoa.common.transport.local:LocalClientTransport',
+                    'kwargs': {
+                        'server_class': ErrorServer,
+                        'server_settings': {},
+                    },
+                },
+            },
+            'send_error_service': {
+                'transport': {
+                    'path': 'tests.client.test_send_receive:SendErrorTransport',
+                }
+            },
+            'receive_error_service': {
+                'transport': {
+                    'path': 'tests.client.test_send_receive:ReceiveErrorTransport',
+                }
+            },
+        })
+
+    def test_call_actions_parallel(self):
+        """
+        Test that call_actions_parallel works to call multiple actions run parallel on a single service.
+        """
+        action_responses = self.client.call_actions_parallel(
+            'service_1',
+            [ActionRequest(action='action_1'), ActionRequest(action='action_2'), ActionRequest(action='action_1')],
+        )
+
+        self.assertIsNotNone(action_responses)
+
+        action_responses = list(action_responses)
+        self.assertEqual(3, len(action_responses))
+        self.assertEqual({'foo': 'bar'}, action_responses[0].body)
+        self.assertEqual({'baz': 3}, action_responses[1].body)
+        self.assertEqual({'foo': 'bar'}, action_responses[2].body)
+
+    def test_call_actions_parallel_with_extras(self):
+        """
+        Test that call_actions_parallel works to call multiple actions run parallel on a single service using extra
+        kwargs to more finely control behavior.
+        """
+        action_responses = self.client.call_actions_parallel(
+            'service_2',
+            [
+                ActionRequest(action='action_3'),
+                ActionRequest(action='action_with_errors'),
+                ActionRequest(action='action_4'),
+            ],
+            timeout=2,
+            raise_action_errors=False,
+            continue_on_error=True,
+        )
+
+        self.assertIsNotNone(action_responses)
+
+        action_responses = list(action_responses)
+        self.assertEqual(3, len(action_responses))
+        self.assertEqual({'cat': 'dog'}, action_responses[0].body)
+        self.assertEqual({}, action_responses[1].body)
+        self.assertEqual(
+            [Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo')],
+            action_responses[1].errors,
+        )
+        self.assertEqual({'selected': True, 'count': 7}, action_responses[2].body)
+
+    def test_call_actions_parallel_with_prohibited_arguments(self):
+        """
+        Test that call_actions_parallel doesn't permit raise_job_errors or catch_transport_error arguments
+        """
+        with self.assertRaises(TypeError):
+            self.client.call_actions_parallel(
+                'service_2',
+                [ActionRequest(action='action_3')],
+                raise_job_errors=False,
+            )
+
+        with self.assertRaises(TypeError):
+            self.client.call_actions_parallel(
+                'service_2',
+                [ActionRequest(action='action_3')],
+                catch_transport_errors=False,
+            )
+
+    def test_call_actions_parallel_action_errors_raised(self):
+        """
+        Test that call_actions_parallel raises action errors when they occur
+        """
+        with self.assertRaises(self.client.CallActionError) as error_context:
+            self.client.call_actions_parallel(
+                'service_2',
+                [
+                    ActionRequest(action='action_3'),
+                    ActionRequest(action='action_with_errors'),
+                ],
+            )
+
+        self.assertEqual(
+            [Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo')],
+            error_context.exception.actions[0].errors,
+        )
+
+    def test_call_actions_parallel_job_errors_raised(self):
+        """
+        Test that call_actions_parallel raises job errors when they occur
+        """
+        with self.assertRaises(self.client.JobError) as error_context:
+            self.client.call_actions_parallel('error_service', [{'action': 'job_error'}])
+
+        self.assertEqual([Error(code='BAD_JOB', message='You are a bad job')], error_context.exception.errors)
+
+    def test_call_actions_parallel_transport_send_errors_raised(self):
+        """
+        Test that call_actions_parallel raises transport send errors when they occur
+        """
+        with self.assertRaises(MessageSendError) as error_context:
+            self.client.call_actions_parallel('send_error_service', [{'action': 'does_not_matter'}])
+
+        self.assertEqual('The message failed to send', error_context.exception.args[0])
+
+    def test_call_actions_parallel_transport_receive_errors_raised(self):
+        """
+        Test that call_actions_parallel raises transport receive errors when they occur
+        """
+        with self.assertRaises(MessageReceiveError) as error_context:
+            self.client.call_actions_parallel('receive_error_service', [{'action': 'does_not_matter'}])
+
+        self.assertEqual('Could not receive a message', error_context.exception.args[0])
+
+    def test_call_jobs_parallel_simple(self):
+        """
+        Test that call_jobs_parallel works properly under fairly simple circumstances (no errors).
+        """
+        job_responses = self.client.call_jobs_parallel(
+            [
+                {'service_name': 'service_1', 'actions': [{'action': 'action_2'}, {'action': 'action_1'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_4'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_3'}]},
+            ],
+        )
+
+        self.assertIsNotNone(job_responses)
+
+        self.assertEqual(3, len(job_responses))
+        self.assertEqual(2, len(job_responses[0].actions))
+        self.assertEqual({'baz': 3}, job_responses[0].actions[0].body)
+        self.assertEqual({'foo': 'bar'}, job_responses[0].actions[1].body)
+        self.assertEqual(1, len(job_responses[1].actions))
+        self.assertEqual({'selected': True, 'count': 7}, job_responses[1].actions[0].body)
+        self.assertEqual(1, len(job_responses[2].actions))
+        self.assertEqual({'cat': 'dog'}, job_responses[2].actions[0].body)
+
+    def test_call_jobs_parallel_job_errors_not_raised(self):
+        """
+        Test that call_jobs_parallel returns job errors instead of raising them when asked.
+        """
+        job_responses = self.client.call_jobs_parallel(
+            [
+                {'service_name': 'service_1', 'actions': [{'action': 'action_1'}, {'action': 'action_2'}]},
+                {'service_name': 'error_service', 'actions': [{'action': 'job_error'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_3'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_4'}]},
+            ],
+            raise_job_errors=False,
+        )
+
+        self.assertIsNotNone(job_responses)
+
+        self.assertEqual(4, len(job_responses))
+        self.assertEqual(2, len(job_responses[0].actions))
+        self.assertEqual({'foo': 'bar'}, job_responses[0].actions[0].body)
+        self.assertEqual({'baz': 3}, job_responses[0].actions[1].body)
+        self.assertEqual(0, len(job_responses[1].actions))
+        self.assertEqual([Error(code='BAD_JOB', message='You are a bad job')], job_responses[1].errors)
+        self.assertEqual(1, len(job_responses[2].actions))
+        self.assertEqual({'cat': 'dog'}, job_responses[2].actions[0].body)
+        self.assertEqual(1, len(job_responses[3].actions))
+        self.assertEqual({'selected': True, 'count': 7}, job_responses[3].actions[0].body)
+
+    def test_call_jobs_parallel_transport_send_errors_caught(self):
+        """
+        Test that call_jobs_parallel returns transport send errors instead of raising them when asked.
+        """
+        job_responses = self.client.call_jobs_parallel(
+            [
+                {'service_name': 'service_1', 'actions': [{'action': 'action_1'}, {'action': 'action_2'}]},
+                {'service_name': 'send_error_service', 'actions': [{'action': 'no matter'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_3'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_4'}]},
+            ],
+            catch_transport_errors=True,
+        )
+
+        self.assertIsNotNone(job_responses)
+
+        self.assertEqual(4, len(job_responses))
+        self.assertEqual(2, len(job_responses[0].actions))
+        self.assertEqual({'foo': 'bar'}, job_responses[0].actions[0].body)
+        self.assertEqual({'baz': 3}, job_responses[0].actions[1].body)
+        self.assertIsInstance(job_responses[1], MessageSendError)
+        self.assertEqual('The message failed to send', job_responses[1].args[0])
+        self.assertEqual(1, len(job_responses[2].actions))
+        self.assertEqual({'cat': 'dog'}, job_responses[2].actions[0].body)
+        self.assertEqual(1, len(job_responses[3].actions))
+        self.assertEqual({'selected': True, 'count': 7}, job_responses[3].actions[0].body)
+
+    def test_call_jobs_parallel_transport_receive_errors_caught(self):
+        """
+        Test that call_jobs_parallel returns transport send errors instead of raising them when asked.
+        """
+        job_responses = self.client.call_jobs_parallel(
+            [
+                {'service_name': 'service_1', 'actions': [{'action': 'action_1'}, {'action': 'action_2'}]},
+                {'service_name': 'receive_error_service', 'actions': [{'action': 'no matter'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_3'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_4'}]},
+            ],
+            catch_transport_errors=True,
+        )
+
+        self.assertIsNotNone(job_responses)
+
+        self.assertEqual(4, len(job_responses))
+        self.assertEqual(2, len(job_responses[0].actions))
+        self.assertEqual({'foo': 'bar'}, job_responses[0].actions[0].body)
+        self.assertEqual({'baz': 3}, job_responses[0].actions[1].body)
+        self.assertIsInstance(job_responses[1], MessageReceiveError)
+        self.assertEqual('Could not receive a message', job_responses[1].args[0])
+        self.assertEqual(1, len(job_responses[2].actions))
+        self.assertEqual({'cat': 'dog'}, job_responses[2].actions[0].body)
+        self.assertEqual(1, len(job_responses[3].actions))
+        self.assertEqual({'selected': True, 'count': 7}, job_responses[3].actions[0].body)
+
+    def test_call_jobs_parallel_transport_multiple_send_and_receive_errors_caught(self):
+        """
+        Test that call_jobs_parallel returns transport send errors instead of raising them when asked.
+        """
+        job_responses = self.client.call_jobs_parallel(
+            [
+                {'service_name': 'service_1', 'actions': [{'action': 'action_1'}, {'action': 'action_2'}]},
+                {'service_name': 'send_error_service', 'actions': [{'action': 'no'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_3'}]},
+                {'service_name': 'send_error_service', 'actions': [{'action': 'no'}, {'action': 'no'}]},
+                {'service_name': 'receive_error_service', 'actions': [{'action': 'no'}]},
+                {'service_name': 'service_2', 'actions': [{'action': 'action_4'}]},
+                {'service_name': 'receive_error_service', 'actions': [{'action': 'no'}, {'action': 'no'}]},
+                {'service_name': 'receive_error_service', 'actions': [{'action': 'no'}]},
+                {'service_name': 'receive_error_service', 'actions': [{'action': 'no'}, {'action': 'no'}]},
+            ],
+            catch_transport_errors=True,
+        )
+
+        self.assertIsNotNone(job_responses)
+
+        self.assertEqual(9, len(job_responses))
+        self.assertEqual(2, len(job_responses[0].actions))
+        self.assertEqual({'foo': 'bar'}, job_responses[0].actions[0].body)
+        self.assertEqual({'baz': 3}, job_responses[0].actions[1].body)
+        self.assertIsInstance(job_responses[1], MessageSendError)
+        self.assertEqual('The message failed to send', job_responses[1].args[0])
+        self.assertEqual(1, len(job_responses[2].actions))
+        self.assertEqual({'cat': 'dog'}, job_responses[2].actions[0].body)
+        self.assertIsInstance(job_responses[3], MessageSendError)
+        self.assertEqual('The message failed to send', job_responses[3].args[0])
+        self.assertIsInstance(job_responses[4], MessageReceiveError)
+        self.assertEqual('Could not receive a message', job_responses[4].args[0])
+        self.assertEqual(1, len(job_responses[5].actions))
+        self.assertEqual({'selected': True, 'count': 7}, job_responses[5].actions[0].body)
+        self.assertIsInstance(job_responses[6], MessageReceiveError)
+        self.assertEqual('Could not receive a message', job_responses[6].args[0])
+        self.assertIsInstance(job_responses[7], MessageReceiveError)
+        self.assertEqual('Could not receive a message', job_responses[7].args[0])
 
 
 class TestClientMiddleware(TestCase):

--- a/tests/server/action/test_status.py
+++ b/tests/server/action/test_status.py
@@ -200,7 +200,6 @@ class TestBaseStatusAction(unittest.TestCase):
             'bar': {},
             'baz': {},
             'qux': {},
-            'fred': {},
         })
 
         action_request = EnrichedActionRequest(action='status', body={}, switches=None, client=client)
@@ -240,15 +239,7 @@ class TestBaseStatusAction(unittest.TestCase):
             ('QUX_TRANSPORT_ERROR', 'Timeout calling qux'),
             response.body['healthcheck']['errors'],
         )
-        fred_unknown_error_found = False
-        for error in response.body['healthcheck']['errors']:
-            if error[0] == 'FRED_UNKNOWN_ERROR':
-                fred_unknown_error_found = True
-        self.assertTrue(
-            fred_unknown_error_found,
-            'FRED_UNKNOWN_ERROR not found in %s' % (response.body['healthcheck']['errors'], ),
-        )
-        self.assertEqual(4, len(response.body['healthcheck']['errors']))
+        self.assertEqual(3, len(response.body['healthcheck']['errors']))
         self.assertEqual(
             {
                 'services': {


### PR DESCRIPTION
The PySOA communication protocol had innate support for parallel requests, but the client itself only supported serial requests. This large improvement commit does the following:
    
- Adds new methods to the client to support sending multiple requests to execute in parallel and then collect and return all responses blocking.
- Improves `stub_service` so that it works with these new methods.
- Writes extensive tests for parallel requests.
- Improves `BaseStatusAction` to do service client status checks in parallel.
- Improves the documentation to include information about parallel requests.
- Fixes some documentation that wasn't parsing properly in the GitHub viewer.