### PR TITLE
[PATCH] Ensure an error response is sent if response too large

### DIFF
--- a/pysoa/common/constants.py
+++ b/pysoa/common/constants.py
@@ -8,3 +8,4 @@ from conformity.error import (  # noqa
 
 
 ERROR_CODE_SERVER_ERROR = 'SERVER_ERROR'
+ERROR_CODE_RESPONSE_TOO_LARGE = 'RESPONSE_TOO_LARGE'


### PR DESCRIPTION
If a serialized response message is too large to send, resulting in a `MessageTooLarge` error, the error was trickling back all the way up to the server process loop, causing the server to shut down and the client to time out waiting for a response. This change ensures that, in such a case, an error response is sent to the client informing it that the response was too large to send, and then the server continues on with its business as usual instead of shutting down.