### PR TITLE
[PATCH] Move extra_fields_to_redact from common to server settings

### DIFF
--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -205,15 +205,9 @@ class SOASettings(Settings):
             description='The list of all middleware objects that should be applied to this server or client',
         ),
         'metrics': MetricsSchema(),
-        'extra_fields_to_redact': fields.Set(
-            fields.UnicodeString(),
-            description='Use this field to supplement the set of fields that are automatically redacted/censored in '
-                        'request and response fields with additional fields that your service needs redacted.',
-        ),
     }
 
     defaults = {
         'middleware': [],
         'metrics': {'path': 'pysoa.common.metrics:NoOpMetricsRecorder'},
-        'extra_fields_to_redact': set(),
     }

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -136,6 +136,11 @@ class ServerSettings(SOASettings):
                         'can optionally contain the specifier {{pid}}, which will be replaced with the server process '
                         'PID.',
         )),
+        'extra_fields_to_redact': fields.Set(
+            fields.UnicodeString(),
+            description='Use this field to supplement the set of fields that are automatically redacted/censored in '
+                        'request and response fields with additional fields that your service needs redacted.',
+        ),
     }
 
     defaults = {
@@ -188,6 +193,7 @@ class ServerSettings(SOASettings):
         'request_log_success_level': 'INFO',
         'request_log_error_level': 'INFO',
         'heartbeat_file': None,
+        'extra_fields_to_redact': set(),
     }
 
 


### PR DESCRIPTION
The new setting `extra_fields_to_redact` was added in the wrong place. It should be in server settings, but it was added to common settings. The setting has no use to the client, so it should only be in server settings.