### PR TITLE
[MINOR] Make the polymorphic client and server settings extensible

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -675,127 +675,7 @@ Settings Schema Definition
 
     Optional keys: ``kwargs``
 
-- ``transport`` - schema switching on value of ``path``: *(no description)*
-
-  - ``path == '__default__'`` - strict ``dict``: *(no description)*
-
-    - ``kwargs`` - flexible ``dict``: Any keyword arguments that should be passed to the class when constructing a new instance
-
-      keys
-        ``unicode``: *(no description)*
-
-      values
-        ``anything``: *(no description)*
-
-    - ``path`` - ``unicode``: The path to the class to be imported and used, in the format ``module.name:ClassName``
-
-    Optional keys: ``kwargs``
-
-  - ``path == 'pysoa.common.transport.local:LocalClientTransport'`` - strict ``dict``: The settings for the local transport
-
-    - ``kwargs`` - strict ``dict``: *(no description)*
-
-      - ``server_class`` - any of the types bulleted below: The path to the ``Server`` class to use locally (as a library), or a reference to the ``Server``-extending class/type itself
-
-        - ``unicode``: The path to the ``Server`` class, in the format ``module.name:ClassName``
-        - ``object_instance``: A reference to the ``Server``-extending class/type (additional information: ``{u'valid_type': "(<type 'type'>, <type 'classobj'>)"}``)
-
-      - ``server_settings`` - flexible ``dict``: The settings to use when instantiating the ``server_class``
-
-        keys
-          ``unicode``: *(no description)*
-
-        values
-          ``anything``: *(no description)*
-
-
-    - ``path`` - ``unicode``: The path to the local client transport, in the format ``module.name:ClassName``
-
-    Optional keys: ``kwargs``
-
-  - ``path == 'pysoa.common.transport.redis_gateway.client:RedisClientTransport'`` - strict ``dict``: The settings for the Redis transport
-
-    - ``kwargs`` - strict ``dict``: *(no description)*
-
-      - ``backend_layer_kwargs`` - strict ``dict``: The arguments passed to the Redis connection manager
-
-        - ``connection_kwargs`` - flexible ``dict``: The arguments used when creating all Redis connections (see Redis-Py docs)
-
-          keys
-            ``hashable``: *(no description)*
-
-          values
-            ``anything``: *(no description)*
-
-        - ``hosts`` - ``list``: The list of Redis hosts, where each is a tuple of ``("address", port)`` or the simple string address.
-
-          values
-            any of the types bulleted below: *(no description)*
-
-            - ``tuple``: *(no description)* (additional information: ``{u'contents': [{u'type': u'unicode'}, {u'type': u'integer'}]}``)
-            - ``unicode``: *(no description)*
-
-        - ``redis_db`` - ``integer``: The Redis database, a shortcut for putting this in ``connection_kwargs``.
-        - ``redis_port`` - ``integer``: The port number, a shortcut for putting this on all hosts
-        - ``sentinel_failover_retries`` - ``integer``: How many times to retry (with a delay) getting a connection from the Sentinel when a master cannot be found (cluster is in the middle of a failover); should only be used for Sentinel backend type
-        - ``sentinel_services`` - ``list``: A list of Sentinel services (will be discovered by default); should only be used for Sentinel backend type
-
-          values
-            ``unicode``: *(no description)*
-
-        Optional keys: ``connection_kwargs``, ``hosts``, ``redis_db``, ``redis_port``, ``sentinel_failover_retries``, ``sentinel_services``
-
-      - ``backend_type`` - ``constant``: Which backend (standard or sentinel) should be used for this Redis transport (additional information: ``{u'values': [u'redis.standard', u'redis.sentinel']}``)
-      - ``log_messages_larger_than_bytes`` - ``integer``: By default, messages larger than 100KB that do not trigger errors (see ``maximum_message_size_in_bytes``) will be logged with level WARNING to a logger named ``pysoa.transport.oversized_message``. To disable this behavior, set this setting to 0. Or, you can set it to some other number to change the threshold that triggers logging.
-      - ``maximum_message_size_in_bytes`` - ``integer``: The maximum message size, in bytes, that is permitted to be transmitted over this transport (defaults to 100KB on the client and 250KB on the server)
-      - ``message_expiry_in_seconds`` - ``integer``: How long after a message is sent that it is considered expired, dropped from queue
-      - ``queue_capacity`` - ``integer``: The capacity of the message queue to which this transport will send messages
-      - ``queue_full_retries`` - ``integer``: How many times to retry sending a message to a full queue before giving up
-      - ``receive_timeout_in_seconds`` - ``integer``: How long to block waiting on a message to be received
-      - ``serializer_config`` - strict ``dict``: The configuration for the serializer this transport should use
-
-        - ``kwargs`` - flexible ``dict``: Any keyword arguments that should be passed to the class when constructing a new instance
-
-          keys
-            ``unicode``: *(no description)*
-
-          values
-            ``anything``: *(no description)*
-
-        - ``path`` - ``unicode``: The path to the class to be imported and used, in the format ``module.name:ClassName``
-
-        Optional keys: ``kwargs``
-
-
-      Optional keys: ``backend_layer_kwargs``, ``log_messages_larger_than_bytes``, ``maximum_message_size_in_bytes``, ``message_expiry_in_seconds``, ``queue_capacity``, ``queue_full_retries``, ``receive_timeout_in_seconds``, ``serializer_config``
-
-    - ``path`` - ``unicode``: The path to the Redis client or server transport, in the format ``module.name:ClassName``
-
-    Optional keys: ``kwargs``
-
-  - ``path == 'pysoa.common.transport:LocalClientTransport'`` - strict ``dict``: The settings for the local transport
-
-    - ``kwargs`` - strict ``dict``: *(no description)*
-
-      - ``server_class`` - any of the types bulleted below: The path to the ``Server`` class to use locally (as a library), or a reference to the ``Server``-extending class/type itself
-
-        - ``unicode``: The path to the ``Server`` class, in the format ``module.name:ClassName``
-        - ``object_instance``: A reference to the ``Server``-extending class/type (additional information: ``{u'valid_type': "(<type 'type'>, <type 'classobj'>)"}``)
-
-      - ``server_settings`` - flexible ``dict``: The settings to use when instantiating the ``server_class``
-
-        keys
-          ``unicode``: *(no description)*
-
-        values
-          ``anything``: *(no description)*
-
-
-    - ``path`` - ``unicode``: The path to the local client transport, in the format ``module.name:ClassName``
-
-    Optional keys: ``kwargs``
-
-
+- ``transport`` - dictionary whose schema switches based on the value of ``path``, dynamically based on class imported from ``path`` (see the settings schema documentation for the class named at ``path``){}
 - ``transport_cache_time_in_seconds`` - ``anything``: This field is deprecated. The transport cache is no longer supported. This settings field will remain in place until 2018-06-15 to give a safe period for people to remove it from settings, but its value will always be ignored.
 
 Default Values
