### PR TITLE
Improve auto-docs using built-in method designed for it

### DIFF
--- a/pysoa/test/plan/grammar/__init__.py
+++ b/pysoa/test/plan/grammar/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+import inspect
+
 import six
 
 from pysoa.test.plan.grammar.data_types import (
@@ -234,7 +236,7 @@ for __directive_class in get_all_directives():
     __doc__ += (
         '' + __name + '\n' +
         ('~' * len(__name)) + '\n\n' +
-        '\n'.join(x.strip(' \n\t') for x in (__directive_class.__doc__ or '').split('\n')).strip(' \n\t') + '\n\n' +
+        inspect.cleandoc(__directive_class.__doc__ or '') + '\n\n' +
         '(from: ``' + __directive_class.__module__ + '``)' + '\n\n' +
         'Syntax::\n\n' + __wrap_documentation_line(repr(__directive_class())) + '\n\n\n'
     )


### PR DESCRIPTION
The code was stripping to much indentation from auto-generated directive documentation, which was causing important contextual documentation to be lost. This uses a built-in method designed to remove leading and trailing blank lines and uniformly remove leading spaces from all remaining lines in Python docstrings so that contextual indentation is not lost.