### PR TITLE
Better handling of out-of-order responses (WIP)

### DIFF
--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -34,7 +34,6 @@ class ServiceHandler(object):
     _transport_cache = {}
 
     def __init__(self, service_name, settings):
-        self.service_name = service_name
         self.metrics = settings['metrics']['object'](**settings['metrics'].get('kwargs', {}))
 
         transport_cache_time_in_seconds = 0

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -314,7 +314,6 @@ class stub_action(object):  # noqa
 
         self._stub_action_responses_outstanding = defaultdict(dict)
         self._stub_action_responses_to_merge = defaultdict(dict)
-        self._stub_action_unwrapped_call_id_map = {}
 
     def __enter__(self):
         self._wrapped_client_send_request = Client.send_request
@@ -371,7 +370,6 @@ class stub_action(object):  # noqa
                     request_id,
                     continue_on_error,
                 )
-                self._stub_action_unwrapped_call_id_map[request_id] = unwrapped_request_id
 
             ordered_actions_for_merging = OrderedDict()
             job_response_transport_exception = None


### PR DESCRIPTION
Added `get_response_for_request` helper that blocks until an expected request is received (or times out). This solves bugs that result from `call_actions` receiving an OOO response via `get_all_responses`.