@@ -1237,6 +1117,38 @@ Parameters
   - ``body``
 
 
+.. _pysoa.common.transport.local.LocalTransportSchema
+
+``class-path settings schema LocalTransportSchema``
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**module:** ``pysoa.common.transport.local``
+
+Settings Schema Definition
+**************************
+strict ``dict``: The settings for the local transport
+
+- ``kwargs`` - strict ``dict``: *(no description)*
+
+  - ``server_class`` - any of the types bulleted below: The path to the ``Server`` class to use locally (as a library), or a reference to the ``Server``-extending class/type itself
+
+    - ``unicode``: The path to the ``Server`` class, in the format ``module.name:ClassName``
+    - ``object_instance``: A reference to the ``Server``-extending class/type (additional information: ``{u'valid_type': "(<type 'type'>, <type 'classobj'>)"}``)
+
+  - ``server_settings`` - flexible ``dict``: The settings to use when instantiating the ``server_class``
+
+    keys
+      ``unicode``: *(no description)*
+
+    values
+      ``anything``: *(no description)*
+
+
+- ``path`` - ``unicode``: The path to the local client transport, in the format ``module.name:ClassName``
+
+Optional keys: ``kwargs``
+
+
 .. _pysoa.common.transport.redis_gateway.client.RedisClientTransport:
 
 ``class RedisClientTransport``
@@ -1327,6 +1239,76 @@ Parameters
 ********************************************************
 
 *(No documentation)*
