### PR TITLE
[PATCH] Remove use of deprecated assertEquals

### DIFF
--- a/tests/common/transport/redis_gateway/backend/test_sentinel.py
+++ b/tests/common/transport/redis_gateway/backend/test_sentinel.py
@@ -77,7 +77,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
         with self.assertRaises(CannotGetConnectionError):
             client.get_connection('test_master_not_found_no_retry')
 
-        self.assertEquals(1, mock_sentinel.return_value.master_for.call_count)
+        self.assertEqual(1, mock_sentinel.return_value.master_for.call_count)
         self.assertIn(mock_sentinel.return_value.master_for.call_args[0][0], {'service1', 'service2', 'service3'})
 
     @mock.patch('redis.sentinel.Sentinel')
@@ -93,7 +93,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
         with self.assertRaises(CannotGetConnectionError):
             client.get_connection('test_master_not_found_max_retries')
 
-        self.assertEquals(3, mock_sentinel.return_value.master_for.call_count)
+        self.assertEqual(3, mock_sentinel.return_value.master_for.call_count)
         self.assertIn(
             mock_sentinel.return_value.master_for.call_args_list[0][0][0],
             {'service1', 'service2', 'service3'},
@@ -124,7 +124,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
         connection = client.get_connection('test_master_not_found_worked_after_retries')
         self.assertIsNotNone(connection)
 
-        self.assertEquals(3, mock_sentinel.return_value.master_for.call_count)
+        self.assertEqual(3, mock_sentinel.return_value.master_for.call_count)
         self.assertIn(
             mock_sentinel.return_value.master_for.call_args_list[0][0][0],
             {'service1', 'service2', 'service3'},

--- a/tests/common/transport/redis_gateway/test_core.py
+++ b/tests/common/transport/redis_gateway/test_core.py
@@ -145,7 +145,7 @@ class TestRedisTransportCore(unittest.TestCase):
         with self.assertRaises(MessageSendError) as error_context:
             core.send_message('my_queue', 71, {}, {})
 
-        self.assertEquals('Cannot get connection: This is my error', error_context.exception.args[0])
+        self.assertEqual('Cannot get connection: This is my error', error_context.exception.args[0])
 
         self.assertFalse(mock_sentinel.called)
         mock_standard.return_value.get_connection.assert_called_once_with('pysoa:my_queue')
@@ -160,7 +160,7 @@ class TestRedisTransportCore(unittest.TestCase):
         with self.assertRaises(MessageReceiveError) as error_context:
             core.receive_message('your_queue')
 
-        self.assertEquals('Cannot get connection: This is another error', error_context.exception.args[0])
+        self.assertEqual('Cannot get connection: This is another error', error_context.exception.args[0])
 
         self.assertFalse(mock_sentinel.called)
         mock_standard.return_value.get_connection.assert_called_once_with('pysoa:your_queue')

--- a/tests/test/plan/grammar/test_tools.py
+++ b/tests/test/plan/grammar/test_tools.py
@@ -19,69 +19,69 @@ class TestPathAccessors(unittest.TestCase):
         out = {}
         path_put(out, 'foo', 'bar')
 
-        self.assertEquals(out, {'foo': 'bar'})
-        self.assertEquals(path_get(out, 'foo'), 'bar')
+        self.assertEqual(out, {'foo': 'bar'})
+        self.assertEqual(path_get(out, 'foo'), 'bar')
 
     def test_002_nested_put(self):
         out = {}
         path_put(out, 'foo.bar', 'baz')
 
-        self.assertEquals(out, {'foo': {'bar': 'baz'}})
-        self.assertEquals(path_get(out, 'foo.bar'), 'baz')
+        self.assertEqual(out, {'foo': {'bar': 'baz'}})
+        self.assertEqual(path_get(out, 'foo.bar'), 'baz')
 
     def test_003_bracket_name_put(self):
         out = {}
         path_put(out, 'foo.{bar.baz}', 'moo')
 
-        self.assertEquals(out, {'foo': {'bar.baz': 'moo'}})
-        self.assertEquals(path_get(out, 'foo.{bar.baz}'), 'moo')
+        self.assertEqual(out, {'foo': {'bar.baz': 'moo'}})
+        self.assertEqual(path_get(out, 'foo.{bar.baz}'), 'moo')
 
     def test_004_bracket_name_then_more_depth(self):
         out = {}
         path_put(out, 'foo.{bar.baz}.gar', 'moo')
 
-        self.assertEquals(out, {'foo': {'bar.baz': {'gar': 'moo'}}})
-        self.assertEquals(path_get(out, 'foo.{bar.baz}.gar'), 'moo')
+        self.assertEqual(out, {'foo': {'bar.baz': {'gar': 'moo'}}})
+        self.assertEqual(path_get(out, 'foo.{bar.baz}.gar'), 'moo')
 
     def test_005_simple_array_put(self):
         out = {}
         path_put(out, 'foo.bar.0', 'thing')
 
-        self.assertEquals(out, {'foo': {'bar': ['thing']}})
-        self.assertEquals(path_get(out, 'foo.bar.0'), 'thing')
+        self.assertEqual(out, {'foo': {'bar': ['thing']}})
+        self.assertEqual(path_get(out, 'foo.bar.0'), 'thing')
 
     def test_005_02_bracket_name_then_list(self):
         out = {}
         path_put(out, 'foo.bar.{thing.in.bracket}.0', 'la la la')
-        self.assertEquals(out, {'foo': {'bar': {'thing.in.bracket': ['la la la']}}})
-        self.assertEquals(path_get(out, 'foo.bar.{thing.in.bracket}.0'), 'la la la')
+        self.assertEqual(out, {'foo': {'bar': {'thing.in.bracket': ['la la la']}}})
+        self.assertEqual(path_get(out, 'foo.bar.{thing.in.bracket}.0'), 'la la la')
 
     def test_006_array_with_nested_dict(self):
         out = {}
         path_put(out, 'foo.bar.0.baz', 'thing')
 
-        self.assertEquals(out, {'foo': {'bar': [{'baz': 'thing'}]}})
-        self.assertEquals(path_get(out, 'foo.bar.0.baz'), 'thing')
+        self.assertEqual(out, {'foo': {'bar': [{'baz': 'thing'}]}})
+        self.assertEqual(path_get(out, 'foo.bar.0.baz'), 'thing')
 
     def test_007_array_with_nested_array(self):
         out = {}
         path_put(out, 'foo.bar.0.0.baz', 'thing')
 
-        self.assertEquals(out, {'foo': {'bar': [[{'baz': 'thing'}]]}})
-        self.assertEquals(path_get(out, 'foo.bar.0.0.baz'), 'thing')
+        self.assertEqual(out, {'foo': {'bar': [[{'baz': 'thing'}]]}})
+        self.assertEqual(path_get(out, 'foo.bar.0.0.baz'), 'thing')
 
     def test_008_array_with_missing_index(self):
         out = {}
         path_put(out, 'foo.bar.2.baz', 'thing')
 
-        self.assertEquals(out, {'foo': {'bar': [{}, {}, {'baz': 'thing'}]}})
-        self.assertEquals(path_get(out, 'foo.bar.2.baz'), 'thing')
+        self.assertEqual(out, {'foo': {'bar': [{}, {}, {'baz': 'thing'}]}})
+        self.assertEqual(path_get(out, 'foo.bar.2.baz'), 'thing')
 
     def test_009_numeric_dictionary_keys(self):
         out = {}
         path_put(out, 'foo.bar.{2}.baz', 'thing')
-        self.assertEquals(out, {'foo': {'bar': {'2': {'baz': 'thing'}}}})
-        self.assertEquals(path_get(out, 'foo.bar.{2}.baz'), 'thing')
+        self.assertEqual(out, {'foo': {'bar': {'2': {'baz': 'thing'}}}})
+        self.assertEqual(path_get(out, 'foo.bar.{2}.baz'), 'thing')
 
     def test_010_path_get_missing_key(self):
         with self.assertRaises(KeyError):
@@ -110,19 +110,19 @@ class TestPathAccessors(unittest.TestCase):
     def test_016_escaped_array_index_key(self):
         out = {}
         path_put(out, '{record_transaction.0}.inputs.foo', 'bar')
-        self.assertEquals(out, {'record_transaction.0': {'inputs': {'foo': 'bar'}}})
-        self.assertEquals(path_get(out, '{record_transaction.0}.inputs.foo'), 'bar')
+        self.assertEqual(out, {'record_transaction.0': {'inputs': {'foo': 'bar'}}})
+        self.assertEqual(path_get(out, '{record_transaction.0}.inputs.foo'), 'bar')
 
     def test_017_escaped_array_of_dict(self):
         out = {}
         path_put(out, 'transaction.metadata.references.0.reference_type', 'FOO')
         path_put(out, 'transaction.metadata.references.0.reference_ids.0', '1234')
-        self.assertEquals(
+        self.assertEqual(
             out,
             {'transaction': {'metadata': {'references': [{'reference_type': 'FOO', 'reference_ids': ['1234']}]}}},
         )
-        self.assertEquals(path_get(out, 'transaction.metadata.references.0.reference_type'), 'FOO')
-        self.assertEquals(path_get(out, 'transaction.metadata.references.0.reference_ids.0'), '1234')
+        self.assertEqual(path_get(out, 'transaction.metadata.references.0.reference_type'), 'FOO')
+        self.assertEqual(path_get(out, 'transaction.metadata.references.0.reference_ids.0'), '1234')
 
     def test_018_get_all_paths(self):
         path_list = [
@@ -143,14 +143,14 @@ class TestPathAccessors(unittest.TestCase):
         for path in path_list:
             path_put(out, path, 'blah_blah')
 
-        self.assertEquals(sorted(path_list), sorted(get_all_paths(out)))
+        self.assertEqual(sorted(path_list), sorted(get_all_paths(out)))
 
     def test_020_nested_brackets(self):
         out = {}
         path_put(out, 'charge.cost_components.{{item.gross}}', {'MISSING'})
 
-        self.assertEquals(out, {'charge': {'cost_components': {'{item.gross}': {'MISSING'}}}})
-        self.assertEquals(path_get(out, 'charge.cost_components.{{item.gross}}'), {'MISSING'})
+        self.assertEqual(out, {'charge': {'cost_components': {'{item.gross}': {'MISSING'}}}})
+        self.assertEqual(path_get(out, 'charge.cost_components.{{item.gross}}'), {'MISSING'})
 
 
 class TestSubstituteValues(unittest.TestCase):


### PR DESCRIPTION
`assertEquals` has been deprecated [0] both in Python 2 and Python 3, in
favor of `assertEqual`.

[0] https://docs.python.org/3/library/unittest.html#deprecated-aliases