### PR TITLE
[MAJOR] Add a response context dict to all responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ addons:
       - liblua5.2-dev
 python:
   - '2.7'
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'
 cache: pip
 install:
-  - export PKG_CONFIG_PATH="$(python-config --prefix)/lib/pkgconfig:/opt/python/3.3.6/lib/pkgconfig:$PKG_CONFIG_PATH"
+  - export PKG_CONFIG_PATH="$(python-config --prefix)/lib/pkgconfig:$PKG_CONFIG_PATH"
   - echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
   # The above two statements can be removed when/if https://github.com/travis-ci/travis-ci/issues/8217 is fixed
   - pip install -U pip setuptools flake8

--- a/pysoa/common/types.py
+++ b/pysoa/common/types.py
@@ -65,6 +65,7 @@ class JobResponse(object):
         default=attr.Factory(list),
         convert=lambda l: [e if isinstance(e, Error) else Error(**e) for e in l],
     )
+    context = attr.ib(default=attr.Factory(dict))
     actions = attr.ib(
         default=attr.Factory(list),
         convert=lambda l: [a if isinstance(a, ActionResponse) else ActionResponse(**a) for a in l],

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -278,6 +278,8 @@ class Server(object):
                 self.execute_job,
             )
             job_response = wrapper(job_request)
+            if 'correlation_id' in job_request['context']:
+                job_response.context['correlation_id'] = job_request['context']['correlation_id']
         except JobError as e:
             self.metrics.counter('server.error.job_error').increment()
             job_response = JobResponse(

--- a/tests/client/test_send_receive.py
+++ b/tests/client/test_send_receive.py
@@ -284,6 +284,7 @@ class TestClientSendReceive(TestCase):
             response = client.call_actions(SERVICE_NAME, actions, raise_action_errors=False)
             self.assertEqual(response.actions[0].body, {'foo': 'bar'})
             self.assertEqual(response.actions[1].errors, error_expected)
+            self.assertIsNotNone(response.context['correlation_id'])
 
     def test_call_actions_raises_exception_on_job_error(self):
         """Client.call_actions raises Client.JobError when a JobError occurs on the server."""


### PR DESCRIPTION
We already have a request context, which includes things like the correlation ID, session ID, locale, authentication/authorization information, etc. We now have a need of a response context for the service to send job-level response information back to the client. (This change also removes support for Python 3.3, as the build tools we use no longer support it.)

This is a backwards-incompatible change. All service clients must be upgraded before service servers are upgraded. When a client deserializes a response, it sends the response dict to `JobResponse(**response_dict)`. This will error with an unexpected keyword argument `context` if the client hasn't been upgraded.