+
+
+.. _pysoa.common.transport.redis_gateway.settings.RedisTransportSchema
+
+``class-path settings schema RedisTransportSchema``
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**module:** ``pysoa.common.transport.redis_gateway.settings``
+
+Settings Schema Definition
+**************************
+strict ``dict``: The settings for the Redis transport
+
+- ``kwargs`` - strict ``dict``: *(no description)*
+
+  - ``backend_layer_kwargs`` - strict ``dict``: The arguments passed to the Redis connection manager
+
+    - ``connection_kwargs`` - flexible ``dict``: The arguments used when creating all Redis connections (see Redis-Py docs)
+
+      keys
+        ``hashable``: *(no description)*
+
+      values
+        ``anything``: *(no description)*
+
+    - ``hosts`` - ``list``: The list of Redis hosts, where each is a tuple of ``("address", port)`` or the simple string address.
+
+      values
+        any of the types bulleted below: *(no description)*
+
+        - ``tuple``: *(no description)* (additional information: ``{u'contents': [{u'type': u'unicode'}, {u'type': u'integer'}]}``)
+        - ``unicode``: *(no description)*
+
+    - ``redis_db`` - ``integer``: The Redis database, a shortcut for putting this in ``connection_kwargs``.
+    - ``redis_port`` - ``integer``: The port number, a shortcut for putting this on all hosts
+    - ``sentinel_failover_retries`` - ``integer``: How many times to retry (with a delay) getting a connection from the Sentinel when a master cannot be found (cluster is in the middle of a failover); should only be used for Sentinel backend type
+    - ``sentinel_services`` - ``list``: A list of Sentinel services (will be discovered by default); should only be used for Sentinel backend type
+
+      values
+        ``unicode``: *(no description)*
+
+    Optional keys: ``connection_kwargs``, ``hosts``, ``redis_db``, ``redis_port``, ``sentinel_failover_retries``, ``sentinel_services``
+
+  - ``backend_type`` - ``constant``: Which backend (standard or sentinel) should be used for this Redis transport (additional information: ``{u'values': [u'redis.standard', u'redis.sentinel']}``)
+  - ``log_messages_larger_than_bytes`` - ``integer``: By default, messages larger than 100KB that do not trigger errors (see ``maximum_message_size_in_bytes``) will be logged with level WARNING to a logger named ``pysoa.transport.oversized_message``. To disable this behavior, set this setting to 0. Or, you can set it to some other number to change the threshold that triggers logging.
+  - ``maximum_message_size_in_bytes`` - ``integer``: The maximum message size, in bytes, that is permitted to be transmitted over this transport (defaults to 100KB on the client and 250KB on the server)
+  - ``message_expiry_in_seconds`` - ``integer``: How long after a message is sent that it is considered expired, dropped from queue
+  - ``queue_capacity`` - ``integer``: The capacity of the message queue to which this transport will send messages
+  - ``queue_full_retries`` - ``integer``: How many times to retry sending a message to a full queue before giving up
+  - ``receive_timeout_in_seconds`` - ``integer``: How long to block waiting on a message to be received
+  - ``serializer_config`` - strict ``dict``: The configuration for the serializer this transport should use
+
+    - ``kwargs`` - flexible ``dict``: Any keyword arguments that should be passed to the class when constructing a new instance
+
+      keys
+        ``unicode``: *(no description)*
+
+      values
+        ``anything``: *(no description)*
+
+    - ``path`` - ``unicode``: The path to the class to be imported and used, in the format ``module.name:ClassName``
+
+    Optional keys: ``kwargs``
+
+
+  Optional keys: ``backend_layer_kwargs``, ``log_messages_larger_than_bytes``, ``maximum_message_size_in_bytes``, ``message_expiry_in_seconds``, ``queue_capacity``, ``queue_full_retries``, ``receive_timeout_in_seconds``, ``serializer_config``
+
+- ``path`` - ``unicode``: The path to the Redis client or server transport, in the format ``module.name:ClassName``
+
+Optional keys: ``kwargs``
 
 
 .. _pysoa.common.types.ActionRequest:
@@ -2186,125 +2168,7 @@ Settings Schema Definition
 
 - ``request_log_error_level`` - ``constant``: The logging level at which full request and response contents will be logged for requests whose responses contain errors (setting this to a more severe level than ``request_log_success_level`` will allow you to easily filter for unsuccessful requests) (additional information: ``{u'values': [u'DEBUG', u'INFO', u'WARNING', u'CRITICAL', u'ERROR']}``)
 - ``request_log_success_level`` - ``constant``: The logging level at which full request and response contents will be logged for successful requests (additional information: ``{u'values': [u'DEBUG', u'INFO', u'WARNING', u'CRITICAL', u'ERROR']}``)
