### PR TITLE
[MINOR] Apply isort and clean up imports

### DIFF
--- a/pysoa/__init__.py
+++ b/pysoa/__init__.py
@@ -1,3 +1,12 @@
 from __future__ import absolute_import
 
-from pysoa.version import __version__, __version_info__  # noqa
+from pysoa.version import (
+    __version__,
+    __version_info__,
+)
+
+
+__all__ = (
+    '__version__',
+    '__version_info__',
+)

--- a/pysoa/client/README.md
+++ b/pysoa/client/README.md
@@ -1,2 +1,0 @@
-# pysoa-client
-The client package for pysoa.

--- a/pysoa/client/__init__.py
+++ b/pysoa/client/__init__.py
@@ -1,5 +1,8 @@
-from .client import Client
+from __future__ import absolute_import
 
-__all__ = [
+from pysoa.client.client import Client
+
+
+__all__ = (
     'Client',
-]
+)

--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -1,4 +1,7 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import collections
 import random

--- a/pysoa/client/expander.py
+++ b/pysoa/client/expander.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from conformity import fields
 import six

--- a/pysoa/client/settings.py
+++ b/pysoa/client/settings.py
@@ -1,4 +1,7 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from conformity import fields
 

--- a/pysoa/common/constants.py
+++ b/pysoa/common/constants.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from conformity.error import (  # noqa
     ERROR_CODE_INVALID,

--- a/pysoa/common/logging.py
+++ b/pysoa/common/logging.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import logging
 import threading

--- a/pysoa/common/metrics.py
+++ b/pysoa/common/metrics.py
@@ -1,4 +1,7 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import abc
 import enum

--- a/pysoa/common/schemas.py
+++ b/pysoa/common/schemas.py
@@ -1,4 +1,7 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from conformity import fields
 

--- a/pysoa/common/serializer/__init__.py
+++ b/pysoa/common/serializer/__init__.py
@@ -1,4 +1,10 @@
-from .json_serializer import JSONSerializer  # flake8: noqa
-from .msgpack_serializer import MsgpackSerializer
+from __future__ import absolute_import
 
-__all__ = ['JSONSerializer', 'MsgpackSerializer']
+from pysoa.common.serializer.json_serializer import JSONSerializer
+from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer
+
+
+__all__ = (
+    'JSONSerializer',
+    'MsgpackSerializer',
+)

--- a/pysoa/common/serializer/json_serializer.py
+++ b/pysoa/common/serializer/json_serializer.py
@@ -1,11 +1,17 @@
-from pysoa.common.serializer.base import Serializer as BaseSerializer
-from pysoa.common.serializer.exceptions import (
-    InvalidMessage,
-    InvalidField,
+from __future__ import (
+    absolute_import,
+    unicode_literals,
 )
 
 import json
+
 import six
+
+from pysoa.common.serializer.base import Serializer as BaseSerializer
+from pysoa.common.serializer.exceptions import (
+    InvalidField,
+    InvalidMessage,
+)
 
 
 class JSONSerializer(BaseSerializer):

--- a/pysoa/common/serializer/msgpack_serializer.py
+++ b/pysoa/common/serializer/msgpack_serializer.py
@@ -1,18 +1,22 @@
-from __future__ import absolute_import, division  # do not import unicode literals in this file
+# do not import unicode_literals in this file
+from __future__ import (
+    absolute_import,
+    division,
+)
 
-import decimal
 import datetime
+import decimal
 import struct
 
 import currint
-from pysoa.common.serializer.base import Serializer as BaseSerializer
-from pysoa.common.serializer.exceptions import (
-    InvalidMessage,
-    InvalidField,
-)
+import msgpack
 import six
 
-import msgpack
+from pysoa.common.serializer.base import Serializer as BaseSerializer
+from pysoa.common.serializer.exceptions import (
+    InvalidField,
+    InvalidMessage,
+)
 
 
 class MsgpackSerializer(BaseSerializer):

--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -1,8 +1,11 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
+import copy
 import importlib
 import itertools
-import copy
 
 from conformity import fields
 from conformity.validator import validate

--- a/pysoa/common/transport/__init__.py
+++ b/pysoa/common/transport/__init__.py
@@ -1,9 +1,12 @@
-from .local import (
+from __future__ import absolute_import
+
+from pysoa.common.transport.local import (
     LocalClientTransport,
     LocalServerTransport,
 )
 
-__all__ = [
+
+__all__ = (
     'LocalClientTransport',
     'LocalServerTransport',
-]
+)

--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -12,7 +12,10 @@ is not business logic. For example, if your implementation has multiple serializ
 types, the metadata may include a mime type to tell the endpoint receiving the message
 which type of serializer to use.
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import abc
 import threading

--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -1,14 +1,18 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
 from collections import deque
 
-import six
 from conformity import fields
+import six
 
 from pysoa.common.settings import (
-    resolve_python_path,
     BasicClassSchema,
+    resolve_python_path,
 )
-from .base import (
+from pysoa.common.transport.base import (
     ClientTransport,
     ServerTransport,
 )

--- a/pysoa/common/transport/redis_gateway/backend/base.py
+++ b/pysoa/common/transport/redis_gateway/backend/base.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import abc
 import binascii

--- a/pysoa/common/transport/redis_gateway/backend/sentinel.py
+++ b/pysoa/common/transport/redis_gateway/backend/sentinel.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import itertools
 import random

--- a/pysoa/common/transport/redis_gateway/backend/standard.py
+++ b/pysoa/common/transport/redis_gateway/backend/standard.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import redis
 import six

--- a/pysoa/common/transport/redis_gateway/client.py
+++ b/pysoa/common/transport/redis_gateway/client.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import uuid
 

--- a/pysoa/common/transport/redis_gateway/core.py
+++ b/pysoa/common/transport/redis_gateway/core.py
@@ -1,13 +1,16 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
-import random
-import six
-import time
-import logging
 from copy import deepcopy
+import logging
+import random
+import time
 
 import attr
 import redis
+import six
 
 from pysoa.common.logging import RecursivelyCensoredDictWrapper
 from pysoa.common.metrics import (
@@ -17,11 +20,11 @@ from pysoa.common.metrics import (
 )
 from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer
 from pysoa.common.transport.exceptions import (
-    MessageTooLarge,
-    MessageReceiveError,
-    MessageSendError,
     InvalidMessageError,
+    MessageReceiveError,
     MessageReceiveTimeout,
+    MessageSendError,
+    MessageTooLarge,
 )
 from pysoa.common.transport.redis_gateway.backend.base import CannotGetConnectionError
 from pysoa.common.transport.redis_gateway.backend.sentinel import SentinelRedisClient

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from pysoa.common.metrics import TimerResolution
 from pysoa.common.transport.base import ServerTransport

--- a/pysoa/common/transport/redis_gateway/settings.py
+++ b/pysoa/common/transport/redis_gateway/settings.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from conformity import fields
 

--- a/pysoa/common/types.py
+++ b/pysoa/common/types.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import attr
 import six
 

--- a/pysoa/server/README.md
+++ b/pysoa/server/README.md
@@ -1,7 +1,0 @@
-# pysoa-server
-SOA Server reference Python implementation.
-
-## Running tests
-```python
-python setup.py test
-```

--- a/pysoa/server/__init__.py
+++ b/pysoa/server/__init__.py
@@ -1,8 +1,11 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from pysoa.server.server import Server
 
 
-__all__ = [
+__all__ = (
     'Server',
-]
+)

--- a/pysoa/server/action/__init__.py
+++ b/pysoa/server/action/__init__.py
@@ -1,5 +1,14 @@
-from pysoa.server.action.base import (  # noqa
+from __future__ import absolute_import
+
+from pysoa.server.action.base import (
     Action,
     ActionError,
     ActionResponse,
+)
+
+
+__all__ = (
+    'Action',
+    'ActionError',
+    'ActionResponse',
 )

--- a/pysoa/server/action/base.py
+++ b/pysoa/server/action/base.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import abc
 

--- a/pysoa/server/action/introspection.py
+++ b/pysoa/server/action/introspection.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import re
 

--- a/pysoa/server/action/status.py
+++ b/pysoa/server/action/status.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import abc
 import platform

--- a/pysoa/server/action/switched.py
+++ b/pysoa/server/action/switched.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import abc
 

--- a/pysoa/server/autoreload.py
+++ b/pysoa/server/autoreload.py
@@ -44,7 +44,11 @@ The following changes were made to the borrowed code. This is a summary only, an
     - Renamed a bunch of variables and functions/methods to reduce ambiguity and have more-self-documenting code.
     - Added considerable documentation about the operation of the reloader.
 """
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
 
 import abc
 import os
@@ -56,6 +60,7 @@ import threading
 import time
 
 import six
+
 
 USE_PY_INOTIFY = False
 try:
@@ -71,7 +76,9 @@ except ImportError:
     pyinotify = None
 
 
-__all__ = ['get_reloader']
+__all__ = (
+    'get_reloader',
+)
 
 
 NEED_RELOAD_EXIT_CODE = 3

--- a/pysoa/server/internal/types.py
+++ b/pysoa/server/internal/types.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 
 def get_switch(item):

--- a/pysoa/server/schemas.py
+++ b/pysoa/server/schemas.py
@@ -1,3 +1,8 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
 from conformity.fields import (
     Boolean,
     Dictionary,

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -1,13 +1,16 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import argparse
 import importlib
 import logging
 import logging.config
 import os
+import signal
 import sys
 import traceback
-import signal
 
 import attr
 import six
@@ -35,14 +38,14 @@ from pysoa.common.types import (
     JobResponse,
     UnicodeKeysDict,
 )
-from pysoa.server.internal.types import RequestSwitchSet
 from pysoa.server.errors import (
     ActionError,
     JobError,
 )
-from pysoa.server.types import EnrichedActionRequest
+from pysoa.server.internal.types import RequestSwitchSet
 from pysoa.server.schemas import JobRequestSchema
 from pysoa.server.settings import PolymorphicServerSettings
+from pysoa.server.types import EnrichedActionRequest
 import pysoa.version
 
 

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import functools
 from logging.handlers import SysLogHandler

--- a/pysoa/server/standalone.py
+++ b/pysoa/server/standalone.py
@@ -1,9 +1,15 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import sys
 
 
-__all__ = ['simple_main', 'django_main']
+__all__ = (
+    'django_main',
+    'simple_main',
+)
 
 
 if sys.path[0] and not sys.path[0].endswith('/bin'):

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import attr
 
 from pysoa.common.types import ActionRequest

--- a/pysoa/test/compatibility.py
+++ b/pysoa/test/compatibility.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
+
 try:
-    import mock  # noqa
+    import mock
     # First we try to import the Python 2 backport library of Mock, because if the project is using it, we should use it
 except ImportError as e:
     try:

--- a/pysoa/test/factories.py
+++ b/pysoa/test/factories.py
@@ -1,11 +1,15 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
-import factory
 import importlib
 
+import factory
+
 from pysoa.server import Server
-from pysoa.server.settings import ServerSettings
 from pysoa.server.action import Action
+from pysoa.server.settings import ServerSettings
 
 
 class ServerSettingsFactory(factory.Factory):

--- a/pysoa/test/plan/__init__.py
+++ b/pysoa/test/plan/__init__.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import abc
 import os

--- a/pysoa/test/plan/errors.py
+++ b/pysoa/test/plan/errors.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import codecs
 

--- a/pysoa/test/plan/grammar/__init__.py
+++ b/pysoa/test/plan/grammar/__init__.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import inspect
 import re

--- a/pysoa/test/plan/grammar/assertions.py
+++ b/pysoa/test/plan/grammar/assertions.py
@@ -1,12 +1,15 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import pprint
 
 import six
 
 from pysoa.test.plan.grammar.tools import (
-    path_get,
     get_all_paths,
+    path_get,
 )
 
 

--- a/pysoa/test/plan/grammar/data_types.py
+++ b/pysoa/test/plan/grammar/data_types.py
@@ -1,13 +1,14 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import base64
 import datetime
 import decimal
 import re
 
-from pyparsing import (
-    oneOf,
-)
+from pyparsing import oneOf
 import pytz
 import six
 

--- a/pysoa/test/plan/grammar/directive.py
+++ b/pysoa/test/plan/grammar/directive.py
@@ -38,19 +38,22 @@ OR
 
 Register your directive using the `register_directive` function.
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import abc
-import pkg_resources
 import sys
 
+import pkg_resources
 from pyparsing import (
-    alphanums,
-    nums,
     Literal,
     Optional,
-    restOfLine,
     Word,
+    alphanums,
+    nums,
+    restOfLine,
 )
 import six
 

--- a/pysoa/test/plan/grammar/directives/expects_errors.py
+++ b/pysoa/test/plan/grammar/directives/expects_errors.py
@@ -1,14 +1,17 @@
 """
 Expect error directives
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from pyparsing import (
-    alphanums,
     Literal,
     Optional,
-    restOfLine,
     Word,
+    alphanums,
+    restOfLine,
 )
 import six
 
@@ -18,12 +21,10 @@ from pysoa.test.plan.grammar.assertions import (
     assert_expected_list_subset_of_actual,
     assert_lists_match_any_order,
 )
+from pysoa.test.plan.grammar.data_types import AnyValue
 from pysoa.test.plan.grammar.directive import (
     ActionDirective,
     register_directive,
-)
-from pysoa.test.plan.grammar.data_types import (
-    AnyValue,
 )
 from pysoa.test.plan.grammar.tools import (
     path_get,

--- a/pysoa/test/plan/grammar/directives/expects_values.py
+++ b/pysoa/test/plan/grammar/directives/expects_values.py
@@ -1,7 +1,10 @@
 """
 Expect action directives
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from pyparsing import (
     CaselessLiteral,
@@ -22,9 +25,9 @@ from pysoa.test.plan.grammar.data_types import (
 )
 from pysoa.test.plan.grammar.directive import (
     ActionDirective,
-    register_directive,
     VarNameGrammar,
     VarValueGrammar,
+    register_directive,
 )
 from pysoa.test.plan.grammar.tools import path_put
 

--- a/pysoa/test/plan/grammar/directives/inputs.py
+++ b/pysoa/test/plan/grammar/directives/inputs.py
@@ -1,12 +1,15 @@
 """
 Action input directives
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from pyparsing import (
     Literal,
+    Optional,
     oneOf,
-    Optional
 )
 
 from pysoa.test.plan.grammar.data_types import (
@@ -15,9 +18,9 @@ from pysoa.test.plan.grammar.data_types import (
 )
 from pysoa.test.plan.grammar.directive import (
     ActionDirective,
-    register_directive,
     VarNameGrammar,
     VarValueGrammar,
+    register_directive,
 )
 from pysoa.test.plan.grammar.tools import path_put
 

--- a/pysoa/test/plan/grammar/directives/mock.py
+++ b/pysoa/test/plan/grammar/directives/mock.py
@@ -1,7 +1,10 @@
 """
 Directives for mocking
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import json
 import sys
@@ -10,8 +13,8 @@ import traceback
 from pyparsing import (
     Literal,
     Optional,
-    oneOf,
     Regex,
+    oneOf,
 )
 import six
 
@@ -19,10 +22,10 @@ from pysoa.common.settings import resolve_python_path
 from pysoa.test.compatibility import mock as unittest_mock
 from pysoa.test.plan.errors import FixtureSyntaxError
 from pysoa.test.plan.grammar.directive import (
-    Directive,
     ActionDirective,
+    Directive,
+    VarValueGrammar,
     register_directive,
-    VarValueGrammar
 )
 
 

--- a/pysoa/test/plan/grammar/directives/plans.py
+++ b/pysoa/test/plan/grammar/directives/plans.py
@@ -1,15 +1,18 @@
 """
 Top level plan oriented directives
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from pyparsing import (
-    alphanums,
     Literal,
     Optional,
-    restOfLine,
     Suppress,
     Word,
+    alphanums,
+    restOfLine,
 )
 
 from pysoa.test.plan.errors import FixtureSyntaxError

--- a/pysoa/test/plan/grammar/directives/stub_action.py
+++ b/pysoa/test/plan/grammar/directives/stub_action.py
@@ -1,17 +1,20 @@
 """
 Directives for stubbing calls to other services
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import sys
 import traceback
 
 from pyparsing import (
-    alphanums,
     Literal,
     Optional,
-    restOfLine,
     Word,
+    alphanums,
+    restOfLine,
 )
 import six
 
@@ -23,11 +26,11 @@ from pysoa.test.plan.grammar.data_types import (
     get_parsed_data_type_value,
 )
 from pysoa.test.plan.grammar.directive import (
-    Directive,
     ActionDirective,
-    register_directive,
+    Directive,
     VarNameGrammar,
-    VarValueGrammar
+    VarValueGrammar,
+    register_directive,
 )
 from pysoa.test.plan.grammar.tools import path_put
 from pysoa.test.stub_service import stub_action

--- a/pysoa/test/plan/grammar/directives/time.py
+++ b/pysoa/test/plan/grammar/directives/time.py
@@ -1,7 +1,10 @@
 """
 Directives for freezing time during test execution
 """
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import datetime
 
@@ -9,10 +12,10 @@ from pyparsing import Literal
 
 from pysoa.test.plan.errors import FixtureSyntaxError
 from pysoa.test.plan.grammar.directive import (
-    Directive,
     ActionDirective,
+    Directive,
+    VarValueGrammar,
     register_directive,
-    VarValueGrammar
 )
 
 

--- a/pysoa/test/plan/grammar/tools.py
+++ b/pysoa/test/plan/grammar/tools.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import re
 
@@ -10,7 +13,7 @@ from pyparsing import (
     Or,
     Regex,
     White,
-    Word
+    Word,
 )
 import six
 

--- a/pysoa/test/plan/parser.py
+++ b/pysoa/test/plan/parser.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import codecs
 import copy
@@ -6,9 +9,6 @@ import functools
 import os
 
 from pyparsing import (
-    col as get_parse_column,
-    line as get_parse_line,
-    lineno as get_parse_line_number,
     LineEnd,
     LineStart,
     MatchFirst,
@@ -16,6 +16,9 @@ from pyparsing import (
     ParseException,
     StringEnd,
     StringStart,
+    col as get_parse_column,
+    line as get_parse_line,
+    lineno as get_parse_line_number,
 )
 
 from pysoa.test.plan.errors import (
@@ -25,9 +28,9 @@ from pysoa.test.plan.errors import (
 from pysoa.test.plan.grammar.data_types import DataTypeConversionError
 from pysoa.test.plan.grammar.directive import get_all_directives
 from pysoa.test.plan.grammar.tools import (
+    get_all_paths,
     path_get,
     path_put,
-    get_all_paths,
 )
 
 

--- a/pysoa/test/plugins/pytest.py
+++ b/pysoa/test/plugins/pytest.py
@@ -1,19 +1,22 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from functools import wraps
 import re
 import sys
 from unittest import SkipTest
 
-import py
-import six
+from _pytest._code.code import TracebackEntry
+from _pytest._code.source import Source
+from _pytest.mark import MARK_GEN
 from _pytest.unittest import (
     TestCaseFunction,
     UnitTestCase,
 )
-from _pytest._code.code import TracebackEntry
-from _pytest._code.source import Source
-from _pytest.mark import MARK_GEN
+import py
+import six
 
 
 try:

--- a/pysoa/test/server.py
+++ b/pysoa/test/server.py
@@ -1,4 +1,7 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import importlib
 import os

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -1,8 +1,11 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from collections import (
-    defaultdict,
     OrderedDict,
+    defaultdict,
 )
 from functools import wraps
 import re

--- a/pysoa/utils.py
+++ b/pysoa/utils.py
@@ -1,5 +1,8 @@
 # coding=utf-8
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import six
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,30 @@ license_file = LICENSE
 exclude = .git,.env/*,docs/*,build/*,.eggs/*,*.egg-info/*
 max-line-length = 120
 
+[isort]
+# Vertical Hanging Indent
+multi_line_output = 3
+# Formatting settings
+line_length = 120
+include_trailing_comma = 1
+combine_as_imports = 1
+force_grid_wrap = 2
+use_parentheses = 1
+force_sort_within_sections = 1
+lines_after_imports = 2
+skip=pysoa/test/plan/grammar/directives/__init__.py
+skip_glob=*.git/*,*.env/*,*/docs/*,*/build/*,*/.eggs/*,*.egg-info/*
+not_skip=__init__.py
+# Section ordering
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,CURRENT_PROJECT,LOCALFOLDER,TESTS
+no_lines_before=LOCALFOLDER
+# Section for third party packages
+known_third_party=addict,attr,conformity,currint,dateutil,ddtrace,django,factory,faker,freezegun,gargoyle,msgpack, \
+    pytest,pytest_django,pytz,requests,six
+# Section for specific project imports
+known_current_project=pysoa
+known_tests=tests
+
 [aliases]
 test=pytest
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
-from setuptools import setup, find_packages
+from setuptools import (
+    find_packages,
+    setup,
+)
 
 from pysoa import __version__
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,3 +1,8 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
 from invoke_release.tasks import *  # noqa: F403
 
 

--- a/tests/client/test_expander.py
+++ b/tests/client/test_expander.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from unittest import TestCase
 

--- a/tests/client/test_expansions.py
+++ b/tests/client/test_expansions.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from unittest import TestCase
 

--- a/tests/client/test_send_receive.py
+++ b/tests/client/test_send_receive.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from unittest import TestCase
 
@@ -8,9 +11,7 @@ from pysoa.common.constants import (
     ERROR_CODE_INVALID,
     ERROR_CODE_SERVER_ERROR,
 )
-from pysoa.common.transport.base import (
-    ClientTransport,
-)
+from pysoa.common.transport.base import ClientTransport
 from pysoa.common.transport.exceptions import (
     MessageReceiveError,
     MessageSendError,
@@ -18,8 +19,8 @@ from pysoa.common.transport.exceptions import (
 from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
-    JobResponse,
     Error,
+    JobResponse,
 )
 from pysoa.server.errors import JobError
 from pysoa.server.server import Server

--- a/tests/common/test_logging.py
+++ b/tests/common/test_logging.py
@@ -1,8 +1,12 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
-import six
 import threading
 import unittest
+
+import six
 
 from pysoa.common.logging import (
     PySOALogContextFilter,

--- a/tests/common/test_serializers.py
+++ b/tests/common/test_serializers.py
@@ -1,7 +1,10 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
-import decimal
 import datetime
+import decimal
 
 import currint
 import pytest
@@ -11,8 +14,8 @@ from pysoa.common.serializer import (
     MsgpackSerializer,
 )
 from pysoa.common.serializer.exceptions import (
-    InvalidMessage,
     InvalidField,
+    InvalidMessage,
 )
 
 

--- a/tests/common/test_settings.py
+++ b/tests/common/test_settings.py
@@ -1,12 +1,20 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 
+from conformity import fields
 import pytest
 
 from pysoa.client.client import Client
 from pysoa.client.middleware import ClientMiddleware
 from pysoa.client.settings import ClientSettings
+from pysoa.common.serializer import (
+    JSONSerializer,
+    MsgpackSerializer,
+)
 from pysoa.common.settings import (
     Settings,
     SOASettings,
@@ -15,17 +23,11 @@ from pysoa.common.transport.redis_gateway.client import RedisClientTransport
 from pysoa.common.transport.redis_gateway.constants import REDIS_BACKEND_TYPE_STANDARD
 from pysoa.common.transport.redis_gateway.core import RedisTransportCore
 from pysoa.common.transport.redis_gateway.server import RedisServerTransport
-from pysoa.common.serializer import (
-    JSONSerializer,
-    MsgpackSerializer,
-)
 from pysoa.server.server import Server
 from pysoa.server.settings import (
     PolymorphicServerSettings,
     ServerSettings,
 )
-
-from conformity import fields
 
 
 class SettingsWithSimpleSchema(Settings):

--- a/tests/common/test_test.py
+++ b/tests/common/test_test.py
@@ -1,4 +1,7 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from unittest import TestCase
 

--- a/tests/common/transport/redis_gateway/backend/test_sentinel.py
+++ b/tests/common/transport/redis_gateway/backend/test_sentinel.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 
@@ -9,7 +12,8 @@ from pysoa.common.transport.redis_gateway.backend.base import CannotGetConnectio
 from pysoa.common.transport.redis_gateway.backend.sentinel import SentinelRedisClient
 from pysoa.test.compatibility import mock
 
-from .test_standard import mockredis  # To ensure all the patching over there happens over here
+# To ensure all the patching over there happens over here
+from tests.common.transport.redis_gateway.backend.test_standard import mockredis
 
 
 class MockSentinelRedis(mockredis.MockRedis):

--- a/tests/common/transport/redis_gateway/backend/test_standard.py
+++ b/tests/common/transport/redis_gateway/backend/test_standard.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 
@@ -10,6 +13,7 @@ import six
 
 from pysoa.common.transport.redis_gateway.backend.standard import StandardRedisClient
 from pysoa.test.compatibility import mock
+
 
 #####
 # The following MockRedis fixes were submitted as part of https://github.com/locationlabs/mockredis/pull/133. They can

--- a/tests/common/transport/redis_gateway/test_client.py
+++ b/tests/common/transport/redis_gateway/test_client.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 import uuid

--- a/tests/common/transport/redis_gateway/test_core.py
+++ b/tests/common/transport/redis_gateway/test_core.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import datetime
 import time
@@ -18,13 +21,14 @@ from pysoa.common.transport.exceptions import (
 )
 from pysoa.common.transport.redis_gateway.backend.base import CannotGetConnectionError
 from pysoa.common.transport.redis_gateway.constants import (
-    REDIS_BACKEND_TYPE_STANDARD,
     REDIS_BACKEND_TYPE_SENTINEL,
+    REDIS_BACKEND_TYPE_STANDARD,
 )
 from pysoa.common.transport.redis_gateway.core import RedisTransportCore
 from pysoa.test.compatibility import mock
 
-from .backend.test_standard import mockredis  # To ensure all the patching over there happens over here
+# To ensure all the patching over there happens over here
+from tests.common.transport.redis_gateway.backend.test_standard import mockredis
 
 
 @attr.s

--- a/tests/common/transport/redis_gateway/test_server.py
+++ b/tests/common/transport/redis_gateway/test_server.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 import uuid

--- a/tests/common/transport/redis_gateway/test_threading.py
+++ b/tests/common/transport/redis_gateway/test_threading.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import threading
 import time

--- a/tests/server/action/test_base.py
+++ b/tests/server/action/test_base.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 

--- a/tests/server/action/test_introspection.py
+++ b/tests/server/action/test_introspection.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 

--- a/tests/server/action/test_status.py
+++ b/tests/server/action/test_status.py
@@ -1,4 +1,8 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    print_function,
+    unicode_literals,
+)
 
 import platform
 import unittest
@@ -17,8 +21,8 @@ from pysoa.common.types import (
 )
 from pysoa.server.action.status import (
     BaseStatusAction,
-    make_default_status_action_class,
     StatusActionFactory,
+    make_default_status_action_class,
 )
 from pysoa.server.types import EnrichedActionRequest
 from pysoa.test.stub_service import stub_action

--- a/tests/server/action/test_switched.py
+++ b/tests/server/action/test_switched.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 

--- a/tests/server/test_autoreloader.py
+++ b/tests/server/test_autoreloader.py
@@ -1,11 +1,14 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import importlib
 import os
 import signal
 import sys
-import unittest
 import time
+import unittest
 
 import pysoa
 import pysoa.client
@@ -13,13 +16,13 @@ import pysoa.server
 import pysoa.server.autoreload
 # noinspection PyProtectedMember
 from pysoa.server.autoreload import (
-    _clean_files,  # noqa
+    NEED_RELOAD_EXIT_CODE,
+    AbstractReloader,
     _PollingReloader,
     _PyInotifyReloader,
-    AbstractReloader,
     get_reloader,
-    NEED_RELOAD_EXIT_CODE,
 )
+from pysoa.server.autoreload import _clean_files  # noqa
 from pysoa.test.compatibility import mock
 import pysoa.version
 

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -1,13 +1,17 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
-import six
 import uuid
+
 import pytest
+import six
 
 from pysoa.server.schemas import (
     ActionRequestSchema,
-    ControlHeaderSchema,
     ContextHeaderSchema,
+    ControlHeaderSchema,
     JobRequestSchema,
 )
 

--- a/tests/server/test_server/test_configuration.py
+++ b/tests/server/test_server/test_configuration.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from unittest import TestCase
 

--- a/tests/server/test_server/test_process_job.py
+++ b/tests/server/test_server/test_process_job.py
@@ -1,12 +1,15 @@
-from __future__ import unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from unittest import TestCase
 
-from pysoa.server.server import Server
+from pysoa.common.constants import ERROR_CODE_INVALID
+from pysoa.common.types import Error
 from pysoa.server.errors import ActionError
 from pysoa.server.middleware import ServerMiddleware
-from pysoa.common.types import Error
-from pysoa.common.constants import ERROR_CODE_INVALID
+from pysoa.server.server import Server
 from pysoa.test import factories
 
 

--- a/tests/server/test_standalone.py
+++ b/tests/server/test_standalone.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import os
 import signal

--- a/tests/test/plan/grammar/test_assertions.py
+++ b/tests/test/plan/grammar/test_assertions.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 

--- a/tests/test/plan/grammar/test_data_types.py
+++ b/tests/test/plan/grammar/test_data_types.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import base64
 import copy

--- a/tests/test/plan/grammar/test_tools.py
+++ b/tests/test/plan/grammar/test_tools.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 

--- a/tests/test/plan/test_001_fixtures_work.py
+++ b/tests/test/plan/test_001_fixtures_work.py
@@ -1,22 +1,25 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import datetime
 import os
 import random
 import sys
-import uuid
 import unittest
+import uuid
 
 from conformity import fields
 import pytest
 import six
 
 from pysoa.common.types import Error
+from pysoa.server.action.base import Action
 from pysoa.server.errors import (
     ActionError,
     JobError,
 )
-from pysoa.server.action.base import Action
 from pysoa.server.server import Server
 from pysoa.test.plan import ServicePlanTestCase
 

--- a/tests/test/plan/test_002_plugin_stats.py
+++ b/tests/test/plan/test_002_plugin_stats.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from pysoa.test.plugins.pytest import PLUGIN_STATISTICS
 

--- a/tests/test/plan/test_parser.py
+++ b/tests/test/plan/test_parser.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import codecs
 import contextlib

--- a/tests/test/plan/test_plan_execution_errors.py
+++ b/tests/test/plan/test_plan_execution_errors.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import os
 import unittest

--- a/tests/test/test_stub_service.py
+++ b/tests/test/test_stub_service.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import random
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 from unittest import TestCase
 


### PR DESCRIPTION
- Add isort config to `setup.cfg` and apply isort to the entire project
- Add `absolute_import` and `unicode_literals` `__future__` imports in many places missing them
- General import cleanup, including standardizing `__all__` in several places
- Remove three unused/blank/unfinished `README.md` files located in Python submodules