### PR TITLE
[MINOR] Allow setting `side_effect` while defining the stub

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -162,7 +162,7 @@ the real service is not configured).
 Calling ``stub_action``
 ***********************
 
-``stub_action`` has four potential arguments. Only the first two are required:
+``stub_action`` has five potential arguments. Only the first two are required:
 
 - ``service``: The name of the service on which this action will be called
 - ``action``: The name of the action to stub
@@ -170,17 +170,25 @@ Calling ``stub_action``
   would normally be returned from the action class's ``run`` method).
 - ``errors``: A list of SOA errors that should be raised, where each error is a dict with at least ``code`` and
   ``message`` keys and optionally a ``field`` for field errors.
+- ``side_effect``: A function, an exception class or instance, or an iterable. It behaves exactly like
+  ``mock.MagicMock.side_effect``.
 
 Instead of providing ``body`` and/or ``errors`` to ``stub_action``, you can manipulate the action stub object passed
 to the test method (or returned from the context manager) to tell it to return certain values or have certain side
 effects. The action stub object actually extends ``mock.MagicMock``, so you may already be very familiar with how it
 works.
 
-Given an action stub object ``stub_xx_action``, you can set ``stub_xx_action.return_value`` to control what
-the action returns (this is equivalent to the ``body`` argument to ``stub_action``). Alternatively, you can set
+Given an action stub object ``stub_xx_action``, you can set ``stub_xx_action.return_value`` to control what the action
+returns (this is equivalent to the ``body`` argument to ``stub_action``). Alternatively, you can set
 ``stub_xx_action.side_effect`` to raise SOA errors, provide different behavior for each of multiple expected calls, or
 exert more control over how the stub behaves. ``side_effect`` can be a single value of any of the following or a
 list/tuple (for multiple calls) where each value is any of the following:
+
+``side_effect`` is useful for raising exceptions or dynamically changing return values. The function is called with the
+same arguments as the mock, and unless it returns DEFAULT, the return value of this function is used as the return
+value. Alternatively ``side_effect`` can be an exception class or instance. In this case the exception will be raised
+when the mock is called. If ``side_effect`` is an iterable then each call to the mock will return the next value from
+the iterable.
 
 - A response body dict (same as the ``body`` argument to ``stub_action``)
 - An instance of ``ActionError`` with one or more SOA errors configured

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -181,19 +181,24 @@ works.
 Given an action stub object ``stub_xx_action``, you can set ``stub_xx_action.return_value`` to control what the action
 returns (this is equivalent to the ``body`` argument to ``stub_action``). Alternatively, you can set
 ``stub_xx_action.side_effect`` to raise SOA errors, provide different behavior for each of multiple expected calls, or
-exert more control over how the stub behaves. ``side_effect`` can be a single value of any of the following or a
-list/tuple (for multiple calls) where each value is any of the following:
+exert more control over how the stub behaves.
 
-``side_effect`` is useful for raising exceptions or dynamically changing return values. The function is called with the
-same arguments as the mock, and unless it returns DEFAULT, the return value of this function is used as the return
-value. Alternatively ``side_effect`` can be an exception class or instance. In this case the exception will be raised
-when the mock is called. If ``side_effect`` is an iterable then each call to the mock will return the next value from
-the iterable.
+While it's possible to use ``body`` or ``errors`` in conjunction with ``side_effect``, it is not recommended unless you
+really know what you're doing. It can be confusing for future developers working in your code. See the Python
+``unittest.Mock`` documentation for a detailed description of the expected behavior when specifying ``return_value`` and
+``side_effect`` at the same time. ``side_effect`` can be a single value of any of the following or a list/tuple (for
+multiple calls) where each value is any of the following:
 
 - A response body dict (same as the ``body`` argument to ``stub_action``)
 - An instance of ``ActionError`` with one or more SOA errors configured
 - A callable, which should accept one argument (which will be the request body dict) and should either return a
   response body dict or raise an ``ActionError``.
+
+``side_effect`` argument is useful for raising exceptions or dynamically changing return values. The function is called
+with the same arguments as the mock, and unless it returns DEFAULT, the return value of this function is used as the
+return value. Alternatively ``side_effect`` can be an exception class or instance. In this case the exception will be
+raised when the mock is called. If ``side_effect`` is an iterable then each call to the mock will return the next value
+from the iterable.
 
 
 Making ``stub_action`` Assertions

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -378,10 +378,11 @@ class stub_action(object):  # noqa
 
         mock_action = self._MockAction(name='{}.{}'.format(self.service, self.action))
 
+        if self.body or self.errors:
+            mock_action.return_value = ActionResponse(self.action, errors=self.errors, body=self.body)
+
         if self.side_effect:
             mock_action.side_effect = self.side_effect
-        elif self.body or self.errors:
-            mock_action.side_effect = lambda _: ActionResponse(self.action, errors=self.errors, body=self.body)
 
         @wraps(Client.send_request)
         def wrapped_send_request(client, service_name, actions, *args, **kwargs):

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -353,7 +353,7 @@ class stub_action(object):  # noqa
         def call_bodies(self):
             return tuple(args[0][0] for args in self.call_args_list)
 
-    def __init__(self, service, action, body=None, errors=None):
+    def __init__(self, service, action, body=None, errors=None, side_effect=None):
         assert isinstance(service, six.text_type), 'Stubbed service name "{}" must be unicode'.format(service)
         assert isinstance(action, six.text_type), 'Stubbed action name "{}" must be unicode'.format(action)
 
@@ -361,6 +361,7 @@ class stub_action(object):  # noqa
         self.action = action
         self.body = body or {}
         self.errors = errors or []
+        self.side_effect = side_effect
         self.enabled = False
 
         # Play nice with @mock.patch
@@ -377,7 +378,9 @@ class stub_action(object):  # noqa
 
         mock_action = self._MockAction(name='{}.{}'.format(self.service, self.action))
 
-        if self.body or self.errors:
+        if self.side_effect:
+            mock_action.side_effect = self.side_effect
+        elif self.body or self.errors:
             mock_action.side_effect = lambda _: ActionResponse(self.action, errors=self.errors, body=self.body)
 
         @wraps(Client.send_request)


### PR DESCRIPTION
This is currently possible only after the mock is returned by the context manager, which makes it impossible to define preconfigured stubs (specially when setting a callable that rely on variable data).