-- ``transport`` - schema switching on value of ``path``: *(no description)*
-
-  - ``path == '__default__'`` - strict ``dict``: *(no description)*
-
-    - ``kwargs`` - flexible ``dict``: Any keyword arguments that should be passed to the class when constructing a new instance
-
-      keys
-        ``unicode``: *(no description)*
-
-      values
-        ``anything``: *(no description)*
-
-    - ``path`` - ``unicode``: The path to the class to be imported and used, in the format ``module.name:ClassName``
-
-    Optional keys: ``kwargs``
-
-  - ``path == 'pysoa.common.transport.local:LocalServerTransport'`` - strict ``dict``: The settings for the local transport
-
-    - ``kwargs`` - strict ``dict``: *(no description)*
-
-      - ``server_class`` - any of the types bulleted below: The path to the ``Server`` class to use locally (as a library), or a reference to the ``Server``-extending class/type itself
-
-        - ``unicode``: The path to the ``Server`` class, in the format ``module.name:ClassName``
-        - ``object_instance``: A reference to the ``Server``-extending class/type (additional information: ``{u'valid_type': "(<type 'type'>, <type 'classobj'>)"}``)
-
-      - ``server_settings`` - flexible ``dict``: The settings to use when instantiating the ``server_class``
-
-        keys
-          ``unicode``: *(no description)*
-
-        values
-          ``anything``: *(no description)*
-
-
-    - ``path`` - ``unicode``: The path to the local client transport, in the format ``module.name:ClassName``
-
-    Optional keys: ``kwargs``
-
-  - ``path == 'pysoa.common.transport.redis_gateway.server:RedisServerTransport'`` - strict ``dict``: The settings for the Redis transport
-
-    - ``kwargs`` - strict ``dict``: *(no description)*
-
-      - ``backend_layer_kwargs`` - strict ``dict``: The arguments passed to the Redis connection manager
-
-        - ``connection_kwargs`` - flexible ``dict``: The arguments used when creating all Redis connections (see Redis-Py docs)
-
-          keys
-            ``hashable``: *(no description)*
-
-          values
-            ``anything``: *(no description)*
-
-        - ``hosts`` - ``list``: The list of Redis hosts, where each is a tuple of ``("address", port)`` or the simple string address.
-
-          values
-            any of the types bulleted below: *(no description)*
-
-            - ``tuple``: *(no description)* (additional information: ``{u'contents': [{u'type': u'unicode'}, {u'type': u'integer'}]}``)
-            - ``unicode``: *(no description)*
-
-        - ``redis_db`` - ``integer``: The Redis database, a shortcut for putting this in ``connection_kwargs``.
-        - ``redis_port`` - ``integer``: The port number, a shortcut for putting this on all hosts
-        - ``sentinel_failover_retries`` - ``integer``: How many times to retry (with a delay) getting a connection from the Sentinel when a master cannot be found (cluster is in the middle of a failover); should only be used for Sentinel backend type
-        - ``sentinel_services`` - ``list``: A list of Sentinel services (will be discovered by default); should only be used for Sentinel backend type
-
-          values
-            ``unicode``: *(no description)*
-
-        Optional keys: ``connection_kwargs``, ``hosts``, ``redis_db``, ``redis_port``, ``sentinel_failover_retries``, ``sentinel_services``
-
-      - ``backend_type`` - ``constant``: Which backend (standard or sentinel) should be used for this Redis transport (additional information: ``{u'values': [u'redis.standard', u'redis.sentinel']}``)
-      - ``log_messages_larger_than_bytes`` - ``integer``: By default, messages larger than 100KB that do not trigger errors (see ``maximum_message_size_in_bytes``) will be logged with level WARNING to a logger named ``pysoa.transport.oversized_message``. To disable this behavior, set this setting to 0. Or, you can set it to some other number to change the threshold that triggers logging.
-      - ``maximum_message_size_in_bytes`` - ``integer``: The maximum message size, in bytes, that is permitted to be transmitted over this transport (defaults to 100KB on the client and 250KB on the server)
-      - ``message_expiry_in_seconds`` - ``integer``: How long after a message is sent that it is considered expired, dropped from queue
-      - ``queue_capacity`` - ``integer``: The capacity of the message queue to which this transport will send messages
-      - ``queue_full_retries`` - ``integer``: How many times to retry sending a message to a full queue before giving up
-      - ``receive_timeout_in_seconds`` - ``integer``: How long to block waiting on a message to be received
-      - ``serializer_config`` - strict ``dict``: The configuration for the serializer this transport should use
-
-        - ``kwargs`` - flexible ``dict``: Any keyword arguments that should be passed to the class when constructing a new instance
-
-          keys
-            ``unicode``: *(no description)*
-
-          values
-            ``anything``: *(no description)*
-
-        - ``path`` - ``unicode``: The path to the class to be imported and used, in the format ``module.name:ClassName``
-
-        Optional keys: ``kwargs``
-
-
-      Optional keys: ``backend_layer_kwargs``, ``log_messages_larger_than_bytes``, ``maximum_message_size_in_bytes``, ``message_expiry_in_seconds``, ``queue_capacity``, ``queue_full_retries``, ``receive_timeout_in_seconds``, ``serializer_config``
-
-    - ``path`` - ``unicode``: The path to the Redis client or server transport, in the format ``module.name:ClassName``
-
-    Optional keys: ``kwargs``
-
-  - ``path == 'pysoa.common.transport:LocalServerTransport'`` - strict ``dict``: The settings for the local transport
-
-    - ``kwargs`` - strict ``dict``: *(no description)*
-
-      - ``server_class`` - any of the types bulleted below: The path to the ``Server`` class to use locally (as a library), or a reference to the ``Server``-extending class/type itself
-
-        - ``unicode``: The path to the ``Server`` class, in the format ``module.name:ClassName``
-        - ``object_instance``: A reference to the ``Server``-extending class/type (additional information: ``{u'valid_type': "(<type 'type'>, <type 'classobj'>)"}``)
-
-      - ``server_settings`` - flexible ``dict``: The settings to use when instantiating the ``server_class``
-
-        keys
-          ``unicode``: *(no description)*
-
-        values
-          ``anything``: *(no description)*
-
-
-    - ``path`` - ``unicode``: The path to the local client transport, in the format ``module.name:ClassName``
-
-    Optional keys: ``kwargs``
+- ``transport`` - dictionary whose schema switches based on the value of ``path``, dynamically based on class imported from ``path`` (see the settings schema documentation for the class named at ``path``){}
 
 Default Values
 **************

