### PR TITLE
[MINOR] A better Syslog logging handler

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2047,6 +2047,10 @@ Settings Schema Definition
       ``anything``: *(no description)*
 
 
+- ``extra_fields_to_redact`` - ``set``: Use this field to supplement the set of fields that are automatically redacted/censored in request and response fields with additional fields that your service needs redacted.
+
+  values
+    ``unicode``: *(no description)*
 - ``harakiri`` - strict ``dict``: Instructions for automatically terminating a server process when request processing takes longer than expected.
 
   - ``shutdown_grace`` - ``integer``: Seconds to forcefully shutdown after harakiri is triggered if shutdown does not occur (additional information: ``{u'gt': 0}``)
@@ -2195,6 +2199,7 @@ apply as the default values.
 
     {
         "client_routing": {},
+        "extra_fields_to_redact": [],
         "harakiri": {
             "shutdown_grace": 30,
             "timeout": 300
@@ -2229,7 +2234,7 @@ apply as the default values.
                         "localhost",
                         514
                     ],
-                    "class": "logging.handlers.SysLogHandler",
+                    "class": "pysoa.common.logging.SyslogHandler",
                     "facility": 23,
                     "filters": [
                         "pysoa_logging_context_filter"

--- a/pysoa/common/logging.py
+++ b/pysoa/common/logging.py
@@ -4,6 +4,8 @@ from __future__ import (
 )
 
 import logging
+import logging.handlers
+import socket
 import threading
 
 import six
@@ -176,6 +178,7 @@ class RecursivelyCensoredDictWrapper(object):
 
     def __unicode__(self):
         # If this method is called, we must be in Python 2, which means __str__ must be returning bytes
+        # noinspection PyUnresolvedReferences
         return self.__str__().decode('utf-8')
 
     @classmethod
@@ -199,3 +202,192 @@ class RecursivelyCensoredDictWrapper(object):
     @classmethod
     def _copy_and_censor_iterable(cls, i, should_censor_strings):
         return type(i)(cls._copy_and_censor_unknown_value(v, should_censor_strings) for v in i)
+
+
+IP_MTU_DISCOVER = 10  # Position of the IP Path MTU Discovery flag in request packets
+IP_MTU_DISCOVER_DO = 2  # "Don't fragment" value of the IP Path MTU Discovery flag in request packets
+WORST_CASE_MTU_IP = 576
+MTU_ATTEMPTS = 65535, 2000, 1500, 1280
+DATAGRAM_HEADER_LENGTH_IN_BYTES = 28
+
+
+def _discover_minimum_mtu_to_target(address, port):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect((address, port))
+    s.setsockopt(socket.IPPROTO_IP, IP_MTU_DISCOVER, IP_MTU_DISCOVER_DO)
+    for attempt in MTU_ATTEMPTS:
+        try:
+            s.send(b'#' * (attempt - DATAGRAM_HEADER_LENGTH_IN_BYTES))
+            return attempt
+        except socket.error as e:
+            if 'too long' not in e.strerror:
+                # We can't rely on the error code, because it varies from platform to platform, but the message always
+                # contains "too long" if we're getting an "MTU exceeded" ICMP response. IF this isn't an "MTU exceeded"
+                # response, then something went wrong, and we can't determine the MTU, so fall back to worst case.
+                break
+            # Now we try again with a lower MTU, which might still be too high
+    return WORST_CASE_MTU_IP
+
+
+class SyslogHandler(logging.handlers.SysLogHandler):
+    """
+    A more advanced Syslog logging handler that attempts to understand the MTU of the underlying connection and then
+    tailor Syslog packets to match that MTU, either by truncating or splitting logging packets. This contrasts to the
+    superclass, which will simply drop packets that exceed the MTU (optionally logging an error about the failure).
+
+    Notes:
+        The maximum UDP packet header in bytes is 28 bytes (20 bytes IP header + 8 bytes UDP header). Note that the
+        optional 40-byte IP header options could make this 68 bytes, but this is rarely used, and this handler does not
+        use it.
+
+        The Syslog priority and facility are encoded into a single 32-bit (4-byte) value.
+    """
+    OVERFLOW_BEHAVIOR_FRAGMENT = 0
+    OVERFLOW_BEHAVIOR_TRUNCATE = 1
+
+    def __init__(
+        self,
+        address=('localhost', logging.handlers.SYSLOG_UDP_PORT),
+        facility=logging.handlers.SysLogHandler.LOG_USER,
+        socket_type=None,
+        overflow=OVERFLOW_BEHAVIOR_FRAGMENT,
+    ):
+        super(SyslogHandler, self).__init__(address, facility, socket_type)
+
+        if not self.unixsocket and self.socktype == socket.SOCK_DGRAM:
+            self.maximum_length = _discover_minimum_mtu_to_target(address[0], 9999) - DATAGRAM_HEADER_LENGTH_IN_BYTES
+            self.overflow = overflow
+        else:
+            self.maximum_length = 1048576  # Let's not send more than a megabyte to Syslog, even over TCP/Unix ... crazy
+            self.overflow = self.OVERFLOW_BEHAVIOR_TRUNCATE
+
+    def emit(self, record):
+        """
+        Emits a record. The record is sent carefully, according to the following rules, to ensure that data is not
+        lost by exceeding the MTU of the connection.
+
+        - If the byte-encoded record length plus prefix length plus suffix length plus priority length is less than the
+          maximum allowed length, then a single packet is sent, containing the priority, prefix, full record, and
+          suffix, in that order.
+
+        - If it's greater than or equal to the maximum allowed length and the overflow behavior is set to "truncate,"
+          the record is cleanly truncated (being careful not to split in the middle of a multi-byte character), and
+          then a single packet is sent, containing the priority, prefix, truncated record, and suffix, in that order.
+
+        - If it's greater than or equal to the maximum allowed length and the overflow behavior is set to "fragment,"
+          the record preamble (things like file name, logger name, correlation ID, etc.) is extracted from the start
+          of the record to calculate a new chunk length. The remainder of the record (which should just be the true
+          message and any exception info) is then chunked (being careful not to split in the middle of a multi-byte
+          character) into lengths less than or equal to the chunk length, and then the record is sent as multiple
+          packets, each packet containing the priority, prefix, record preamble, message chunk, and suffix, in that
+          order.
+        """
+        # noinspection PyBroadException
+        try:
+            formatted_message = self.format(record)
+            encoded_message = formatted_message.encode('utf-8')
+
+            prefix = suffix = b''
+            if getattr(self, 'ident', False):
+                prefix = self.ident.encode('utf-8') if isinstance(self.ident, six.text_type) else self.ident
+            if getattr(self, 'append_nul', True):
+                suffix = '\000'.encode('utf-8')
+
+            priority = '<{:d}>'.format(
+                self.encodePriority(self.facility, self.mapPriority(record.levelname))
+            ).encode('utf-8')
+
+            message_length = len(encoded_message)
+            message_length_limit = self.maximum_length - len(prefix) - len(suffix) - len(priority)
+
+            if message_length < message_length_limit:
+                parts = [priority + prefix + encoded_message + suffix]
+            elif self.overflow == self.OVERFLOW_BEHAVIOR_TRUNCATE:
+                truncated_message, _ = self._cleanly_slice_encoded_string(encoded_message, message_length_limit)
+                parts = [priority + prefix + truncated_message + suffix]
+            else:
+                # This can't work perfectly, but it's pretty unusual for a message to go before machine-parseable parts
+                # in the formatted record. So we split the record on the message part. Everything before the split
+                # becomes the preamble and gets repeated every packet. Everything after the split gets chunked. There's
+                # no reason to match on more than the first 40 characters of the message--the chances of that matching
+                # the wrong part of the record are astronomical.
+                try:
+                    index = formatted_message.index(record.getMessage()[:40])
+                    start_of_message, to_chunk = formatted_message[:index], formatted_message[index:]
+                except (TypeError, ValueError):
+                    # We can't locate the message in the formatted record? That's unfortunate. Let's make something up.
+                    start_of_message, to_chunk = '{} '.format(formatted_message[:30]), formatted_message[30:]
+
+                start_of_message = start_of_message.encode('utf-8')
+                to_chunk = to_chunk.encode('utf-8')
+
+                # 12 is the length of "... (cont'd)" in bytes
+                chunk_length_limit = message_length_limit - len(start_of_message) - 12
+
+                i = 1
+                parts = []
+                remaining_message = to_chunk
+                while remaining_message:
+                    message_id = b''
+                    subtractor = 0
+                    if i > 1:
+                        # If this is not the first message, we determine message # so that we can subtract that length
+                        message_id = '{}'.format(i).encode('utf-8')
+                        # 14 is the length of "(cont'd #) ..." in bytes
+                        subtractor = 14 + len(message_id)
+                    chunk, remaining_message = self._cleanly_slice_encoded_string(
+                        remaining_message,
+                        chunk_length_limit - subtractor,
+                    )
+                    if i > 1:
+                        # If this is not the first message, we prepend the chunk to indicate continuation
+                        chunk = b"(cont'd #" + message_id + b') ...' + chunk
+                    i += 1
+                    if remaining_message:
+                        # If this is not the last message, we append the chunk to indicate continuation
+                        chunk = chunk + b"... (cont'd)"
+                    parts.append(priority + prefix + start_of_message + chunk + suffix)
+
+            self._send(parts)
+        except Exception:
+            self.handleError(record)
+
+    def _send(self, parts):
+        for message in parts:
+            if self.unixsocket:
+                try:
+                    self.socket.send(message)
+                except OSError:
+                    self.socket.close()
+                    self._connect_unixsocket(self.address)
+                    self.socket.send(message)
+            elif self.socktype == socket.SOCK_DGRAM:
+                self.socket.sendto(message, self.address)
+            else:
+                self.socket.sendall(message)
+
+    @staticmethod
+    def _cleanly_slice_encoded_string(encoded_string, length_limit):
+        """
+        Takes a byte string (a UTF-8 encoded string) and splits it into two pieces such that the first slice is no
+        longer than argument `length_limit`, then returns a tuple containing the first slice and remainder of the
+        byte string, respectively. The first slice may actually be shorter than `length_limit`, because this ensures
+        that the string does not get split in the middle of a multi-byte character.
+
+        This works because the first byte in a multi-byte unicode character encodes how many bytes compose that
+        character, so we can determine empirically if we are splitting in the middle of the character and correct for
+        that.
+
+        You can read more about how this works here: https://en.wikipedia.org/wiki/UTF-8#Description
+
+        :param encoded_string: The encoded string to split in two
+        :param length_limit: The maximum length allowed for the first slice of the string
+        :return: A tuple of (slice, remaining)
+        """
+        sliced, remaining = encoded_string[:length_limit], encoded_string[length_limit:]
+        try:
+            sliced.decode('utf-8')
+        except UnicodeDecodeError as e:
+            sliced, remaining = sliced[:e.start], sliced[e.start:] + remaining
+
+        return sliced, remaining

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -4,10 +4,10 @@ from __future__ import (
 )
 
 import functools
-from logging.handlers import SysLogHandler
 
 from conformity import fields
 
+from pysoa.common.logging import SyslogHandler
 from pysoa.common.schemas import (
     BasicClassSchema,
     PolymorphClassSchema,
@@ -172,8 +172,8 @@ class ServerSettings(SOASettings):
                 },
                 'syslog': {
                     'level': 'INFO',
-                    'class': 'logging.handlers.SysLogHandler',
-                    'facility': SysLogHandler.LOG_LOCAL7,
+                    'class': 'pysoa.common.logging.SyslogHandler',
+                    'facility': SyslogHandler.LOG_LOCAL7,
                     'address': ('localhost', 514),
                     'formatter': 'syslog',
                     'filters': ['pysoa_logging_context_filter'],


### PR DESCRIPTION
The Syslog logging handler built into Python has a crucial flaw: If the total, formatted log message exceeds the minimum interface MTU between the service and the Syslog server, that entire message is lost if sent over UDP (the default and best-performing option). It will either log the error or silently fail, but the message will be lost. Since PySOA logging includes request/response logging, which can be large, it means we can possibly lose a lot of logged information that we didn't expect to lose, without even know we lost it.

This commit provides an improvement on that built-in Syslog handler. At startup, it will attempt to determine the minimum MTU between the running process and the Syslog server, or make an educated guess if it can't (or set an upper boundary of 1MB over TCP and Unix sockets). It will then either truncate all messages to come in under that MTU or fragment messages into multiple Syslog messages, based on the configured setting.

This Syslog handler replaces the built-in Syslog handler in the default Server settings.