### PR TITLE
[PATCH] Remove use of deprecated EntryPoint.load

### DIFF
--- a/pysoa/test/plan/grammar/directive.py
+++ b/pysoa/test/plan/grammar/directive.py
@@ -75,10 +75,10 @@ def get_all_directives():
     if not ENTRY_POINT_DIRECTIVES:
         for entry_point in pkg_resources.iter_entry_points('pysoa.test.plan.grammar.directives'):
             try:
-                directive_class = entry_point.load(require=False)
+                directive_class = entry_point.resolve()
                 ENTRY_POINT_DIRECTIVES.append(directive_class)
             except ImportError:
-                sys.stderr.write('Warning: could not load {}\n'.format(entry_point))
+                sys.stderr.write('Warning: could not resolve {}\n'.format(entry_point))
 
     return REGISTERED_DIRECTIVES + ENTRY_POINT_DIRECTIVES
 


### PR DESCRIPTION
`setuptools` has deprecated the `EntryPoint.load` method in version
10.2 [0], and added a `resolve` method in version 11.3 [1], released in
January 2015.

[0] https://github.com/pypa/setuptools/blob/898c252e4c1d0521a106fb608993aef099dca16e/CHANGES.rst#102
[1] https://github.com/pypa/setuptools/commit/92a553d3adeb431cdf92b136ac9ccc3f2ef98bf1