--- a/pysoa/client/settings.py
+++ b/pysoa/client/settings.py
@@ -6,16 +6,13 @@ from __future__ import (
 from conformity import fields
 
 from pysoa.client.middleware import ClientMiddleware
-from pysoa.common.settings import (
+from pysoa.common.schemas import (
     BasicClassSchema,
-    SOASettings,
+    PolymorphClassSchema,
 )
+from pysoa.common.settings import SOASettings
 from pysoa.common.transport.base import ClientTransport as BaseClientTransport
-from pysoa.common.transport.local import (
-    LocalClientTransport,
-    LocalTransportSchema,
-)
-from pysoa.common.transport.redis_gateway.client import RedisClientTransport
+from pysoa.common.transport.local import LocalTransportSchema
 from pysoa.common.transport.redis_gateway.settings import RedisTransportSchema
 
 
@@ -71,15 +68,10 @@ class PolymorphicClientSettings(ClientSettings):
         }
     }
     schema = {
-        'transport': fields.Polymorph(
-            switch_field='path',
+        'transport': PolymorphClassSchema(
             contents_map={
-                'pysoa.common.transport.local:LocalClientTransport': LocalTransportSchema(LocalClientTransport),
-                'pysoa.common.transport:LocalClientTransport': LocalTransportSchema(LocalClientTransport),
-                'pysoa.common.transport.redis_gateway.client:RedisClientTransport': RedisTransportSchema(
-                    RedisClientTransport,
-                ),
                 '__default__': BasicClassSchema(BaseClientTransport),
             },
+            enforce_object_type_subclass_of=BaseClientTransport,
         ),
     }

--- a/pysoa/common/schemas.py
+++ b/pysoa/common/schemas.py
@@ -5,6 +5,8 @@ from __future__ import (
 
 from conformity import fields
 
+from pysoa.utils import resolve_python_path
+
 
 class BasicClassSchema(fields.Dictionary):
     contents = {
@@ -34,3 +36,94 @@ class BasicClassSchema(fields.Dictionary):
                 class_name=self.object_type.__name__,
             ) if self.object_type else '',
         )
+
+
+class PolymorphClassSchema(fields.Polymorph):
+    """
+    This is a more advanced variant of Conformity's `Polymorph` class, whose `switch_field` is always `path` (so that
+    it supports `BasicClassSchema`), and whose contents map is dynamic and extensible. When provided a `path` value
+    not found in the contents map, the path will be imported and the imported class will be inspected for a
+    `settings_schema` attribute. `settings_schema` must be an instance of `BasicClassSchema`, and its value will be
+    cached as the contents map value corresponding to that value of `path`. This allows other projects to extend
+    polymorph settings and still provide settings validation without having to re-write the entire settings
+    hierarchy to support new features.
+
+    Some important notes:
+
+    * You may specify already-known values in the `contents_map` parameter, but this is not required.
+    * If you want to support `path` values that cannot be found (imported), you must supply a `'__default__'` key in
+      the `contents_map` parameter.
+    * You may specify the `enforce_object_type_subclass_of` parameter to enforce that any dynamically-discovered
+      schemas' `object_type` attribute (see `BasicClassSchema`) is a subclass of the specified value. For example, the
+      `PolymorphicServerSettings`'s `transport` field (a `PolymorphClassSchema`) enforces that the schemas'
+      `object_type` attribute is a subclass of `ServerTransport` (to ensure that the `path` points to a server transport
+      and not a client transport or some other arbitrary object), and likewise `PolymorphicClientSettings` enforces an
+      `object_type` of `ClientTransport` (or its children) for `transport`.
+    """
+    def __init__(self, contents_map, enforce_object_type_subclass_of=None, description=None, **kwargs):
+        super(PolymorphClassSchema, self).__init__(
+            switch_field='path',
+            contents_map=contents_map,
+            description=description,
+            **kwargs
+        )
+
+        self.contents_map = self.DynamicContentsMap(enforce_object_type_subclass_of, self.contents_map)
+
+    class DynamicContentsMap(dict):
+        def __init__(self, enforce_object_type_subclass_of, *args, **kwargs):
+            super(PolymorphClassSchema.DynamicContentsMap, self).__init__(*args, **kwargs)
+
+            self._enforce_object_type_subclass_of = enforce_object_type_subclass_of
+            self._unresolved_paths = set()
+
+        def get(self, key, default=None):
+            if key in self:
+                return super(PolymorphClassSchema.DynamicContentsMap, self).__getitem__(key)
+            return default
+
+        def __getitem__(self, key):
+            self._add_path_to_map_if_available_and_necessary(key)
+
+            return super(PolymorphClassSchema.DynamicContentsMap, self).__getitem__(key)
+
+        def __contains__(self, key):
+            if super(PolymorphClassSchema.DynamicContentsMap, self).__contains__(key):
+                return True
+
+            self._add_path_to_map_if_available_and_necessary(key)
+            return super(PolymorphClassSchema.DynamicContentsMap, self).__contains__(key)
+
+        def _add_path_to_map_if_available_and_necessary(self, path):
+            if (
+                super(PolymorphClassSchema.DynamicContentsMap, self).__contains__(path) or
+                path in self._unresolved_paths
+            ):
+                return
+
+            if path == '__default__':
+                raise ValueError(
+                    'You did not specify a key named "__default__" in the polymorph class schema, but you used a '
+                    'path for which no module or class could be imported.'
+                )
+
+            try:
+                item = resolve_python_path(path)
+                schema = item.settings_schema
+                if not isinstance(schema, BasicClassSchema):
+                    raise ValueError('Schema `{}` for path "{}" must be a `BasicClassSchema`'.format(schema, path))
+                if (
+                    self._enforce_object_type_subclass_of and
+                    not issubclass(schema.object_type, self._enforce_object_type_subclass_of)
+                ):
+                    raise ValueError(
+                        'Schema attribute `settings_schema.object_type` of `{}` for path "{}" must be a '
+                        'subclass of `{}`'.format(
+                            schema.object_type.__name__,
+                            path,
+                            self._enforce_object_type_subclass_of.__name__,
+                        )
+                    )
+                self[path] = schema
+            except (ImportError, AttributeError):
+                self._unresolved_paths.add(path)

--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -4,7 +4,6 @@ from __future__ import (
 )
 
 import copy
-import importlib
 import itertools
 
 from conformity import fields
@@ -13,20 +12,7 @@ import six
 
 from pysoa.common.metrics import MetricsSchema
 from pysoa.common.schemas import BasicClassSchema
-
-
-def resolve_python_path(path):
-    """
-    Turns a python path like module.name.here:ClassName.SubClass into an object
-    """
-    # Get the module
-    module_path, local_path = path.split(':', 1)
-    thing = importlib.import_module(module_path)
-    # Traverse the local sections
-    local_bits = local_path.split('.')
-    for bit in local_bits:
-        thing = getattr(thing, bit)
-    return thing
+from pysoa.utils import resolve_python_path
 
 
 class SettingsMetaclass(type):

--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -165,3 +165,7 @@ class LocalTransportSchema(BasicClassSchema):
     }
 
     description = 'The settings for the local transport'
