### PR TITLE
[MINOR] Add support for a heartbeat file

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2055,6 +2055,7 @@ Settings Schema Definition
   - ``shutdown_grace`` - ``integer``: Seconds to forcefully shutdown after harakiri is triggered if shutdown does not occur (additional information: ``{u'gt': 0}``)
   - ``timeout`` - ``integer``: Seconds of inactivity before harakiri is triggered; 0 to disable, defaults to 300 (additional information: ``{u'gte': 0}``)
 
+- ``heartbeat_file`` - ``unicode`` (nullable): If specified, the server will create a heartbeat file at the specified path on startup, update the timestamp in that file after the processing of every request or every time idle operations are processed, and delete the file when the server shuts down. The file name can optionally contain the specifier {{pid}}, which will be replaced with the server process PID.
 - ``logging`` - strict ``dict``: Settings for service logging, which should follow the standard Python logging configuration
 
   - ``disable_existing_loggers`` - ``boolean``: *(no description)*
@@ -2319,6 +2320,7 @@ apply as the default values.
             "shutdown_grace": 30,
             "timeout": 300
         },
+        "heartbeat_file": null,
         "logging": {
             "disable_existing_loggers": false,
             "filters": {
@@ -2437,3 +2439,4 @@ Attrs Properties
 - ``context``
 - ``control``
 - ``client``
+- ``async_event_loop``

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -132,6 +132,13 @@ class ServerSettings(SOASettings):
                         'whose responses contain errors (setting this to a more severe level than '
                         '`request_log_success_level` will allow you to easily filter for unsuccessful requests)',
         ),
+        'heartbeat_file': fields.Nullable(fields.UnicodeString(
+            description='If specified, the server will create a heartbeat file at the specified path on startup, '
+                        'update the timestamp in that file after the processing of every request or every time '
+                        'idle operations are processed, and delete the file when the server shuts down. The file name '
+                        'can optionally contain the specifier {{pid}}, which will be replaced with the server process '
+                        'PID.',
+        )),
     }
 
     defaults = {
@@ -183,6 +190,7 @@ class ServerSettings(SOASettings):
         },
         'request_log_success_level': 'INFO',
         'request_log_error_level': 'INFO',
+        'heartbeat_file': None,
     }
 
 


### PR DESCRIPTION
It's often advantageous to have the ability to programmatically check the health of a specific server process, which can't easily be achieved without using a client, and which can't be achieved with a client in a multi-server environment. This commit adds support for an optional (configured via settings) heartbeat file, which gets created when the server starts, updated after each request or during idle processes, and removed when the server shuts down.