### PR TITLE
[MINOR]: Use error codes supplied by Conformity

### DIFF
--- a/pysoa/common/constants.py
+++ b/pysoa/common/constants.py
@@ -1,4 +1,10 @@
-ERROR_CODE_INVALID = 'INVALID'
-ERROR_CODE_MISSING = 'MISSING'
-ERROR_CODE_UNKNOWN = 'UNKNOWN'
+from __future__ import absolute_import, unicode_literals
+
+from conformity.error import (  # noqa
+    ERROR_CODE_INVALID,
+    ERROR_CODE_MISSING,
+    ERROR_CODE_UNKNOWN,
+)
+
+
 ERROR_CODE_SERVER_ERROR = 'SERVER_ERROR'

--- a/pysoa/server/action/base.py
+++ b/pysoa/server/action/base.py
@@ -4,9 +4,14 @@ import abc
 
 import six
 
-from pysoa.common.constants import ERROR_CODE_INVALID
-from pysoa.common.types import ActionResponse, Error
-from pysoa.server.errors import ActionError, ResponseValidationError
+from pysoa.common.types import (
+    ActionResponse,
+    Error,
+)
+from pysoa.server.errors import (
+    ActionError,
+    ResponseValidationError,
+)
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -59,7 +64,7 @@ class Action(object):
         if self.request_schema:
             errors = [
                 Error(
-                    code=ERROR_CODE_INVALID,
+                    code=error.code,
                     message=error.message,
                     field=error.pointer,
                 )

--- a/pysoa/server/errors.py
+++ b/pysoa/server/errors.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 class JobError(Exception):
     def __init__(self, errors):
         self.errors = errors
@@ -19,7 +22,7 @@ class ResponseValidationError(Exception):
         self.errors = errors
 
     def __str__(self):
-        return "%s had an invalid response:\n%s" % (
+        return '{} had an invalid response:\n\t{}'.format(
             self.action,
-            "\n".join("%s: %s" % (error.pointer, error.message) for error in self.errors)
+            '\n\t'.join('{} {}: {}'.format(error.pointer, error.code, error.message) for error in self.errors)
         )

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -12,7 +12,6 @@ import signal
 import attr
 from pysoa.client import Client
 from pysoa.common.constants import (
-    ERROR_CODE_INVALID,
     ERROR_CODE_SERVER_ERROR,
     ERROR_CODE_UNKNOWN,
 )
@@ -168,7 +167,7 @@ class Server(object):
             # Validate JobRequest message
             validation_errors = [
                 Error(
-                    code=ERROR_CODE_INVALID,
+                    code=error.code,
                     message=error.message,
                     field=error.pointer,
                 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 install_requires = [
     'attrs~=17.4',
-    'conformity~=1.11',
+    'conformity~=1.12',
     'currint~=1.6',
     'enum34;python_version<"3.4"',
     'msgpack-python~=0.4',


### PR DESCRIPTION
Conformity now supplies machine-readable error codes when validating schemas, so we should use those error codes instead of hard-coding `INVALID` as the error code.