+
+
+LocalClientTransport.settings_schema = LocalTransportSchema(LocalClientTransport)
+LocalServerTransport.settings_schema = LocalTransportSchema(LocalServerTransport)

--- a/pysoa/common/transport/redis_gateway/client.py
+++ b/pysoa/common/transport/redis_gateway/client.py
@@ -14,6 +14,7 @@ from pysoa.common.transport.exceptions import MessageReceiveTimeout
 from pysoa.common.transport.redis_gateway.backend.base import BaseRedisClient
 from pysoa.common.transport.redis_gateway.constants import DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT
 from pysoa.common.transport.redis_gateway.core import RedisTransportCore
+from pysoa.common.transport.redis_gateway.settings import RedisTransportSchema
 from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 
 
@@ -83,3 +84,6 @@ class RedisClientTransport(ClientTransport):
         else:
             # This tells Client.get_all_responses to stop waiting for more.
             return None, None, None
+
+
+RedisClientTransport.settings_schema = RedisTransportSchema(RedisClientTransport)

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -11,6 +11,7 @@ from pysoa.common.transport.exceptions import (
 )
 from pysoa.common.transport.redis_gateway.constants import DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER
 from pysoa.common.transport.redis_gateway.core import RedisTransportCore
+from pysoa.common.transport.redis_gateway.settings import RedisTransportSchema
 from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 
 
@@ -56,3 +57,6 @@ class RedisServerTransport(ServerTransport):
 
         with self.metrics.timer('server.transport.redis_gateway.send', resolution=TimerResolution.MICROSECONDS):
             self.core.send_message(queue_name, request_id, meta, body)
+
+
+RedisServerTransport.settings_schema = RedisTransportSchema(RedisServerTransport)

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -4,10 +4,6 @@ from __future__ import (
 )
 
 import argparse
-try:
-    import asyncio
-except ImportError:
-    asyncio = None
 import codecs
 import importlib
 import logging
