### PR TITLE
[MAJOR] Fix several expansion bugs and refactor configuration

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -290,8 +290,9 @@ To satisfy an expansion, the expansion processing code needs to know which servi
         <type>: {
             <expansion name>: {
                 "type": <expansion type>,
+                "route": <expansion route>,
                 "source_field": <source field name>,
-                "dest_field": <destination field name>,
+                "destination_field": <destination field name>,
                 "raise_action_errors": <bool>,
             },
             ...
@@ -303,7 +304,8 @@ Key:
 
 - ``<type>``: A type for which you are defining expansions.
 - ``<expansion name>``: The name of an expansion.
-- ``<expansion type>``: The type of the expansion. This is used to look up the appropriate expansion route in the Type Route Configuration.
+- ``<expansion type>``: The type of the expansion. This is used to look up the type for nested expansions.
+- ``<expansion route>``: The route to the expansion. This is used to look up the appropriate expansion route in the Type Route Configuration.
 - ``<source field name>``: The name of the field on an object of type ``<type>`` that contains the value of the expansion identifier.
 - ``<destination field name>``: The name of the field on an object of type ``<type>`` that will be filled with the expanded value.
 
@@ -317,7 +319,7 @@ Consider a ``Client`` with the following expansions config::
 
     {
         "type_routes": {
-            "bar": {
+            "bar_route": {
                 "service": "bar_example",
                 "action": "get_bar",
                 "request_field": "id",
@@ -328,8 +330,9 @@ Consider a ``Client`` with the following expansions config::
             "foo": {
                 "bar": {
                     "type": "bar",
+                    "route": "bar_route",
                     "source_field": "bar_id",
-                    "dest_field": "bar",
+                    "destination_field": "bar",
                 },
             },
         },
@@ -390,7 +393,7 @@ The ``bar_example`` service returns the following response::
         },
     }
 
-The ``bar_example`` response is added to the original response from the ``foo_example`` service, replacing the ``bar_id`` field (``source_field``) with the ``bar`` field  (``dest_field``). The final response body looks like::
+The ``bar_example`` response is added to the original response from the ``foo_example`` service, replacing the ``bar_id`` field (``source_field``) with the ``bar`` field  (``destination_field``). The final response body looks like::
 
     {
         "foo": {

--- a/pysoa/client/expander.py
+++ b/pysoa/client/expander.py
@@ -1,38 +1,32 @@
-import six
+from __future__ import absolute_import, unicode_literals
 
-from pysoa.common.types import Error
+import six
 
 
 class TypeNode(object):
     """
     Represents a type node for an expansion tree.
     """
-    def __init__(self, type):
+
+    def __init__(self, node_type):
         """
         Create a new TypeNode instance.
 
-        Args:
-            type (str): a type.
-
-        Returns:
-            A TypeNode instance.
+        :param node_type: The node type name
+        :type node_type: union[str, unicode]
         """
-        self.type = type
+        self.type = node_type
         self._expansions = {}
 
     def add_expansion(self, expansion_node):
         """
         Add a child expansion node to the type node's expansions.
 
-        If an expansion node with the same name is already present in type
-        node's expansions, the new and existing expansion node's children
-        are merged.
+        If an expansion node with the same name is already present in type node's expansions, the new and existing
+        expansion node's children are merged.
 
-        Args:
-            expansion_node: an ExpansionNode instance.
-
-        Returns:
-            None
+        :param expansion_node: The expansion node to add
+        :type expansion_node: ExpansionNode
         """
         # Check for existing expansion node with the same name
         existing_expansion_node = self.get_expansion(expansion_node.name)
@@ -48,11 +42,11 @@ class TypeNode(object):
         """
         Get an expansion node by name.
 
-        Args:
-            expansion_name (str): name of the expansion.
+        :param expansion_name: The name of the expansion
+        :type expansion_name: union[str, unicode]
 
-        Returns:
-            An ExpansionNode instance if the expansion exists, None otherwise.
+        :return: an `ExpansionNode` instance if the expansion exists, None otherwise.
+        :rtype: union[ExpansionNode, NoneType]
         """
 
         return self._expansions.get(expansion_name)
@@ -61,28 +55,29 @@ class TypeNode(object):
         """
         Find all objects in obj that match the type of the type node.
 
-        Args:
-            obj: a dictionary or list instance to search.
+        :param obj: A dictionary or list of dictionaries to search, recursively
+        :type obj: union[dict, list[dict]]
 
-        Returns:
-            A list of dictionary objects that have a "_type" key value that
-            matches the type of the type node.
+        :return: a list of dictionary objects that have a "_type" key value that matches the type of this node.
+        :rtype: list[dict]
         """
         objects = []
+
         if isinstance(obj, dict):
             # obj is a dictionary, so it is a potential match...
-            obj_type = obj.get('_type')
-            if obj_type == self.type:
+            object_type = obj.get('_type')
+            if object_type == self.type:
                 # Found a match!
                 objects.append(obj)
-            elif obj_type is None:
+            else:
                 # Not a match. Check each value of the dictionary for matches.
-                for sub_obj in six.itervalues(obj):
-                    objects.extend(self.find_objects(sub_obj))
+                for sub_object in six.itervalues(obj):
+                    objects.extend(self.find_objects(sub_object))
         elif isinstance(obj, list):
             # obj is a list. Check each element of the list for matches.
-            for sub_obj in obj:
-                objects.extend(self.find_objects(sub_obj))
+            for sub_object in obj:
+                objects.extend(self.find_objects(sub_object))
+
         return objects
 
     @property
@@ -96,13 +91,14 @@ class TypeNode(object):
         """
         Convert the tree node to its dictionary representation.
 
-        Returns:
-            An expansion dictionary that represents the type and expansions of
-            the tree node.
+        :return: an expansion dictionary that represents the type and expansions of this tree node.
+        :rtype dict[list[union[str, unicode]]]
         """
         expansion_strings = []
+
         for expansion in self.expansions:
             expansion_strings.extend(expansion.to_strings())
+
         return {
             self.type: expansion_strings,
         }
@@ -112,15 +108,15 @@ class ExpansionNode(TypeNode):
     """
     Represents a expansion node for an expansion tree.
 
-    If an expansion node has its own expansions, it can also function as a type
-    node.
+    If an expansion node has its own expansions, it can also function as a type node.
     """
+
     def __init__(
         self,
-        type,
+        node_type,
         name,
         source_field,
-        dest_field,
+        destination_field,
         service,
         action,
         request_field,
@@ -130,27 +126,30 @@ class ExpansionNode(TypeNode):
         """
         Create a new ExpansionNode instance.
 
-        Args:
-            type (str): a type.
-            name (str): name of the expansion.
-            source_field (str): a type's source field name for the expansion
-                identifier.
-            dest_field (str): a type's destination field name for the expansion
-                result.
-            service (str): name of the service that satisfies the expansion.
-            action (str): name of the action that satisfies the expansion.
-            request_field (str): field name for the expansion's ActionRequest body.
-            response_field (str): field name for the expansion's ActionResponse body.
-            raise_action_errors (bool): tells the Client not to raise an exception if the
-                expansion action returns an error response.
-
-        Returns:
-            An ExpansionNode instance.
+        :param node_type: The node type name
+        :type node_type: union[str, unicode]
+        :param name: The node name
+        :type name: union[str, unicode]
+        :param source_field: The type's source field name for the expansion identifier
+        :type source_field: union[str, unicode]
+        :param destination_field: The type's destination field name for the expansion result
+        :type destination_field: union[str, unicode]
+        :param service: The name of the service that satisfies the expansion
+        :type service: union[str, unicode]
+        :param action: The name of the service action that satisfies the expansion
+        :type action: union[str, unicode]
+        :param request_field: The name of the field for the expansion request's body
+        :type request_field: union[str, unicode]
+        :param response_field: The name of the field for the expansion response's body
+        :type response_field: union[str, unicode]
+        :param raise_action_errors: Tells the client whether to raise an exception if the expansion action returns an
+                                    error response (defaults to True)
+        :type raise_action_errors: True
         """
-        super(ExpansionNode, self).__init__(type)
+        super(ExpansionNode, self).__init__(node_type)
         self.name = name
         self.source_field = source_field
-        self.dest_field = dest_field
+        self.destination_field = destination_field
         self.service = service
         self.action = action
         self.request_field = request_field
@@ -161,47 +160,41 @@ class ExpansionNode(TypeNode):
         """
         Convert the expansion node to a list of expansion strings.
 
-        Returns:
-            A list of expansion strings that represent the leaf
-            nodes of the expansion tree.
+        :return: a list of expansion strings that represent the leaf nodes of the expansion tree.
+        :rtype: list[union[str, unicode]]
         """
         result = []
+
         if not self.expansions:
             result.append(self.name)
         else:
             for expansion in self.expansions:
-                result.extend(
-                    "{}.{}".format(self.name, es)
-                    for es in expansion.to_strings()
-                )
+                result.extend('{}.{}'.format(self.name, es) for es in expansion.to_strings())
+
         return result
 
 
 class ExpansionConverter(object):
     """
-    A utility class for converting the compact dictionary representation of
-    expansions to expansion trees (and back again).
+    A utility class for converting the compact dictionary representation of expansions to expansion trees (and back
+    again).
     """
+
     def __init__(self, type_routes, type_expansions):
         """
         Create an ExpansionConverter instance.
 
-        Args:
-            type_routes (dict): a type route configuration dictionary
-                (see below).
-            type_expansions (dict): a type expansions configuration dictionary
-                (see below).
-
-        Returns:
-            An ExpansionConverter instance.
+        :param type_routes: A type route configuration dictionary
+        :type type_routes: dict
+        :param type_expansions: A type expansions configuration dictionary
+        :type type_expansions: dict
 
         Type Routes:
-        To satisfy an expansion, the expansion processing code needs to know
-        which service action to call and how to call it. Type routes solve this
-        problem by by giving the expansion processing code all the information
-        it needs to properly call a service action to satisfy an expansion.
+        To satisfy an expansion, the expansion processing code needs to know which service action to call and how to
+        call it. Type routes solve this problem by by giving the expansion processing code all the information in needs
+        to properly call a service action to satisfy an expansion.
 
-        <type> is the type of the expansion.
+        <route> is the name of the expansion route, to be referenced from the type expansions configuration
         <service name> is the name of the service to call.
         <action name> is the name of the action to call.
         <request field> is the name of the field to use in the ActionRequest
@@ -210,9 +203,9 @@ class ExpansionConverter(object):
         <response field> is the name of the field returned in the
             ActionResponse body that contains the expansion object.
 
-        Type Route Configuration Format:
+        Type Routes Configuration Format:
         {
-            "<type>": {
+            "<route>": {
                 "service": "<service name>",
                 "action": "<action name>",
                 "request_field": "<request field name>",
@@ -222,27 +215,30 @@ class ExpansionConverter(object):
         }
 
         Type Expansions:
-        Type expansions detail the expansions that are supported for each type.
-        If a type wishes to support expansions, it must have a corresponding
-        entry in the Type Expansions Configuration dictionary.
+        Type expansions detail the expansions that are supported for each type and the routes to use to expand them. If
+        a type wishes to support expansions, it must have a corresponding entry in the Type Expansions Configuration
+        dictionary.
 
         <type> is a type for which you are defining expansions.
         <expansion name> is the name of an expansion.
-        <expansion type> is the type of the expansion. This is used to look up
-            the appropriate expansion route in the Type Route Configuration.
-        <source field name> is the name of the field on an object of type
-            <type> that contains the value of the expansion identifier.
-        <destination field name> is the name of the field on an object of type
-            <type> that will be filled with the expanded value.
+        <expansion type> is the type of the expansion. This is used to look up the type of the values returned by the
+            expansion in this Type Expansions Configuration dictionary for the purpose of processing nested/recursive
+            expansions.
+        <expansion route> is a reference to the route to use to process the expansion. This is used to look up the
+            appropriate expansion route in the Type Routes Configuration.
+        <source field name> is the name of the source field that contains the identifier for obtaining the expansion
+            object.
+        <destination field name> is the name of the destination field into which the expansion object will be placed.
 
         Type Expansions Configuration Format:
         {
             "<type>": {
                 "<expansion name>": {
                     "type": "<expansion type>",
+                    "route": "<expansion route>",
                     "source_field": "<source field name>",
-                    "dest_field": "<destination field name>",
-                    "raise_action_errors": <bool>
+                    "destination_field": "<destination field name>",
+                    "raise_action_errors": <bool>,
                 },
                 ...
             },
@@ -252,15 +248,15 @@ class ExpansionConverter(object):
         self.type_routes = type_routes
         self.type_expansions = type_expansions
 
-    def dict_to_trees(self, exp_dict):
+    def dict_to_trees(self, expansion_dict):
         """
         Convert an expansion dictionary to a list of expansion trees.
 
-        Args:
-            exp_dict (dict): an expansion dictionary (see below).
+        :param expansion_dict: An expansion dictionary (see below)
+        :type expansion_dict: dict
 
-        Returns:
-            A list of expansion trees (i.e. TreeNode instances).
+        :return: a list of expansion trees (`TreeNode` instances).
+        :rtype: list[TreeNode]
 
         Expansion Dictionary Format:
         {
@@ -270,31 +266,33 @@ class ExpansionConverter(object):
 
         <type> is the type of object to expand.
         <expansion string> is a string with the following format:
-            <expansion string> => <expansion name>.<expansion string> |
-                <expansion name>
+            <expansion string> => <expansion name>[.<expansion string>]
 
         """
         trees = []
-        for exp_type, exp_list in six.iteritems(exp_dict):
-            type_node = TypeNode(type=exp_type)
-            for exp_string in exp_list:
+        for node_type, expansion_list in six.iteritems(expansion_dict):
+            type_node = TypeNode(node_type=node_type)
+
+            for expansion_string in expansion_list:
                 expansion_node = type_node
-                for exp_name in exp_string.split('.'):
-                    child_expansion_node = expansion_node.get_expansion(exp_name)
+
+                for expansion_name in expansion_string.split('.'):
+                    child_expansion_node = expansion_node.get_expansion(expansion_name)
+
                     if not child_expansion_node:
-                        type_expansion = self.type_expansions[expansion_node.type][exp_name]
-                        type_route = self.type_routes[type_expansion['type']]
-                        if type_expansion['dest_field'] == type_expansion['source_field']:
-                            raise Error(
-                                'Expansion configuration dest_field error: '
-                                'dest_field can not have the same name as the source_field: '
+                        type_expansion = self.type_expansions[expansion_node.type][expansion_name]
+                        type_route = self.type_routes[type_expansion['route']]
+                        if type_expansion['destination_field'] == type_expansion['source_field']:
+                            raise ValueError(
+                                'Expansion configuration destination_field error: '
+                                'destination_field can not have the same name as the source_field: '
                                 '{}'.format(type_expansion['source_field'])
                             )
                         child_expansion_node = ExpansionNode(
-                            type=type_expansion['type'],
-                            name=exp_name,
+                            node_type=type_expansion['type'],
+                            name=expansion_name,
                             source_field=type_expansion['source_field'],
-                            dest_field=type_expansion['dest_field'],
+                            destination_field=type_expansion['destination_field'],
                             service=type_route['service'],
                             action=type_route['action'],
                             request_field=type_route['request_field'],
@@ -302,22 +300,27 @@ class ExpansionConverter(object):
                             raise_action_errors=type_expansion.get('raise_action_errors', False),
                         )
                         expansion_node.add_expansion(child_expansion_node)
+
                     expansion_node = child_expansion_node
+
             trees.append(type_node)
+
         return trees
 
-    def trees_to_dict(self, exp_trees):
+    @staticmethod
+    def trees_to_dict(trees_list):
         """
-        Convert a list of TreeNodes to an expansion dictionary.
+        Convert a list of `TreeNode`s to an expansion dictionary.
 
-        Args:
-            exp_trees (list): a list of TreeNode instances.
+        :param trees_list: A list of `TreeNode` instances
+        :type trees_list: list[TreeNode]
 
-        Returns:
-            An expansion dictionary that represents the expansions detailed in
-            the provided expansions tree nodes.
+        :return: An expansion dictionary that represents the expansions detailed in the provided expansions tree nodes
+        :rtype: dict[union[str, unicode]]
         """
         result = {}
-        for exp_tree in exp_trees:
-            result.update(exp_tree.to_dict())
+
+        for tree in trees_list:
+            result.update(tree.to_dict())
+
         return result

--- a/tests/client/test_expansions.py
+++ b/tests/client/test_expansions.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import mock
 from unittest import TestCase
 
 from pysoa.client.client import Client
@@ -11,25 +12,25 @@ class TestClientWithExpansions(TestCase):
     def setUp(self):
         expansion_config = {
             'type_routes': {
-                'author_router': {
+                'author_route': {
                     'service': 'author_info_service',
                     'action': 'get_authors_by_ids',
                     'request_field': 'ids',
                     'response_field': 'authors_detail',
                 },
-                'publisher_type': {  # Note: Likely a bug here
+                'publisher_route': {  # Note: Likely a bug here
                     'service': 'publisher_info_service',
                     'action': 'get_publishers_by_ids',
                     'request_field': 'ids',
                     'response_field': 'publishers_detail',
                 },
-                'address_router': {
+                'address_route': {
                     'service': 'address_info_service',
                     'action': 'get_addresses_by_ids',
                     'request_field': 'ids',
                     'response_field': 'addresses_detail',
                 },
-                'automaker_router': {
+                'automaker_route': {
                     'service': 'automaker_info_service',
                     'action': 'get_automakers_by_ids',
                     'request_field': 'ids',
@@ -39,29 +40,33 @@ class TestClientWithExpansions(TestCase):
             'type_expansions': {
                 'book_type': {
                     'author_rule': {
-                        'type': 'author_router',
+                        'type': None,
+                        'route': 'author_route',
                         'source_field': 'author_id',
-                        'dest_field': 'author_profile',
+                        'destination_field': 'author_profile',
                     },
                     'publisher_rule': {
                         'type': 'publisher_type',
+                        'route': 'publisher_route',
                         'source_field': 'publish_id',
-                        'dest_field': 'publisher_profile',
+                        'destination_field': 'publisher_profile',
                         'raise_action_errors': True,
                     },
                 },
                 'publisher_type': {
                     'address_rule': {
-                        'type': 'address_router',
+                        'type': None,
+                        'route': 'address_route',
                         'source_field': 'address_id',
-                        'dest_field': 'address_profile',
+                        'destination_field': 'address_profile',
                     },
                 },
                 'car_type': {
                     'automaker_rule': {
-                        'type': 'automaker_router',
+                        'type': None,
+                        'route': 'automaker_route',
                         'source_field': 'automaker_id',
-                        'dest_field': 'automaker_profile',
+                        'destination_field': 'automaker_profile',
                     },
                 },
             },
@@ -92,7 +97,7 @@ class TestClientWithExpansions(TestCase):
             'get_authors_by_ids': {
                 'body': {
                     'authors_detail': {
-                        '2': {
+                        2: {
                             '_type': 'author_type',
                             'id': 2,
                             'stuff': 'things',
@@ -106,7 +111,7 @@ class TestClientWithExpansions(TestCase):
             'get_publishers_by_ids': {
                 'body': {
                     'publishers_detail': {
-                        '3': {
+                        3: {
                             '_type': 'publisher_type',
                             'id': 3,
                             'address_id': 4,
@@ -120,7 +125,7 @@ class TestClientWithExpansions(TestCase):
             'get_addresses_by_ids': {
                 'body': {
                     'addresses_detail': {
-                        '4': {
+                        4: {
                             '_type': 'address_type',
                             'id': 4,
                         },
@@ -133,7 +138,7 @@ class TestClientWithExpansions(TestCase):
             'get_automakers_by_ids': {
                 'body': {
                     'automakers_detail': {
-                        '6': {
+                        6: {
                             '_type': 'auto_type',
                             'id': 6,
                         },
@@ -361,7 +366,7 @@ class TestClientWithExpansions(TestCase):
         }
 
         with stub_action('author_info_service', 'get_authors_by_ids', body={'authors_detail': {
-            '2': {
+            2: {
                 '_type': 'author_type',
                 'id': 201838,
                 'things': 'stuff',
@@ -434,7 +439,7 @@ class TestClientWithExpansions(TestCase):
         }
 
         with stub_action('author_info_service', 'get_authors_by_ids', body={'authors_detail': {
-            '2': {
+            2: {
                 '_type': 'author_type',
                 'id': 201838,
                 'things': 'stuff',
@@ -691,3 +696,532 @@ class TestClientWithExpansions(TestCase):
             )
         message, = err.exception.args
         self.assertEqual(message, 'Invalid key in expansion request: author_rule_typo_key')
+
+
+class AnyOrderEqualsList(list):
+    def __eq__(self, other):
+        return isinstance(other, list) and len(other) == len(self) and set(other) == set(self)
+
+
+class TestComplexCompanyHierarchyExpansions(TestCase):
+    def setUp(self):
+        expansion_config = {
+            'type_routes': {
+                'employee_route': {
+                    'service': 'employee_service',
+                    'action': 'get_employees_by_ids',
+                    'request_field': 'employee_ids',
+                    'response_field': 'employees',
+                },
+                'employee_report_route': {
+                    'service': 'employee_service',
+                    'action': 'get_employees_reports_by_manager_ids',
+                    'request_field': 'manager_ids',
+                    'response_field': 'reports',
+                },
+                'company_employees_route': {
+                    'service': 'employee_service',
+                    'action': 'get_company_employees_by_company_ids',
+                    'request_field': 'company_ids',
+                    'response_field': 'employees',
+                },
+                'image_route': {
+                    'service': 'image_service',
+                    'action': 'get_images_by_ids',
+                    'request_field': 'image_ids',
+                    'response_field': 'images',
+                },
+            },
+            'type_expansions': {
+                'company_type': {
+                    'ceo': {
+                        'type': 'employee_type',
+                        'route': 'employee_route',
+                        'source_field': 'ceo_id',
+                        'destination_field': 'ceo',
+                    },
+                    'logo': {
+                        'type': None,
+                        'route': 'image_route',
+                        'source_field': 'logo_id',
+                        'destination_field': 'logo',
+                    },
+                    'employees': {
+                        'type': 'employee_type',
+                        'route': 'company_employees_route',
+                        'source_field': 'company_id',
+                        'destination_field': 'employees'
+                    }
+                },
+                'employee_type': {
+                    'manager': {
+                        'type': 'employee_type',
+                        'route': 'employee_route',
+                        'source_field': 'manager_id',
+                        'destination_field': 'manager',
+                    },
+                    'photo': {
+                        'type': None,
+                        'route': 'image_route',
+                        'source_field': 'photo_id',
+                        'destination_field': 'photo',
+                    },
+                    'reports': {
+                        'type': 'employee_type',
+                        'route': 'employee_report_route',
+                        'source_field': 'employee_id',
+                        'destination_field': 'reports',
+                    },
+                },
+            },
+        }
+
+        self.client = Client(config={}, expansion_config=expansion_config)
+
+    @stub_action('image_service', 'get_images_by_ids')
+    @stub_action('employee_service', 'get_employees_by_ids')
+    @stub_action('company_service', 'get_all_companies')
+    def test_expand_company_ceo_and_logo(self, mock_get_companies, mock_get_employees, mock_get_images):
+        mock_get_companies.return_value = {
+            'companies': [
+                {'_type': 'company_type', 'company_id': '9183', 'name': 'Acme', 'ceo_id': '5791'},
+                {'_type': 'company_type', 'company_id': '7261', 'name': 'Logo Makers', 'ceo_id': '51', 'logo_id': '65'},
+            ],
+        }
+
+        mock_get_employees.return_value = {
+            'employees': {
+                '5791': {'_type': 'employee_type', 'employee_id': '5791', 'name': 'Julia', 'photo_id': '37'},
+                '51': {'_type': 'employee_type', 'employee_id': '51', 'name': 'Nathan', 'photo_id': '79'},
+            },
+        }
+
+        mock_get_images.side_effect = (
+            {'images': {'65': {'image_id': '65', 'uri': '65.jpg'}}},
+            {'images': {'37': {'image_id': '37', 'uri': '37.jpg'}, '79': {'image_id': '79', 'uri': '79.jpg'}}},
+        )
+
+        response = self.client.call_action(
+            'company_service',
+            'get_all_companies',
+            body={},
+            expansions={'company_type': ['ceo', 'ceo.photo', 'logo']},
+        )
+
+        mock_get_companies.assert_called_once_with({})
+        mock_get_employees.assert_called_once_with({'employee_ids': AnyOrderEqualsList(['5791', '51'])})
+        mock_get_images.assert_has_calls(
+            [
+                mock.call({'image_ids': ['65']}),
+                mock.call({'image_ids': AnyOrderEqualsList(['37', '79'])}),
+            ],
+        )
+
+        expected_response = {
+            'companies': [
+                {
+                    '_type': 'company_type',
+                    'company_id': '9183',
+                    'name': 'Acme',
+                    'ceo_id': '5791',
+                    'ceo': {
+                        '_type': 'employee_type',
+                        'employee_id': '5791',
+                        'name': 'Julia',
+                        'photo_id': '37',
+                        'photo': {'image_id': '37', 'uri': '37.jpg'},
+                    },
+                },
+                {
+                    '_type': 'company_type',
+                    'company_id': '7261',
+                    'name': 'Logo Makers',
+                    'ceo_id': '51',
+                    'ceo': {
+                        '_type': 'employee_type',
+                        'employee_id': '51',
+                        'name': 'Nathan',
+                        'photo_id': '79',
+                        'photo': {'image_id': '79', 'uri': '79.jpg'},
+                    },
+                    'logo_id': '65',
+                    'logo': {'image_id': '65', 'uri': '65.jpg'},
+                },
+            ],
+        }
+
+        self.assertEqual(expected_response, response.body)
+
+    @stub_action('image_service', 'get_images_by_ids')
+    @stub_action('employee_service', 'get_employees_reports_by_manager_ids')
+    @stub_action('employee_service', 'get_employees_by_ids')
+    @stub_action('company_service', 'get_all_companies')
+    def test_expand_company_ceo_and_reports(
+        self,
+        mock_get_companies,
+        mock_get_employees,
+        mock_get_reports,
+        mock_get_images,
+    ):
+        mock_get_companies.return_value = {
+            'companies': [
+                {'_type': 'company_type', 'company_id': '9183', 'name': 'Acme', 'ceo_id': '5791'},
+                {'_type': 'company_type', 'company_id': '7261', 'name': 'Logo Makers', 'ceo_id': '51', 'logo_id': '65'},
+            ],
+        }
+
+        mock_get_employees.return_value = {
+            'employees': {
+                '5791': {'_type': 'employee_type', 'employee_id': '5791', 'name': 'Julia', 'photo_id': '37'},
+                '51': {'_type': 'employee_type', 'employee_id': '51', 'name': 'Nathan', 'photo_id': '79'},
+            },
+        }
+
+        mock_get_reports.return_value = {
+            'reports': {
+                '5791': [
+                    {'_type': 'employee_type', 'employee_id': '1039', 'name': 'Scott'},
+                    {'_type': 'employee_type', 'employee_id': '1047', 'name': 'Whitney', 'photo_id': '41'},
+                    {'_type': 'employee_type', 'employee_id': '1983', 'name': 'Matt', 'photo_id': None},
+                ],
+                '51': [
+                    {'_type': 'employee_type', 'employee_id': '79', 'name': 'Jamie', 'photo_id': None},
+                    {'_type': 'employee_type', 'employee_id': '68', 'name': 'Greg', 'photo_id': '16'},
+                    {'_type': 'employee_type', 'employee_id': '413', 'name': 'Ralph', 'photo_id': '98'},
+                    {'_type': 'employee_type', 'employee_id': '2706', 'name': 'Melanie'},
+                ],
+            },
+        }
+
+        mock_get_images.side_effect = (
+            {'images': {'37': {'image_id': '37', 'uri': '37.jpg'}, '79': {'image_id': '79', 'uri': '79.jpg'}}},
+            {
+                'images': {
+                    '41': {'image_id': '41', 'uri': '41.jpg'},
+                    '16': {'image_id': '16', 'uri': '16.jpg'},
+                    '98': {'image_id': '98', 'uri': '98.jpg'},
+                },
+            },
+        )
+
+        response = self.client.call_action(
+            'company_service',
+            'get_all_companies',
+            body={},
+            expansions={'company_type': ['ceo', 'ceo.photo', 'ceo.reports', 'ceo.reports.photo']},
+        )
+
+        mock_get_companies.assert_called_once_with({})
+        mock_get_employees.assert_called_once_with({'employee_ids': AnyOrderEqualsList(['5791', '51'])})
+        mock_get_reports.assert_called_once_with({'manager_ids': AnyOrderEqualsList(['5791', '51'])})
+        mock_get_images.assert_has_calls(
+            [
+                mock.call({'image_ids': AnyOrderEqualsList(['37', '79'])}),
+                mock.call({'image_ids': AnyOrderEqualsList(['41', '16', '98'])}),
+            ],
+        )
+
+        expected_response = {
+            'companies': [
+                {
+                    '_type': 'company_type',
+                    'company_id': '9183',
+                    'name': 'Acme',
+                    'ceo_id': '5791',
+                    'ceo': {
+                        '_type': 'employee_type',
+                        'employee_id': '5791',
+                        'name': 'Julia',
+                        'photo_id': '37',
+                        'photo': {'image_id': '37', 'uri': '37.jpg'},
+                        'reports': [
+                            {'_type': 'employee_type', 'employee_id': '1039', 'name': 'Scott'},
+                            {
+                                '_type': 'employee_type',
+                                'employee_id': '1047',
+                                'name': 'Whitney',
+                                'photo_id': '41',
+                                'photo': {'image_id': '41', 'uri': '41.jpg'},
+                            },
+                            {'_type': 'employee_type', 'employee_id': '1983', 'name': 'Matt', 'photo_id': None},
+                        ],
+                    },
+                },
+                {
+                    '_type': 'company_type',
+                    'company_id': '7261',
+                    'name': 'Logo Makers',
+                    'ceo_id': '51',
+                    'ceo': {
+                        '_type': 'employee_type',
+                        'employee_id': '51',
+                        'name': 'Nathan',
+                        'photo_id': '79',
+                        'photo': {'image_id': '79', 'uri': '79.jpg'},
+                        'reports': [
+                            {'_type': 'employee_type', 'employee_id': '79', 'name': 'Jamie', 'photo_id': None},
+                            {
+                                '_type': 'employee_type',
+                                'employee_id': '68',
+                                'name': 'Greg',
+                                'photo_id': '16',
+                                'photo': {'image_id': '16', 'uri': '16.jpg'},
+                            },
+                            {
+                                '_type': 'employee_type',
+                                'employee_id': '413',
+                                'name': 'Ralph',
+                                'photo_id': '98',
+                                'photo': {'image_id': '98', 'uri': '98.jpg'},
+                            },
+                            {'_type': 'employee_type', 'employee_id': '2706', 'name': 'Melanie'},
+                        ],
+                    },
+                    'logo_id': '65',
+                },
+            ],
+        }
+
+        self.assertEqual(expected_response, response.body)
+
+    @stub_action('image_service', 'get_images_by_ids')
+    @stub_action('employee_service', 'get_employees_by_ids')
+    @stub_action('employee_service', 'get_company_employees_by_company_ids')
+    @stub_action('company_service', 'get_all_companies')
+    def test_expand_company_employees_and_managers(
+        self,
+        mock_get_companies,
+        mock_get_employees,
+        mock_get_managers,
+        mock_get_images,
+    ):
+        mock_get_companies.return_value = {
+            'companies': [
+                {'_type': 'company_type', 'company_id': '9183', 'name': 'Acme', 'ceo_id': '5791'},
+                {'_type': 'company_type', 'company_id': '7261', 'name': 'Logo Makers', 'ceo_id': '51', 'logo_id': '65'},
+            ],
+        }
+
+        mock_get_employees.return_value = {
+            'employees': {
+                '9183': [
+                    {'_type': 'employee_type', 'employee_id': '5791', 'name': 'Julia', 'photo_id': '37'},
+                    {'_type': 'employee_type', 'employee_id': '1039', 'name': 'Scott', 'manager_id': '5791'},
+                    {
+                        '_type': 'employee_type',
+                        'employee_id': '1047',
+                        'name': 'Whitney',
+                        'photo_id': '41',
+                        'manager_id': '5791',
+                    },
+                    {
+                        '_type': 'employee_type',
+                        'employee_id': '1983',
+                        'name': 'Matt',
+                        'photo_id': None,
+                        'manager_id': '5791',
+                    },
+                ],
+                '7261': [
+                    {'_type': 'employee_type', 'employee_id': '51', 'name': 'Nathan', 'photo_id': '79'},
+                    {
+                        '_type': 'employee_type',
+                        'employee_id': '79',
+                        'name': 'Jamie',
+                        'photo_id': None,
+                        'manager_id': '51',
+                    },
+                    {
+                        '_type': 'employee_type',
+                        'employee_id': '68',
+                        'name': 'Greg',
+                        'photo_id': '16',
+                        'manager_id': '51',
+                    },
+                    {
+                        '_type': 'employee_type',
+                        'employee_id': '413',
+                        'name': 'Ralph',
+                        'photo_id': '98',
+                        'manager_id': '51',
+                    },
+                    {'_type': 'employee_type', 'employee_id': '2706', 'name': 'Melanie', 'manager_id': '51'},
+                ],
+            },
+        }
+
+        mock_get_managers.return_value = {
+            'employees': {
+                '5791': {'_type': 'employee_type', 'employee_id': '5791', 'name': 'Julia', 'photo_id': '37'},
+                '51': {'_type': 'employee_type', 'employee_id': '51', 'name': 'Nathan', 'photo_id': '79'},
+            },
+        }
+
+        mock_get_images.side_effect = (
+            {
+                'images': {
+                    '37': {'image_id': '37', 'uri': '37.jpg'},
+                    '79': {'image_id': '79', 'uri': '79.jpg'},
+                    '41': {'image_id': '41', 'uri': '41.jpg'},
+                    '16': {'image_id': '16', 'uri': '16.jpg'},
+                    '98': {'image_id': '98', 'uri': '98.jpg'},
+                },
+            },
+            {'images': {'37': {'image_id': '37', 'uri': '37.jpg'}, '79': {'image_id': '79', 'uri': '79.jpg'}}},
+        )
+
+        response = self.client.call_action(
+            'company_service',
+            'get_all_companies',
+            body={},
+            expansions={
+                'company_type': ['employees', 'employees.photo', 'employees.manager', 'employees.manager.photo'],
+            },
+        )
+
+        mock_get_companies.assert_called_once_with({})
+        mock_get_employees.assert_called_once_with({'company_ids': AnyOrderEqualsList(['9183', '7261'])})
+        mock_get_managers.assert_called_once_with({'employee_ids': AnyOrderEqualsList(['5791', '51'])})
+        mock_get_images.assert_has_calls(
+            [
+                mock.call({'image_ids': AnyOrderEqualsList(['37', '41', '79', '16', '98'])}),
+                mock.call({'image_ids': AnyOrderEqualsList(['37', '79'])}),
+            ],
+        )
+
+        expected_response = {
+            'companies': [
+                {
+                    '_type': 'company_type',
+                    'company_id': '9183',
+                    'name': 'Acme',
+                    'ceo_id': '5791',
+                    'employees': [
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '5791',
+                            'name': 'Julia',
+                            'photo_id': '37',
+                            'photo': {'image_id': '37', 'uri': '37.jpg'},
+                        },
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '1039',
+                            'name': 'Scott',
+                            'manager_id': '5791',
+                            'manager': {
+                                '_type': 'employee_type',
+                                'employee_id': '5791',
+                                'name': 'Julia',
+                                'photo_id': '37',
+                                'photo': {'image_id': '37', 'uri': '37.jpg'},
+                            },
+                        },
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '1047',
+                            'name': 'Whitney',
+                            'photo_id': '41',
+                            'photo': {'image_id': '41', 'uri': '41.jpg'},
+                            'manager_id': '5791',
+                            'manager': {
+                                '_type': 'employee_type',
+                                'employee_id': '5791',
+                                'name': 'Julia',
+                                'photo_id': '37',
+                                'photo': {'image_id': '37', 'uri': '37.jpg'},
+                            },
+                        },
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '1983',
+                            'name': 'Matt',
+                            'photo_id': None,
+                            'manager_id': '5791',
+                            'manager': {
+                                '_type': 'employee_type',
+                                'employee_id': '5791',
+                                'name': 'Julia',
+                                'photo_id': '37',
+                                'photo': {'image_id': '37', 'uri': '37.jpg'},
+                            },
+                        },
+                    ],
+                },
+                {
+                    '_type': 'company_type',
+                    'company_id': '7261',
+                    'name': 'Logo Makers',
+                    'ceo_id': '51',
+                    'logo_id': '65',
+                    'employees': [
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '51',
+                            'name': 'Nathan',
+                            'photo_id': '79',
+                            'photo': {'image_id': '79', 'uri': '79.jpg'},
+                        },
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '79',
+                            'name': 'Jamie',
+                            'photo_id': None,
+                            'manager_id': '51',
+                            'manager': {
+                                '_type': 'employee_type',
+                                'employee_id': '51',
+                                'name': 'Nathan',
+                                'photo_id': '79',
+                                'photo': {'image_id': '79', 'uri': '79.jpg'},
+                            },
+                        },
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '68',
+                            'name': 'Greg',
+                            'photo_id': '16',
+                            'photo': {'image_id': '16', 'uri': '16.jpg'},
+                            'manager_id': '51',
+                            'manager': {
+                                '_type': 'employee_type',
+                                'employee_id': '51',
+                                'name': 'Nathan',
+                                'photo_id': '79',
+                                'photo': {'image_id': '79', 'uri': '79.jpg'},
+                            },
+                        },
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '413',
+                            'name': 'Ralph',
+                            'photo_id': '98',
+                            'photo': {'image_id': '98', 'uri': '98.jpg'},
+                            'manager_id': '51',
+                            'manager': {
+                                '_type': 'employee_type',
+                                'employee_id': '51',
+                                'name': 'Nathan',
+                                'photo_id': '79',
+                                'photo': {'image_id': '79', 'uri': '79.jpg'},
+                            },
+                        },
+                        {
+                            '_type': 'employee_type',
+                            'employee_id': '2706',
+                            'name': 'Melanie',
+                            'manager_id': '51',
+                            'manager': {
+                                '_type': 'employee_type',
+                                'employee_id': '51',
+                                'name': 'Nathan',
+                                'photo_id': '79',
+                                'photo': {'image_id': '79', 'uri': '79.jpg'},
+                            },
+                        },
+                    ],
+                },
+            ],
+        }
+
+        self.assertEqual(expected_response, response.body)


### PR DESCRIPTION
This change fixes the following several bugs in expansions:

- Expansions fail with `KeyError` if only some of the base objects contain the source field or action errors if the source field in one of the base objects is `None`.
- Expansions call expansion actions multiple times (once for every expansion object) instead of one time (with values from every expansion object). Fixing this required a major overhaul of the code that performs expansions.
- Expansions do not pass the correlation ID, context overrides, and control information from the parent request to the expansion requests, which can omit critical authentication information.
- Expansions do not properly process nested expansions unless the nested types and their routes have the same name, which can be extremely confusing. Fixing this required breaking changes to the Type Expansions Configuration format, so I took the opportunity to also rename an abbreviated field in said format (`dest_field` -> `destination_field`).

This change also adds an extensive and complex set of tests against a complicated expansion hierarchy, including many nested levels with values including and not including expansion criteria.