### PR TITLE
[MINOR] Add a SwitchedAction class to facilitate switch usage

### DIFF
--- a/pysoa/server/action/switched.py
+++ b/pysoa/server/action/switched.py
@@ -1,0 +1,145 @@
+from __future__ import absolute_import, unicode_literals
+
+import abc
+
+import six
+
+from pysoa.server.internal.types import is_switch
+
+
+__all__ = (
+    'SwitchedAction',
+)
+
+
+def _len(item):
+    # Safe length that won't raise an error on values that don't support length
+    return getattr(item, '__len__', lambda *_: -1)()
+
+
+class _DefaultAction(object):
+    def __int__(self):
+        d = id(self)
+        return d if d < 0 else -d
+
+    def __eq__(self, other):
+        return getattr(other, '__class__', None) == _DefaultAction
+
+
+class _SwitchedActionMetaClass(abc.ABCMeta):
+    def __new__(mcs, name, bases, body):
+        """
+        Validate the switch_to_action_map when the class is created, instead of doing it every time the class
+        is instantiated. This identifies problems earlier (on import) and improves performance by not performing this
+        validation every time the action is called.
+        """
+        cls = super(_SwitchedActionMetaClass, mcs).__new__(mcs, name, bases, body)
+
+        # noinspection PyUnresolvedReferences
+        if bases[0] is not object and (
+            not cls.switch_to_action_map or
+            not hasattr(cls.switch_to_action_map, '__iter__') or
+            _len(cls.switch_to_action_map) < 2 or
+            any(
+                True for i in cls.switch_to_action_map
+                if not hasattr(i, '__getitem__') or _len(i) != 2 or not is_switch(i[0]) or not callable(i[1])
+            )
+        ):
+            raise ValueError(
+                'Class attribute switch_to_action_map must be an iterable of at least two indexable items, each '
+                'with exactly two indexes, where the first element is a switch and the second element is an action '
+                '(callable).'
+            )
+
+        return cls
+
+
+@six.add_metaclass(_SwitchedActionMetaClass)
+class SwitchedAction(object):
+    """
+    A specialized action that defers to other, concrete actions based on request switches. Subclasses must not
+    override any methods and must override `switch_to_action_map`. `switch_to_action_map` should be some iterable
+    object that provides `__len__` (such as a tuple [recommended] or list). Its items must be indexable objects that
+    provide `__len__` (such as a tuple [recommended] or list) and have exactly two elements.
+
+    For each item in `switch_to_action_map`, the first element must be a switch that provides `__int__` (such as an
+    actual integer) or a switch that provides an attribute `value` which, itself, provides `__int__` (or is an int).
+    The second element must be an action, such as an action class (e.g. one that extends `Action`) or any callable
+    that accepts a server settings object and returns a new callable that, itself, accepts an `ActionRequest` object
+    and returns an `ActionResponse` object or raises an `ActionError`.
+
+    `switch_to_action_map` must have at least two items in it. `SwitchedAction` will iterate over that list, checking
+    the first element (switch) of each item to see if it is enabled in the request. If it is, the second element (the
+    action) of that item will be deferred to. If it finds no items whose switches are enabled, it will use the very
+    last action in `switch_to_action_map`. As such, you can treat the last item as a default, and its switch could
+    simply be `SwitchedAction.DEFAULT_ACTION` (although, this is not required: it could also be a valid switch, and
+    it would still be treated as the default in the case that no other items matched).
+
+    Example usage:
+
+    .. code-block:: python
+
+        class UserActionV1(Action):
+            ...
+
+        class UserActionV2(Action):
+            ...
+
+        class UserTransitionAction(SwitchedAction):
+            switch_to_action_map = (
+                (USER_VERSION_2_ENABLED, UserActionV2),
+                (SwitchedAction.DEFAULT_ACTION, UserActionV1),
+            )
+    """
+
+    DEFAULT_ACTION = _DefaultAction()
+
+    switch_to_action_map = ()
+
+    def __init__(self, settings=None):
+        """
+        Construct a new action. Concrete classes should not override this.
+
+        :param settings: The server settings object
+        :type settings: dict
+        """
+        if self.__class__ is SwitchedAction:
+            raise TypeError('Cannot instantiate abstract SwitchedAction')
+
+        self.settings = settings
+
+    def get_uninitialized_action(self, action_request):
+        """
+        Get the raw action (such as the action class or the base action callable) without instantiating/calling
+        it, based on the switches in the action request, or the default raw action if no switches were present or
+        no switches matched.
+
+        :param action_request: The request object
+        :type action_request: EnrichedActionRequest
+
+        :return: The action
+        :rtype: callable
+        """
+        last_action = None
+        matched_action = None
+        default_action = None
+
+        for switch, action in self.switch_to_action_map:
+            if switch == self.DEFAULT_ACTION:
+                default_action = action
+            elif switch and action_request.switches.is_active(switch):
+                matched_action = action
+                break
+            else:
+                last_action = action
+
+        return matched_action or default_action or last_action
+
+    def __call__(self, action_request):
+        """
+        Main entry point for actions from the `Server` (or potentially from tests).
+
+        :param action_request: The request object
+        :type action_request: EnrichedActionRequest
+        """
+        return self.get_uninitialized_action(action_request)(self.settings)(action_request)