@@ -55,6 +51,11 @@ from pysoa.server.settings import PolymorphicServerSettings
 from pysoa.server.types import EnrichedActionRequest
 import pysoa.version
 
+
+try:
+    import asyncio
+except ImportError:
+    asyncio = None
 
 try:
     from django.conf import settings as django_settings

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -8,16 +8,13 @@ from logging.handlers import SysLogHandler
 
 from conformity import fields
 
-from pysoa.common.settings import (
+from pysoa.common.schemas import (
     BasicClassSchema,
-    SOASettings,
+    PolymorphClassSchema,
 )
+from pysoa.common.settings import SOASettings
 from pysoa.common.transport.base import ServerTransport as BaseServerTransport
-from pysoa.common.transport.local import (
-    LocalServerTransport,
-    LocalTransportSchema,
-)
-from pysoa.common.transport.redis_gateway.server import RedisServerTransport
+from pysoa.common.transport.local import LocalTransportSchema
 from pysoa.common.transport.redis_gateway.settings import RedisTransportSchema
 from pysoa.server.middleware import ServerMiddleware
 
@@ -226,15 +223,10 @@ class PolymorphicServerSettings(ServerSettings):
         }
     }
     schema = {
-        'transport': fields.Polymorph(
-            switch_field='path',
+        'transport': PolymorphClassSchema(
             contents_map={
-                'pysoa.common.transport.local:LocalServerTransport': LocalTransportSchema(LocalServerTransport),
-                'pysoa.common.transport:LocalServerTransport': LocalTransportSchema(LocalServerTransport),
-                'pysoa.common.transport.redis_gateway.server:RedisServerTransport': RedisTransportSchema(
-                    RedisServerTransport,
-                ),
                 '__default__': BasicClassSchema(BaseServerTransport),
-            }
+            },
+            enforce_object_type_subclass_of=BaseServerTransport,
         ),
     }

--- a/pysoa/utils.py
+++ b/pysoa/utils.py
@@ -4,6 +4,8 @@ from __future__ import (
     unicode_literals,
 )
 
+import importlib
+
 import six
 
 
@@ -28,3 +30,17 @@ def dict_to_hashable(d):
         (k, tuple(v) if isinstance(v, list) else (dict_to_hashable(v) if isinstance(v, dict) else v))
         for k, v in six.iteritems(d)
     )
+
+
+def resolve_python_path(path):
+    """
+    Turns a python path like module.name.here:ClassName.SubClass into an object
+    """
+    # Get the module
+    module_path, local_path = path.split(':', 1)
+    thing = importlib.import_module(module_path)
+    # Traverse the local sections
+    local_bits = local_path.split('.')
+    for bit in local_bits:
+        thing = getattr(thing, bit)
+    return thing

