### PR TITLE
Pass position in job to action for multi-action jobs

### DIFF
--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -375,6 +375,7 @@ class Server(object):
                 context=job_request['context'],
                 control=job_request['control'],
                 client=job_request['client'],
+                job_index=i,
             )
             action_in_class_map = action_request.action in self.action_class_map
             if action_in_class_map or action_request.action in ('status', 'introspect'):

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -21,3 +21,4 @@ class EnrichedActionRequest(ActionRequest):
     context = attr.ib(default=attr.Factory(dict))
     control = attr.ib(default=attr.Factory(dict))
     client = attr.ib(default=None)
+    job_index = attr.ib(default=0)


### PR DESCRIPTION
When there are multiple actions in a request, it is sometimes useful for the action to know its position in the job.