--- a/pysoa/server/internal/types.py
+++ b/pysoa/server/internal/types.py
@@ -1,76 +1,71 @@
-import six
+from __future__ import absolute_import, unicode_literals
+
+
+def get_switch(item):
+    if hasattr(item, '__int__'):
+        return item.__int__()
+    if hasattr(getattr(item, 'value', None), '__int__'):
+        return item.value.__int__()
+    raise TypeError('switch does not implement the switch constant interface')
+
+
+def is_switch(item):
+    try:
+        get_switch(item)
+        return True
+    except TypeError:
+        return False
 
 
 class SwitchSet(frozenset):
-    """Immutable set subtype for interacting with switches"""
+    """
+    Immutable set subtype for interacting with switches, which might be integers or might be int-like objects that
+    provide integers in some way.
+    """
 
     def __new__(cls, switches=None):
-        """Create a new SwitchSet instance
-
-        Args:
-            switches: an iterable of integers or objects that implement the
-                switch constant interface.
-        Returns:
-            a new SwitchSet.
-        Raises:
-            TypeError: if switches is not an iterable or if a switch object does
-                not implement the switch constant interface.
         """
+        Create a new uninitialized `SwitchSet` instance.
 
-        return super(SwitchSet, cls).__new__(
-            cls,
-            cls._process_switches(switches or []),
-        )
+        :param switches: An iterable of integers or objects that implement the switch constant interface (provide
+                         `__int__` or provide `value` which is an integer or provides `__int__`)
+        :type switches: iterable
+
+        :return: A new `SwitchSet`
+        :rtype: SwitchSet
+
+        :raise: TypeError
+        """
+        return super(SwitchSet, cls).__new__(cls, (get_switch(switch) for switch in switches or []))
 
     def __contains__(self, switch):
-        """Determine whether or not a switch is in the SwitchSet
-
-        Args:
-            switch: an integer or object that implements the switch constant
-                interface.
-        Returns:
-            a boolean indicating whether or not the switch is active
-            (i.e. in the set)
-        Raises:
-            TypeError: if switch does not implement the switch constant
-                interface.
         """
+        Determine whether or not a switch is in the `SwitchSet`.
 
-        if isinstance(switch, six.integer_types):
-            return super(SwitchSet, self).__contains__(switch)
-        elif isinstance(getattr(switch, 'value', None), int):
-            return super(SwitchSet, self).__contains__(switch.value)
-        else:
-            raise TypeError(
-                'switch does not implement the switch constant interface'
-            )
+        :param switch: An integer or object that implements the switch constant interface (provides `__int__` or
+                       provides `value` which is an integer or provides `__int__`)
+        :type: union[int, provides(__int__), provides(value)]
 
-    @staticmethod
-    def _process_switches(switches):
-        for switch in switches:
-            if isinstance(switch, six.integer_types):
-                yield switch
-            elif isinstance(getattr(switch, 'value', None), int):
-                yield switch.value
-            else:
-                raise TypeError(
-                    'switch does not implement the switch constant interface'
-                )
+        :return: A boolean indicating whether the switch is active (in the set)
+        :rtype: bool
+
+        :raise: TypeError
+        """
+        return super(SwitchSet, self).__contains__(get_switch(switch))
 
 
 class RequestSwitchSet(SwitchSet):
     def is_active(self, switch):
-        """Determine whether or not a switch is active
-
-        Args:
-            switch: an integer or object that implements the switch constant
-                interface.
-        Returns:
-            a boolean indicating whether or not the switch is active
-            (i.e. in the set)
-        Raises:
-            TypeError: if switch does not implement the switch constant
-                interface.
         """
+        Determine whether or not a switch is active.
 
+        :param switch: An integer or object that implements the switch constant interface (provides `__int__` or
+                       provides `value` which is an integer or provides `__int__`)
+        :type: union[int, provides(__int__), provides(value)]
+
+        :return: A boolean indicating whether the switch is active (in the set)
+        :rtype: bool
+
+        :raise: TypeError
+        """
         return switch in self

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -1,6 +1,7 @@
 import attr
 
 from pysoa.common.types import ActionRequest
+from pysoa.server.internal.types import RequestSwitchSet
 
 
 @attr.s
@@ -11,7 +12,10 @@ class EnrichedActionRequest(ActionRequest):
     Contains all the information from ActionRequest, plus some extra information from the
     JobRequest.
     """
