### PR TITLE
[PATCH] Fix usage of deprecated attr.ib `convert` parameter

### DIFF
--- a/pysoa/common/transport/redis_gateway/core.py
+++ b/pysoa/common/transport/redis_gateway/core.py
@@ -65,19 +65,19 @@ class RedisTransportCore(object):
 
     log_messages_larger_than_bytes = attr.ib(
         default=DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT,
-        convert=int,
+        converter=int,
     )
 
     maximum_message_size_in_bytes = attr.ib(
         default=DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT,
-        convert=int,
+        converter=int,
     )
 
     message_expiry_in_seconds = attr.ib(
         # How long after a message is sent before it's considered "expired" and not received by default, unless
         # overridden in the send_message argument `message_expiry_in_seconds`
         default=60,
-        convert=int,
+        converter=int,
     )
 
     metrics = attr.ib(
@@ -93,26 +93,26 @@ class RedisTransportCore(object):
     queue_capacity = attr.ib(
         # The capacity for queues to which messages are sent
         default=10000,
-        convert=int,
+        converter=int,
     )
 
     queue_full_retries = attr.ib(
         # Number of times to retry when the send queue is full
         default=10,
-        convert=int,
+        converter=int,
     )
 
     receive_timeout_in_seconds = attr.ib(
         # How long to block when waiting to receive a message by default, unless overridden in the receive_message
         # argument `receive_timeout_in_seconds`
         default=5,
-        convert=int,
+        converter=int,
     )
 
     serializer_config = attr.ib(
         # Configuration for which serializer should be used by this transport
         default={'object': MsgpackSerializer, 'kwargs': {}},
-        convert=dict,
+        converter=dict,
     )
 
     service_name = attr.ib(

--- a/pysoa/common/types.py
+++ b/pysoa/common/types.py
@@ -36,7 +36,7 @@ class ActionResponse(object):
     action = attr.ib()
     errors = attr.ib(
         default=attr.Factory(list),
-        convert=lambda l: [e if isinstance(e, Error) else Error(**e) for e in l],
+        converter=lambda l: [e if isinstance(e, Error) else Error(**e) for e in l],
     )
     body = attr.ib(default=attr.Factory(dict))
 
@@ -53,7 +53,7 @@ class JobRequest(object):
     context = attr.ib(default=attr.Factory(dict))
     actions = attr.ib(
         default=attr.Factory(list),
-        convert=lambda l: [a if isinstance(a, ActionRequest) else ActionRequest(**a) for a in l],
+        converter=lambda l: [a if isinstance(a, ActionRequest) else ActionRequest(**a) for a in l],
     )
 
 
@@ -66,10 +66,10 @@ class JobResponse(object):
     """
     errors = attr.ib(
         default=attr.Factory(list),
-        convert=lambda l: [e if isinstance(e, Error) else Error(**e) for e in l],
+        converter=lambda l: [e if isinstance(e, Error) else Error(**e) for e in l],
     )
     context = attr.ib(default=attr.Factory(dict))
     actions = attr.ib(
         default=attr.Factory(list),
-        convert=lambda l: [a if isinstance(a, ActionResponse) else ActionResponse(**a) for a in l],
+        converter=lambda l: [a if isinstance(a, ActionResponse) else ActionResponse(**a) for a in l],
     )

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -16,7 +16,7 @@ class EnrichedActionRequest(ActionRequest):
     """
     switches = attr.ib(
         default=attr.Factory(RequestSwitchSet),
-        convert=lambda l: l if isinstance(l, RequestSwitchSet) else RequestSwitchSet(l),
+        converter=lambda l: l if isinstance(l, RequestSwitchSet) else RequestSwitchSet(l),
     )
     context = attr.ib(default=attr.Factory(dict))
     control = attr.ib(default=attr.Factory(dict))


### PR DESCRIPTION
According to `attrs` changelog [0], the `convert` parameter is
deprecated since version 17.4.0. As `pysoa` can't use an older version
based on its requirements, the fix is just to change the argument on
existing calls.

[0] https://github.com/python-attrs/attrs/blob/c2bc83195727f7ba554913bde24ac61dfce33e9f/CHANGELOG.rst#deprecations-1