### PR TITLE
[PATCH] Import Mock if installed before unittest.mock

### DIFF
--- a/pysoa/test/compatibility.py
+++ b/pysoa/test/compatibility.py
@@ -1,11 +1,15 @@
 from __future__ import absolute_import
 
 try:
-    from unittest import mock  # noqa
-    # On this end, we won't require consumers to have mock 3rd-party library installed in Python 3
-except ImportError:
     import mock  # noqa
-    # On this other end, we can still support Python 2
+    # First we try to import the Python 2 backport library of Mock, because if the project is using it, we should use it
+except ImportError as e:
+    try:
+        from unittest import mock  # noqa
+        # Next we try to import the built-in unittest.mock, which is only available on Python 3
+    except ImportError:
+        # We can get here only on Python 2, only if Mock isn't installed, so we raise the original import error for Mock
+        raise e
 
 
 __all__ = (


### PR DESCRIPTION
If a project has Mock installed on Python 3, it probably means that project is using Mock. Their use of Mock combined with PySOA's test utils' use of `unittest.mock` can result in positional argument errors. PySOA must first make an effort to import Mock, and only use `unittest.mock` if Mock isn't installed.