-    switches = attr.ib(default=attr.Factory(list))
+    switches = attr.ib(
+        default=attr.Factory(RequestSwitchSet),
+        convert=lambda l: l if isinstance(l, RequestSwitchSet) else RequestSwitchSet(l),
+    )
     context = attr.ib(default=attr.Factory(dict))
     control = attr.ib(default=attr.Factory(dict))
     client = attr.ib(default=None)

--- a/tests/server/action/test_switched.py
+++ b/tests/server/action/test_switched.py
@@ -1,0 +1,253 @@
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+from conformity import fields
+
+from pysoa.common.types import (
+    ActionResponse,
+    Error,
+)
+from pysoa.server.action.base import Action
+from pysoa.server.action.switched import SwitchedAction
+from pysoa.server.errors import ActionError
+from pysoa.server.internal.types import (
+    get_switch,
+    is_switch,
+)
+from pysoa.server.types import EnrichedActionRequest
+
+
+class SwitchTwelve(object):
+    def __int__(self):
+        return 12
+
+
+class ValueSwitch(object):
+    def __init__(self, value):
+        self.value = value
+
+
+class ActionOne(Action):
+    request_schema = fields.Dictionary({'planet': fields.UnicodeString()})
+
+    response_schema = fields.Dictionary({'planet_response': fields.UnicodeString(), 'settings': fields.Anything()})
+
+    def run(self, request):
+        return {'planet_response': request.body['planet'], 'settings': self.settings}
+
+
+def action_two(settings):
+    def action_logic(request):
+        return ActionResponse(action='one', body={'animal_response': request.body['animal'], 'settings': settings})
+    return action_logic
+
+
+def action_three(_):
+    def action_logic(request):
+        return ActionResponse(action='one', body={'building_response': request.body['building']})
+    return action_logic
+
+
+class SwitchedActionOne(SwitchedAction):
+    switch_to_action_map = (
+        (SwitchTwelve(), ActionOne),
+        (5, action_two),
+    )
+
+
+class SwitchedActionTwo(SwitchedAction):
+    switch_to_action_map = (
+        (SwitchedAction.DEFAULT_ACTION, action_three),
+        (ValueSwitch(7), action_two),
+        (ValueSwitch(SwitchTwelve()), ActionOne),
+    )
+
+
+class TestSwitchedAction(unittest.TestCase):
+    def test_action_one_switch_twelve(self):
+        settings = {'foo': 'bar'}
+
+        action = SwitchedActionOne(settings)
+
+        response = action(EnrichedActionRequest(action='one', body={'planet': 'Mars'}, switches=[12]))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual({'planet_response': 'Mars', 'settings': settings}, response.body)
+
+    def test_action_one_switches_twelve_and_five(self):
+        settings = {'baz': 'qux'}
+
+        action = SwitchedActionOne(settings)
+
+        response = action(EnrichedActionRequest(action='one', body={'planet': 'Jupiter'}, switches=[12, 5]))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual({'planet_response': 'Jupiter', 'settings': settings}, response.body)
+
+    def test_action_one_switch_five(self):
+        settings = {'foo': 'bar'}
+
+        action = SwitchedActionOne(settings)
+
+        response = action(EnrichedActionRequest(action='one', body={'animal': 'cat'}, switches=[5]))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual({'animal_response': 'cat', 'settings': settings}, response.body)
+
+    def test_action_no_switches(self):
+        settings = {'foo': 'bar'}
+
+        action = SwitchedActionOne(settings)
+
+        response = action(EnrichedActionRequest(action='one', body={'animal': 'cat'}, switches=[]))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual({'animal_response': 'cat', 'settings': settings}, response.body)
+
+    def test_action_one_switch_twelve_with_errors(self):
+        settings = {'foo': 'bar'}
+
+        action = SwitchedActionOne(settings)
+
+        with self.assertRaises(ActionError) as error_context:
+            action(EnrichedActionRequest(action='one', body={'animal': 'cat'}, switches=[12]))
+
+        self.assertEqual(2, len(error_context.exception.errors))
+        self.assertIn(Error('MISSING', 'Missing key: planet', field='planet'), error_context.exception.errors)
+        self.assertIn(Error('UNKNOWN', 'Extra keys present: animal'), error_context.exception.errors)
+
+    def test_action_two_switch_seven(self):
+        settings = {'baz': 'qux'}
+
+        action = SwitchedActionTwo(settings)
+
+        response = action(EnrichedActionRequest(action='one', body={'animal': 'dog'}, switches=[7]))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual({'animal_response': 'dog', 'settings': settings}, response.body)
+
+    def test_action_two_switch_twelve(self):
+        settings = {'foo': 'bar'}
+
+        action = SwitchedActionTwo(settings)
+
+        response = action(EnrichedActionRequest(action='one', body={'planet': 'Pluto'}, switches=[12]))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual({'planet_response': 'Pluto', 'settings': settings}, response.body)
+
+    def test_action_two_no_switches(self):
+        settings = {'foo': 'bar'}
+
+        action = SwitchedActionTwo(settings)
+
+        response = action(EnrichedActionRequest(
+            action='one',
+            body={'building': 'Empire State Building'},
+            switches=[],
+        ))
+
+        self.assertEqual([], response.errors)
+        self.assertEqual({'building_response': 'Empire State Building'}, response.body)
+
+
+class TestSwitchedActionValidation(unittest.TestCase):
+    def test_cannot_instantiate_base(self):
+        with self.assertRaises(TypeError) as error_context:
+            SwitchedAction({})
+
+        self.assertIn('instantiate', error_context.exception.args[0])
+
+    def test_map_is_none(self):
+        with self.assertRaises(ValueError) as error_context:
+            # noinspection PyUnusedLocal
+            class BadAction(SwitchedAction):
+                switch_to_action_map = None
+
+        self.assertIn('switch_to_action_map', error_context.exception.args[0])
+
+    def test_map_is_not_iterable(self):
+        with self.assertRaises(ValueError) as error_context:
+            # noinspection PyUnusedLocal
+            class BadAction(SwitchedAction):
+                switch_to_action_map = 7
+
+        self.assertIn('switch_to_action_map', error_context.exception.args[0])
+
+    def test_map_is_iterable_but_has_no_length(self):
+        with self.assertRaises(ValueError) as error_context:
+            # noinspection PyUnusedLocal
+            class BadAction(SwitchedAction):
+                switch_to_action_map = (x for x in range(10))
+
+        self.assertIn('switch_to_action_map', error_context.exception.args[0])
+
+    def test_map_is_empty(self):
+        with self.assertRaises(ValueError) as error_context:
+            # noinspection PyUnusedLocal
+            class BadAction(SwitchedAction):
+                switch_to_action_map = ()
+
+        self.assertIn('switch_to_action_map', error_context.exception.args[0])
+
+    def test_map_has_only_one_valid_item(self):
+        with self.assertRaises(ValueError) as error_context:
+            # noinspection PyUnusedLocal
+            class BadAction(SwitchedAction):
+                switch_to_action_map = ((5, ActionOne), )
+
+        self.assertIn('switch_to_action_map', error_context.exception.args[0])
+
+    def test_map_has_multiple_items_but_one_is_invalid_switch(self):
+        with self.assertRaises(ValueError) as error_context:
+            # noinspection PyUnusedLocal
+            class BadAction(SwitchedAction):
+                switch_to_action_map = (
+                    (5, ActionOne),
+                    (TestSwitchedActionValidation, action_two),
+                )
+
+        self.assertIn('switch_to_action_map', error_context.exception.args[0])
+
+    def test_map_has_multiple_items_but_one_is_invalid_action(self):
+        with self.assertRaises(ValueError) as error_context:
+            # noinspection PyUnusedLocal
+            class BadAction(SwitchedAction):
+                switch_to_action_map = (
+                    (5, ActionOne),
+                    (0, 7),
+                )
+
+        self.assertIn('switch_to_action_map', error_context.exception.args[0])
+
+
+class TestSwitchHelpers(unittest.TestCase):
+    def test_is_switch(self):
+        self.assertTrue(is_switch(5))
+        self.assertTrue(is_switch(12348798123498798987919872349879879123498713249161234987134987))
+        self.assertTrue(is_switch(SwitchTwelve()))
+        self.assertTrue(is_switch(ValueSwitch(31)))
+        self.assertTrue(is_switch(ValueSwitch(SwitchTwelve())))
+        self.assertFalse(is_switch('hello'))
+        self.assertFalse(is_switch(Exception()))
+        self.assertFalse(is_switch(ActionOne({})))
+
+    def test_get_switch(self):
+        self.assertEqual(5, get_switch(5))
+        self.assertEqual(
+            12348798123498798987919872349879879123498713249161234987134987,
+            get_switch(12348798123498798987919872349879879123498713249161234987134987),
+        )
+        self.assertEqual(12, get_switch(SwitchTwelve()))
+        self.assertEqual(31, get_switch(ValueSwitch(31)))
+        self.assertEqual(12, get_switch(ValueSwitch(SwitchTwelve())))
+
+        with self.assertRaises(TypeError):
+            get_switch('hello')
+
+        with self.assertRaises(TypeError):
+            get_switch(Exception())
+
+        with self.assertRaises(TypeError):
+            get_switch(ActionOne({}))


### PR DESCRIPTION
Add a `SwitchedAction` class, which facilitates using different actions for a single given action name depending on which switch(es), if any, were sent with the request context.