--- a/tests/common/test_schemas.py
+++ b/tests/common/test_schemas.py
@@ -1,0 +1,154 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+from conformity import fields
+import pytest
+
+from pysoa.common.schemas import (
+    BasicClassSchema,
+    PolymorphClassSchema,
+)
+
+
+class _ClassSchema(BasicClassSchema):
+    contents = {
+        'path': fields.UnicodeString(
+            description='The path to the Redis client or server transport, in the format `module.name:ClassName`',
+        ),
+        'kwargs': fields.Dictionary(
+            {
+                'foo': fields.UnicodeString(),
+                'bar': fields.Integer(),
+                'baz': fields.Boolean(),
+            },
+            optional_keys=('baz', ),
+        )
+    }
+
+
+class _SuperThingClient(object):
+    pass
+
+
+class _SuperThingServer(object):
+    pass
+
+
+class _ThingOne(_SuperThingClient):
+    pass
+
+
+class _ThingTwo(_SuperThingServer):
+    pass
+
+
+class _ThingThree(object):
+    pass
+
+
+_ThingOne.settings_schema = _ClassSchema(_ThingOne)
+_ThingTwo.settings_schema = BasicClassSchema(_ThingTwo)
+_ThingThree.settings_schema = {}
+
+
+class TestPolymorphClassSchema(object):
+    def test_non_existent_value(self):
+        schema = PolymorphClassSchema({})
+
+        nope = None
+
+        assert 'hello:World' not in schema.contents_map
+        assert schema.contents_map.get('hello:World') is None
+        with pytest.raises(KeyError):
+            nope = schema.contents_map['hello:World']
+
+        assert schema.contents_map.get('goodbye:Universe') is None
+        assert 'goodbye:Universe' not in schema.contents_map
+        with pytest.raises(KeyError):
+            nope = schema.contents_map['goodbye:Universe']
+
+        with pytest.raises(KeyError):
+            nope = schema.contents_map['pysoa.utils:DoesNotExist']
+        assert 'pysoa.utils:DoesNotExist' not in schema.contents_map
+        assert schema.contents_map.get('pysoa.utils:DoesNotExist') is None
+
+        assert 'hello:World' not in schema.contents_map
+        assert schema.contents_map.get('hello:World') is None
+        with pytest.raises(KeyError):
+            nope = schema.contents_map['hello:World']
+
+        assert nope is None
+
+    def test_existent_not_a_class_schema(self):
+        schema = PolymorphClassSchema({})
+
+        with pytest.raises(ValueError):
+            schema.contents_map.get('tests.common.test_schemas:_ThingThree')
+
+    def test_existent_no_subclass_enforcement(self):
+        schema = PolymorphClassSchema({})
+
+        assert schema.contents_map.get('tests.common.test_schemas:_ThingOne') is _ThingOne.settings_schema
+        assert schema.contents_map.get('tests.common.test_schemas:_ThingTwo') is _ThingTwo.settings_schema
+
+        assert schema.contents_map.get('tests.common.test_schemas:_ThingOne') is _ThingOne.settings_schema
+        assert schema.contents_map.get('tests.common.test_schemas:_ThingTwo') is _ThingTwo.settings_schema
+
+    def test_existent_with_subclass_enforcement(self):
+        schema1 = PolymorphClassSchema({}, _SuperThingClient)
+
+        assert schema1.contents_map.get('tests.common.test_schemas:_ThingOne') is _ThingOne.settings_schema
+        assert schema1.contents_map.get('tests.common.test_schemas:_ThingOne') is _ThingOne.settings_schema
+
+        with pytest.raises(ValueError):
+            schema1.contents_map.get('tests.common.test_schemas:_ThingTwo')
+
+        schema2 = PolymorphClassSchema({}, _SuperThingServer)
+
+        assert schema2.contents_map.get('tests.common.test_schemas:_ThingTwo') is _ThingTwo.settings_schema
+        assert schema2.contents_map.get('tests.common.test_schemas:_ThingTwo') is _ThingTwo.settings_schema
+
+        with pytest.raises(ValueError):
+            schema2.contents_map.get('tests.common.test_schemas:_ThingOne')
+
+    def test_missing_default_error(self):
+        schema1 = PolymorphClassSchema({})
+
+        with pytest.raises(ValueError):
+            schema1.contents_map.get('__default__')
+
+        schema2 = PolymorphClassSchema({'__default__': True})
+        assert schema2.contents_map.get('__default__') is True
+
+    def test_errors(self):
+        schema = PolymorphClassSchema(
+            {
+                '__default__': BasicClassSchema(),
+            },
+            _SuperThingClient,
+        )
+
+        assert schema.errors({'path': 'hello:World', 'kwargs': {}}) == []
+        assert schema.errors({'path': 'hello:World', 'kwargs': {'yo': 'cool'}}) == []
+
+        assert len(schema.errors(
+            {'path': 'tests.common.test_schemas:_ThingOne', 'kwargs': {}}
+        )) == 2
+
+        assert len(schema.errors(
+            {'path': 'tests.common.test_schemas:_ThingOne', 'kwargs': {'foo': 12, 'bar': 'geek'}}
+        )) == 2
+
+        assert len(schema.errors(
+            {'path': 'tests.common.test_schemas:_ThingOne', 'kwargs': {'foo': 'geek', 'bar': 12, 'baz': 'no'}}
+        )) == 1
+
+        assert schema.errors(
+            {'path': 'tests.common.test_schemas:_ThingOne', 'kwargs': {'foo': 'geek', 'bar': 12}}
+        ) == []
+
+        assert schema.errors(
+            {'path': 'tests.common.test_schemas:_ThingOne', 'kwargs': {'foo': 'geek', 'bar': 12, 'baz': False}}
+        ) == []

--- a/tests/test/plan/test_002_plugin_stats.py
+++ b/tests/test/plan/test_002_plugin_stats.py
@@ -4,6 +4,7 @@ from __future__ import (
 )
 
 from pysoa.test.plugins.pytest.plans import PLUGIN_STATISTICS
+
 from tests.test.plan import test_001_fixtures_work as fixtures_test_module
 
 

--- a/tests/test/test_assertions.py
+++ b/tests/test/test_assertions.py
@@ -10,12 +10,11 @@ from pysoa.common.types import (
     ActionResponse,
     Error,
 )
-
 from pysoa.test.assertions import (
     raises_call_action_error,
     raises_error_codes,
-    raises_only_error_codes,
     raises_field_errors,
+    raises_only_error_codes,
     raises_only_field_errors,
 )
 


### PR DESCRIPTION
Before this change, if a consumer of PySOA (such as a service or another library) provides a new transport with a validated settings schema, the only way to use the transport and ensure the settings for it are validated is to also extend/override `PolymorphicServerSettings` and `PolymorphicClientSettings` and extend the `Client` to use the new transport settings class. This change makes the polymorphic client and server settings extensible by adding a `settings_schema` class attribute to a transport class.