### PR TITLE
[MINOR] Add option to suppress responses for send-and-forget

### DIFF
--- a/docs/update_reference_docs.py
+++ b/docs/update_reference_docs.py
@@ -282,7 +282,7 @@ def _pretty_introspect(value, depth=1, nullable=''):
                 documentation += ' '
             else:
                 documentation += '\n{}'.format(first)
-            documentation += 'Optional keys: ``{}``\n'.format('``, ``'.join(value.optional_keys))
+            documentation += 'Optional keys: ``{}``\n'.format('``, ``'.join(sorted(value.optional_keys)))
     elif isinstance(value, fields.SchemalessDictionary):
         documentation += 'flexible ``dict``{}: {}\n'.format(nullable, description)
         documentation += '\n{}keys\n{}{}\n'.format(first, second, _pretty_introspect(value.key_type, depth + 1))

--- a/pysoa/common/transport/redis_gateway/settings.py
+++ b/pysoa/common/transport/redis_gateway/settings.py
@@ -59,6 +59,13 @@ class RedisTransportSchema(BasicClassSchema):
                     *REDIS_BACKEND_TYPES,
                     description='Which backend (standard or sentinel) should be used for this Redis transport'
                 ),
+                'log_messages_larger_than_bytes': fields.Integer(
+                    description='By default, messages larger than 100KB that do not trigger errors (see '
+                                '`maximum_message_size_in_bytes`) will be logged with level WARNING to a logger named '
+                                '`pysoa.transport.oversized_message`. To disable this behavior, set this setting to '
+                                '0. Or, you can set it to some other number to change the threshold that triggers '
+                                'logging.',
+                ),
                 'maximum_message_size_in_bytes': fields.Integer(
                     description='The maximum message size, in bytes, that is permitted to be transmitted over this '
                                 'transport (defaults to 100KB on the client and 250KB on the server)',
@@ -82,6 +89,7 @@ class RedisTransportSchema(BasicClassSchema):
             },
             optional_keys=[
                 'backend_layer_kwargs',
+                'log_messages_larger_than_bytes',
                 'maximum_message_size_in_bytes',
                 'message_expiry_in_seconds',
                 'queue_capacity',

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -171,7 +171,8 @@ class Server(object):
 
             # Send the response message
             try:
-                self.transport.send_response_message(request_id, meta, response_message)
+                if not job_request['control'].get('suppress_response', False):
+                    self.transport.send_response_message(request_id, meta, response_message)
             except MessageTooLarge as e:
                 self.metrics.counter('server.error.response_too_large').increment()
                 job_response = self.handle_job_error_code(


### PR DESCRIPTION
We've started using a send-and-forget concept, where we send a request but neither care about nor wait on a response. In these cases, the response the server sends needlessly sits in the Redis queue for 60 seconds until it expires. Using a `suppress_response` flag, you can now implement send-and-forget and instruct the server to not send a response, in order to conserve resources.