### PR TITLE
[MINOR] Remove the transport cache as it is no longer needed

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1109,12 +1109,8 @@ There are several ``Settings`` subclasses provided throughout PySOA, and you can
 Client Settings
   Several classes provide schemas specifically for PySOA Clients:
 
-  - ``pysoa.client.settings.ClientSettings`` extends ``SOASettings`` to provide a client-specific schema. It adds:
-
-    - ``transport_cache_time_in_seconds``: Set this value to enable a transport cache that persists across client
-      instances (keyed off of transport settings), defaults to 0 (new transport is created every time a new client is
-      created); we recommend 60 seconds
-
+  - ``pysoa.client.settings.ClientSettings`` extends ``SOASettings`` to provide a client-specific schema. It enforces
+    that ``middleware`` is only Client middleware and that the ``transport`` is only a Client transport.
   - ``pysoa.client.settings.RedisClientSettings`` extends ``ClientSettings`` to enforce the ``RedisClientTransport``
     settings schema on the ``transport`` setting
   - ``pysoa.client.settings.LocalClientSettings`` extends ``ClientSettings`` to enforce the ``LocalClientTransport``

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -621,7 +621,7 @@ Settings Schema Definition
     Optional keys: ``kwargs``
 
 
-- ``transport_cache_time_in_seconds`` - ``integer``: If enabled, uses a per-service transport cache that is keyed off the service name and transport settings, persists across all clients in memory, and expires after this number of seconds. By default, a new transport is created for every new client. Note that this is safe in a multi-processing environment, but not in a multi-threaded environment. You should disable this in a multi-threaded environment. (additional information: ``{u'gte': 0}``)
+- ``transport_cache_time_in_seconds`` - ``anything``: This field is deprecated. The transport cache is no longer supported. This settings field will remain in place until 2018-06-15 to give a safe period for people to remove it from settings, but its value will always be ignored.
 
 Default Values
 **************

--- a/pysoa/client/settings.py
+++ b/pysoa/client/settings.py
@@ -25,13 +25,10 @@ class ClientSettings(SOASettings):
                         'client to the associated service',
         ),
         'transport': BasicClassSchema(BaseClientTransport),
-        'transport_cache_time_in_seconds': fields.Integer(
-            gte=0,
-            description='If enabled, uses a per-service transport cache that is keyed off the service name and '
-                        'transport settings, persists across all clients in memory, and expires after this number of '
-                        'seconds. By default, a new transport is created for every new client. Note that this is safe '
-                        'in a multi-processing environment, but not in a multi-threaded environment. You should '
-                        'disable this in a multi-threaded environment.',
+        'transport_cache_time_in_seconds': fields.Anything(
+            description='This field is deprecated. The transport cache is no longer supported. This settings field '
+                        'will remain in place until 2018-06-15 to give a safe period for people to remove it from '
+                        'settings, but its value will always be ignored.',
         ),
     }
     defaults = {

--- a/tests/client/test_send_receive.py
+++ b/tests/client/test_send_receive.py
@@ -306,30 +306,6 @@ class TestClientSendReceive(TestCase):
         self.assertEqual(response.action, 'action_1')
         self.assertEqual(response.body['foo'], 'bar')
 
-    def test_call_action_with_cached_transport(self):
-        """
-        Client.call_action sends a valid request and returns a valid response without errors using a cached transport.
-        """
-        self.client_settings[SERVICE_NAME]['transport_cache_time_in_seconds'] = 2
-
-        client = Client(self.client_settings)
-        response = client.call_action(SERVICE_NAME, 'action_1')
-        self.assertTrue(isinstance(response, ActionResponse))
-        self.assertEqual(response.action, 'action_1')
-        self.assertEqual(response.body['foo'], 'bar')
-
-        client = Client(self.client_settings)
-        response = client.call_action(SERVICE_NAME, 'action_2')
-        self.assertTrue(isinstance(response, ActionResponse))
-        self.assertEqual(response.action, 'action_2')
-        self.assertEqual(response.body['baz'], 3)
-
-        client = Client(self.client_settings)
-        response = client.call_action(SERVICE_NAME, 'action_1')
-        self.assertTrue(isinstance(response, ActionResponse))
-        self.assertEqual(response.action, 'action_1')
-        self.assertEqual(response.body['foo'], 'bar')
-
 
 class TestClientParallelSendReceive(TestCase):
     """


### PR DESCRIPTION
The transport cache (controlled by the `transport_cache_time_in_seconds` setting), was put in place before we got our Redis connection handling under control, when creating new transports took multiples of milliseconds. Now that we properly handle Redis connections with a thread-safe, global connection cache, creating new transports take nanoseconds, the same as retrieving transports from the cache. Additionaly, the cache is not thread-safe and introduces problems in multi-threaded environments.

As such, we are removing the transport cache from PySOA. This is a backwards-compatible change, because we are simply deprecating the `transport_cache_time_in_seconds` setting, and leaving it in place for some time. There will be a future, breaking change that removes this setting altogether. Currently, its value is completely ignored.