### PR TITLE
[MINOR] Don't require mock library for `stub_service`, tests in Python 3

### DIFF
--- a/pysoa/test/compatibility.py
+++ b/pysoa/test/compatibility.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+
+try:
+    from unittest import mock  # noqa
+    # On this end, we won't require consumers to have mock 3rd-party library installed in Python 3
+except ImportError:
+    import mock  # noqa
+    # On this other end, we can still support Python 2
+
+
+__all__ = (
+    'mock'
+)

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -7,7 +7,6 @@ from collections import (
 from functools import wraps
 import re
 
-import mock
 import six
 
 from pysoa.client.client import (
@@ -33,6 +32,7 @@ from pysoa.server.errors import (
     ActionError,
     JobError,
 )
+from pysoa.test.compatibility import mock
 
 
 def _make_stub_action(action_name, body=None, errors=None):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
         return f.read()
 
 
-install_requires = [
+base_requirements = [
     'attrs~=17.4',
     'conformity~=1.12',
     'currint~=1.6',
@@ -20,20 +20,23 @@ install_requires = [
     'six~=1.10',
 ]
 
-pytest_plugin_requires = [
-    'mock>=2.0',
+test_helper_requirements = [
+    'mock>=2.0;python_version<"3.3"',
+]
+
+test_plan_requirements = test_helper_requirements + [
     'pyparsing~=2.2',
     'pytest~=3.1',
     'pytz>=2018.4',
 ]
 
-tests_require = [
+test_requirements = [
     'factory_boy~=2.8.0',
     'freezegun~=0.3',
     'lunatic-python-universal~=2.1',
     'mockredispy~=2.9',
     'pytest-cov~=2.5',
-] + pytest_plugin_requires
+] + test_plan_requirements
 
 setup(
     name='pysoa',
@@ -45,13 +48,14 @@ setup(
     url='http://github.com/eventbrite/pysoa',
     packages=list(map(str, find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']))),
     include_package_data=True,
-    install_requires=install_requires,
-    tests_require=tests_require,
+    install_requires=base_requirements,
+    tests_require=test_requirements,
     setup_requires=['pytest-runner'],
     test_suite='tests',
     extras_require={
-        'testing': tests_require,
-        'pytest': pytest_plugin_requires,
+        'testing': test_requirements,
+        'test_helpers': test_helper_requirements,
+        'test_plans': test_plan_requirements,
     },
     entry_points={
         'pytest11': [

--- a/tests/client/test_expansions.py
+++ b/tests/client/test_expansions.py
@@ -1,9 +1,9 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
-import mock
 from unittest import TestCase
 
 from pysoa.client.client import Client
+from pysoa.test.compatibility import mock
 from pysoa.test.stub_service import stub_action
 
 

--- a/tests/client/test_send_receive.py
+++ b/tests/client/test_send_receive.py
@@ -1,4 +1,6 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
+from unittest import TestCase
 
 from pysoa.client.client import Client
 from pysoa.client.middleware import ClientMiddleware
@@ -21,9 +23,8 @@ from pysoa.common.types import (
 )
 from pysoa.server.errors import JobError
 from pysoa.server.server import Server
+from pysoa.test.compatibility import mock
 
-import mock
-from unittest import TestCase
 
 SERVICE_NAME = 'test_service'
 

--- a/tests/common/transport/redis_gateway/backend/test_sentinel.py
+++ b/tests/common/transport/redis_gateway/backend/test_sentinel.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-import mock
 import msgpack
 import redis.sentinel
 
 from pysoa.common.transport.redis_gateway.backend.base import CannotGetConnectionError
 from pysoa.common.transport.redis_gateway.backend.sentinel import SentinelRedisClient
+from pysoa.test.compatibility import mock
 
 from .test_standard import mockredis  # To ensure all the patching over there happens over here
 

--- a/tests/common/transport/redis_gateway/backend/test_standard.py
+++ b/tests/common/transport/redis_gateway/backend/test_standard.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-import mock
 from mockredis import client as mockredis
 from mockredis.exceptions import ResponseError
 from mockredis.script import Script
@@ -10,6 +9,7 @@ import msgpack
 import six
 
 from pysoa.common.transport.redis_gateway.backend.standard import StandardRedisClient
+from pysoa.test.compatibility import mock
 
 #####
 # The following MockRedis fixes were submitted as part of https://github.com/locationlabs/mockredis/pull/133. They can

--- a/tests/common/transport/redis_gateway/test_client.py
+++ b/tests/common/transport/redis_gateway/test_client.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 import uuid
 
-import mock
-
 from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.base import get_hex_thread_id
 from pysoa.common.transport.redis_gateway.client import RedisClientTransport
+from pysoa.test.compatibility import mock
 
 
 @mock.patch('pysoa.common.transport.redis_gateway.client.RedisTransportCore')

--- a/tests/common/transport/redis_gateway/test_core.py
+++ b/tests/common/transport/redis_gateway/test_core.py
@@ -8,7 +8,6 @@ import uuid
 
 import attr
 import freezegun
-import mock
 
 from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer
 from pysoa.common.transport.exceptions import (
@@ -24,6 +23,7 @@ from pysoa.common.transport.redis_gateway.constants import (
     REDIS_BACKEND_TYPE_SENTINEL,
 )
 from pysoa.common.transport.redis_gateway.core import RedisTransportCore
+from pysoa.test.compatibility import mock
 
 from .backend.test_standard import mockredis  # To ensure all the patching over there happens over here
 

--- a/tests/common/transport/redis_gateway/test_server.py
+++ b/tests/common/transport/redis_gateway/test_server.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 import uuid
 
-import mock
-
 from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.exceptions import InvalidMessageError
 from pysoa.common.transport.redis_gateway.server import RedisServerTransport
+from pysoa.test.compatibility import mock
 
 
 @mock.patch('pysoa.common.transport.redis_gateway.server.RedisTransportCore')

--- a/tests/common/transport/redis_gateway/test_threading.py
+++ b/tests/common/transport/redis_gateway/test_threading.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import mock
 import threading
 import time
 import unittest
@@ -10,6 +9,7 @@ from pysoa.common.transport.exceptions import MessageReceiveTimeout
 from pysoa.common.transport.redis_gateway.client import RedisClientTransport
 from pysoa.common.transport.redis_gateway.constants import REDIS_BACKEND_TYPE_STANDARD
 from pysoa.common.transport.redis_gateway.server import RedisServerTransport
+from pysoa.test.compatibility import mock
 
 
 class _FakeBackend(object):

--- a/tests/server/test_autoreloader.py
+++ b/tests/server/test_autoreloader.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import importlib
-import mock
 import os
 import signal
 import sys
@@ -21,6 +20,7 @@ from pysoa.server.autoreload import (
     get_reloader,
     NEED_RELOAD_EXIT_CODE,
 )
+from pysoa.test.compatibility import mock
 import pysoa.version
 
 

--- a/tests/server/test_logging.py
+++ b/tests/server/test_logging.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import mock
 import six
 import threading
 import unittest
@@ -9,6 +8,7 @@ from pysoa.server.logging import (
     PySOALogContextFilter,
     RecursivelyCensoredDictWrapper,
 )
+from pysoa.test.compatibility import mock
 
 
 class TestPySOALogContextFilter(unittest.TestCase):

--- a/tests/server/test_server/test_configuration.py
+++ b/tests/server/test_server/test_configuration.py
@@ -1,8 +1,10 @@
-import mock
+from __future__ import absolute_import, unicode_literals
+
 from unittest import TestCase
 
 from pysoa.server.server import Server
 from pysoa.test import factories
+from pysoa.test.compatibility import mock
 
 
 class BaseTestServiceServer(Server):
@@ -19,10 +21,10 @@ class ServerInitializationTests(TestCase):
 
     def test_service_name_not_set(self):
         TestServiceServer = type(
-            'TestServiceServer',
+            str('TestServiceServer'),
             (BaseTestServiceServer,),
             {
-                'service_name': None,
+                str('service_name'): None,
             },
         )
 

--- a/tests/server/test_standalone.py
+++ b/tests/server/test_standalone.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
-import mock
 import os
 import signal
 import sys
 import unittest
+
+from pysoa.test.compatibility import mock
 
 
 standalone = None
@@ -67,7 +68,7 @@ class TestSimpleMain(unittest.TestCase):
         self.assertFalse(server_getter.return_value.main.called)
 
         mock_get_reloader.assert_called_once_with('', None, signal_forks=False)
-        mock_get_reloader.return_value.main.assert_called_once()
+        self.assertEqual(1, mock_get_reloader.return_value.main.call_count)
         self.assertEqual(
             server_getter.return_value,
             mock_get_reloader.return_value.main.call_args_list[0][0][1][1],
@@ -85,7 +86,7 @@ class TestSimpleMain(unittest.TestCase):
         self.assertFalse(server_getter.return_value.main.called)
 
         mock_get_reloader.assert_called_once_with('', ['example', 'pysoa', 'conformity'], signal_forks=False)
-        mock_get_reloader.return_value.main.assert_called_once()
+        self.assertEqual(1, mock_get_reloader.return_value.main.call_count)
         self.assertEqual(0, mock_get_reloader.return_value.main.call_args_list[0][0][1][0].fork_processes)
         self.assertEqual(
             server_getter.return_value,
@@ -104,7 +105,7 @@ class TestSimpleMain(unittest.TestCase):
         self.assertFalse(server_getter.return_value.main.called)
 
         mock_get_reloader.assert_called_once_with('', None, signal_forks=True)
-        mock_get_reloader.return_value.main.assert_called_once()
+        self.assertEqual(1, mock_get_reloader.return_value.main.call_count)
         self.assertEqual(5, mock_get_reloader.return_value.main.call_args_list[0][0][1][0].fork_processes)
         self.assertEqual(
             server_getter.return_value,
@@ -123,7 +124,7 @@ class TestSimpleMain(unittest.TestCase):
         self.assertFalse(server_getter.return_value.main.called)
 
         mock_get_reloader.assert_called_once_with('', ['pysoa'], signal_forks=True)
-        mock_get_reloader.return_value.main.assert_called_once()
+        self.assertEqual(1, mock_get_reloader.return_value.main.call_count)
         self.assertEqual(5, mock_get_reloader.return_value.main.call_args_list[0][0][1][0].fork_processes)
         self.assertEqual(
             server_getter.return_value,

--- a/tests/test/plan/test_plan_execution_errors.py
+++ b/tests/test/plan/test_plan_execution_errors.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 import unittest
 
-import mock
-
+from pysoa.test.compatibility import mock
 from pysoa.test.plan import ServicePlanTestCase
 from pysoa.test.plan.errors import (
     FixtureLoadError,
@@ -425,7 +424,7 @@ class TestInvalidFixturePaths(unittest.TestCase):
         test._all_directives[0].return_value.tear_down_test_case_action.assert_not_called()
 
         test.addError.assert_not_called()
-        test.addFailure.assert_called_once()
+        test.assertEqual(1, test.addFailure.call_count)
 
     def test_error_on_set_up_test_case_no_other_errors(self):
         test_case = {'my': 'case'}
@@ -584,7 +583,7 @@ class TestInvalidFixturePaths(unittest.TestCase):
         test._all_directives[0].return_value.set_up_test_case_action.assert_not_called()
         test._all_directives[0].return_value.tear_down_test_case_action.assert_not_called()
 
-        test.addError.assert_called_once()
+        test.assertEqual(1, test.addError.call_count)
         test.addFailure.assert_not_called()
 
     def test_keyboard_error_on_tear_down_test_case_no_other_errors(self):
@@ -663,7 +662,7 @@ class TestInvalidFixturePaths(unittest.TestCase):
         test._all_directives[0].return_value.set_up_test_case_action.assert_not_called()
         test._all_directives[0].return_value.tear_down_test_case_action.assert_not_called()
 
-        test.addError.assert_called_once()
+        test.assertEqual(1, test.addError.call_count)
         test.addFailure.assert_not_called()
 
     def test_keyboard_error_on_tear_down_no_other_errors(self):
@@ -821,7 +820,7 @@ class TestInvalidFixturePaths(unittest.TestCase):
         test._all_directives[0].return_value.set_up_test_case_action.assert_not_called()
         test._all_directives[0].return_value.tear_down_test_case_action.assert_not_called()
 
-        test.addError.assert_called_once()
+        test.assertEqual(1, test.addError.call_count)
         test.addFailure.assert_not_called()
 
     def test_other_error_on_assert_test_fixture_results_some_other_errors(self):
@@ -861,7 +860,7 @@ class TestInvalidFixturePaths(unittest.TestCase):
         test._all_directives[0].return_value.set_up_test_case_action.assert_not_called()
         test._all_directives[0].return_value.tear_down_test_case_action.assert_not_called()
 
-        test.addError.assert_called_once()
+        test.assertEqual(1, test.addError.call_count)
         test.addFailure.assert_not_called()
 
     def test_keyboard_error_on_tear_down_test_fixture(self):

--- a/tests/test/test_stub_service.py
+++ b/tests/test/test_stub_service.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 import random
 
-import mock
-
 from pysoa.client import Client
 from pysoa.common.types import (
     ActionRequest,
@@ -17,6 +15,7 @@ from pysoa.server.errors import (
     JobError,
 )
 from pysoa.server.server import Server
+from pysoa.test.compatibility import mock
 from pysoa.test.factories import ActionFactory
 from pysoa.test.server import ServerTestCase
 from pysoa.test.stub_service import stub_action


### PR DESCRIPTION
We can conditionally import `unittest.mock` or `mock` for `stub_service` functionality, and for tests, instead of requiring the Mock backport library in Python 3.