### PR TITLE
[MINOR] Remove deprecated use of "encoding" argument in msgpack.unpackb

### DIFF
--- a/pysoa/common/serializer/msgpack_serializer.py
+++ b/pysoa/common/serializer/msgpack_serializer.py
@@ -80,7 +80,7 @@ class MsgpackSerializer(BaseSerializer):
 
     def blob_to_dict(self, blob):
         try:
-            return msgpack.unpackb(blob, encoding='utf-8', ext_hook=self.ext_hook)
+            return msgpack.unpackb(blob, raw=False, ext_hook=self.ext_hook)
         except (TypeError, msgpack.UnpackValueError, msgpack.ExtraData) as e:
             raise InvalidMessage(*e.args)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ base_requirements = [
     'conformity~=1.17',
     'currint~=1.6',
     'enum34;python_version<"3.4"',
-    'msgpack-python~=0.4',
+    'msgpack-python~=0.5,>=0.5.2',
     'redis~=2.10',
     'six~=1.10',
 ]

--- a/tests/common/transport/redis_gateway/backend/test_sentinel.py
+++ b/tests/common/transport/redis_gateway/backend/test_sentinel.py
@@ -146,7 +146,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
 
         client.send_message_to_queue(
             queue_key='test_simple_send_receive',
-            message=msgpack.packb(payload),
+            message=msgpack.packb(payload, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_simple_send_receive'),
@@ -158,7 +158,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
             message = message or client.get_connection('test_simple_send_receive').lpop('test_simple_send_receive')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload, msgpack.unpackb(message, raw=False))
 
     @mock.patch('redis.sentinel.Sentinel', new=MockSentinel)
     def test_services_send_receive(self):
@@ -168,7 +168,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
 
         client.send_message_to_queue(
             queue_key='test_services_send_receive',
-            message=msgpack.packb(payload),
+            message=msgpack.packb(payload, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_services_send_receive'),
@@ -180,7 +180,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
             message = message or client.get_connection('test_services_send_receive').lpop('test_services_send_receive')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload, msgpack.unpackb(message, raw=False))
 
     @mock.patch('redis.sentinel.Sentinel', new=MockSentinel)
     def test_no_hosts_send_receive(self):
@@ -190,7 +190,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
 
         client.send_message_to_queue(
             queue_key='test_no_hosts_send_receive',
-            message=msgpack.packb(payload),
+            message=msgpack.packb(payload, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_no_hosts_send_receive'),
@@ -202,7 +202,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
             message = message or client.get_connection('test_no_hosts_send_receive').lpop('test_no_hosts_send_receive')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload, msgpack.unpackb(message, raw=False))
 
     @mock.patch('redis.sentinel.Sentinel', new=MockSentinel)
     def test_hashed_server_send_receive(self):
@@ -212,7 +212,7 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
 
         client.send_message_to_queue(
             queue_key='test_hashed_send_receive!',
-            message=msgpack.packb(payload1),
+            message=msgpack.packb(payload1, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_hashed_send_receive!'),
@@ -221,13 +221,13 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
         message = client.get_connection('test_hashed_send_receive!').lpop('test_hashed_send_receive!')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload1, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload1, msgpack.unpackb(message, raw=False))
 
         payload2 = {'for': 'another value'}
 
         client.send_message_to_queue(
             queue_key='test_hashed_send_receive!',
-            message=msgpack.packb(payload2),
+            message=msgpack.packb(payload2, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_hashed_send_receive!'),
@@ -236,13 +236,13 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
         message = client.get_connection('test_hashed_send_receive!').lpop('test_hashed_send_receive!')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload2, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload2, msgpack.unpackb(message, raw=False))
 
         payload3 = {'hashing': 'will this work'}
 
         client.send_message_to_queue(
             queue_key='test_hashed_send_receive!',
-            message=msgpack.packb(payload3),
+            message=msgpack.packb(payload3, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_hashed_send_receive!'),
@@ -251,4 +251,4 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
         message = client.get_connection('test_hashed_send_receive!').lpop('test_hashed_send_receive!')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload3, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload3, msgpack.unpackb(message, raw=False))

--- a/tests/common/transport/redis_gateway/backend/test_standard.py
+++ b/tests/common/transport/redis_gateway/backend/test_standard.py
@@ -172,7 +172,7 @@ class TestStandardRedisClient(unittest.TestCase):
 
         client.send_message_to_queue(
             queue_key='test_simple_send_receive',
-            message=msgpack.packb(payload),
+            message=msgpack.packb(payload, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_simple_send_receive'),
@@ -184,7 +184,7 @@ class TestStandardRedisClient(unittest.TestCase):
             message = message or client.get_connection('test_simple_send_receive').lpop('test_simple_send_receive')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload, msgpack.unpackb(message, raw=False))
 
     def test_hashed_server_send_and_receive(self):
         client = self._set_up_client()
@@ -193,7 +193,7 @@ class TestStandardRedisClient(unittest.TestCase):
 
         client.send_message_to_queue(
             queue_key='test_hashed_send_receive!',
-            message=msgpack.packb(payload1),
+            message=msgpack.packb(payload1, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_hashed_send_receive!'),
@@ -202,13 +202,13 @@ class TestStandardRedisClient(unittest.TestCase):
         message = client.get_connection('test_hashed_send_receive!').lpop('test_hashed_send_receive!')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload1, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload1, msgpack.unpackb(message, raw=False))
 
         payload2 = {'for': 'another value'}
 
         client.send_message_to_queue(
             queue_key='test_hashed_send_receive!',
-            message=msgpack.packb(payload2),
+            message=msgpack.packb(payload2, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_hashed_send_receive!'),
@@ -217,13 +217,13 @@ class TestStandardRedisClient(unittest.TestCase):
         message = client.get_connection('test_hashed_send_receive!').lpop('test_hashed_send_receive!')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload2, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload2, msgpack.unpackb(message, raw=False))
 
         payload3 = {'hashing': 'will this work'}
 
         client.send_message_to_queue(
             queue_key='test_hashed_send_receive!',
-            message=msgpack.packb(payload3),
+            message=msgpack.packb(payload3, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_hashed_send_receive!'),
@@ -232,7 +232,7 @@ class TestStandardRedisClient(unittest.TestCase):
         message = client.get_connection('test_hashed_send_receive!').lpop('test_hashed_send_receive!')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload3, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload3, msgpack.unpackb(message, raw=False))
 
     def test_no_hosts_yields_single_default_host(self):
         client = StandardRedisClient()
@@ -241,7 +241,7 @@ class TestStandardRedisClient(unittest.TestCase):
 
         client.send_message_to_queue(
             queue_key='test_no_hosts_yields_single_default_host',
-            message=msgpack.packb(payload),
+            message=msgpack.packb(payload, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_no_hosts_yields_single_default_host'),
@@ -252,7 +252,7 @@ class TestStandardRedisClient(unittest.TestCase):
         ).lpop('test_no_hosts_yields_single_default_host')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload, msgpack.unpackb(message, raw=False))
 
     def test_string_host_yields_single_host(self):
         client = StandardRedisClient(hosts=['redis://localhost:1234/0'])
@@ -261,7 +261,7 @@ class TestStandardRedisClient(unittest.TestCase):
 
         client.send_message_to_queue(
             queue_key='test_string_host_yields_single_host',
-            message=msgpack.packb(payload),
+            message=msgpack.packb(payload, use_bin_type=True),
             expiry=10,
             capacity=10,
             connection=client.get_connection('test_string_host_yields_single_host'),
@@ -272,4 +272,4 @@ class TestStandardRedisClient(unittest.TestCase):
         ).lpop('test_string_host_yields_single_host')
 
         self.assertIsNotNone(message)
-        self.assertEqual(payload, msgpack.unpackb(message, encoding='utf-8'))
+        self.assertEqual(payload, msgpack.unpackb(message, raw=False))


### PR DESCRIPTION
Since `msgpack-python` version 0.5.2, the `encoding` parameter is deprecated. `raw=False` is the replacement for `encoding='utf-8'`. This commit makes that change and bumps the library to require at least 0.5.2.

Related warning message:

```
/usr/local/lib/python3.5/dist-packages/ebsoa/server/middleware/auth.py:137: PendingDeprecationWarning: encoding is deprecated, Use raw=False instead.
```