### PR TITLE
[MAJOR] Add support for switching message serializer with content type header

### DIFF
--- a/pysoa/common/serializer/base.py
+++ b/pysoa/common/serializer/base.py
@@ -5,8 +5,52 @@ import abc
 import six
 
 
-@six.add_metaclass(abc.ABCMeta)
+__all__ = (
+    'Serializer',
+)
+
+
+class _SerializerMeta(abc.ABCMeta):
+    _mime_type_to_serializer_map = {}
+    _all_supported_mime_types = frozenset()
+
+    def __new__(mcs, name, bases, body):
+        # Don't allow multiple inheritance as it mucks up mime-type collection
+        if len(bases) != 1:
+            raise ValueError('You cannot use multiple inheritance with Serializers')
+        # Make the new class
+        cls = super(_SerializerMeta, mcs).__new__(mcs, name, bases, body)
+
+        if bases[0] is not object:
+            if not cls.mime_type or not cls.mime_type.strip():
+                raise ValueError('All serializers must have a non-null, non-blank MIME type')
+
+            if cls.mime_type in mcs._all_supported_mime_types:
+                raise ValueError('Another serializer {cls} already supports mime type {mime_type}'.format(
+                    cls=mcs._mime_type_to_serializer_map[cls.mime_type],
+                    mime_type=cls.mime_type,
+                ))
+
+            mcs._mime_type_to_serializer_map[cls.mime_type] = cls
+            mcs._all_supported_mime_types = frozenset(mcs._mime_type_to_serializer_map.keys())
+
+        return cls
+
+    @property
+    def all_supported_mime_types(cls):
+        return cls._all_supported_mime_types
+
+
+@six.add_metaclass(_SerializerMeta)
 class Serializer(object):
+
+    mime_type = None
+
+    @classmethod
+    def resolve_serializer(cls, mime_type):
+        if mime_type not in cls.all_supported_mime_types:
+            raise ValueError('Mime type {} is not supported'.format(mime_type))
+        return cls._mime_type_to_serializer_map[mime_type]()
 
     @abc.abstractmethod
     def dict_to_blob(self, message_dict):

--- a/pysoa/common/serializer/json_serializer.py
+++ b/pysoa/common/serializer/json_serializer.py
@@ -28,7 +28,7 @@ class JSONSerializer(BaseSerializer):
     def dict_to_blob(self, data_dict):
         assert isinstance(data_dict, dict), 'Input must be a dict'
         try:
-            return json.dumps(data_dict)
+            return json.dumps(data_dict).encode('utf-8')
         except TypeError as e:
             raise InvalidField(*e.args)
 

--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -15,7 +15,7 @@ from pysoa.common.schemas import BasicClassSchema
 from pysoa.utils import resolve_python_path
 
 
-class SettingsMetaclass(type):
+class _SettingsMetaclass(type):
     """
     Metaclass that gathers fields defined on settings objects into a single
     variable to access them.
@@ -26,7 +26,7 @@ class SettingsMetaclass(type):
         if len(bases) != 1:
             raise ValueError('You cannot use multiple inheritance with Settings')
         # Make the new class
-        cls = type.__new__(mcs, name, bases, body)
+        cls = super(_SettingsMetaclass, mcs).__new__(mcs, name, bases, body)
         # Merge the schema and defaults objects with their parents
         if bases[0] is not object:
             cls.schema = dict(itertools.chain(bases[0].schema.items(), cls.schema.items()))
@@ -34,7 +34,7 @@ class SettingsMetaclass(type):
         return cls
 
 
-@six.add_metaclass(SettingsMetaclass)
+@six.add_metaclass(_SettingsMetaclass)
 class Settings(object):
     """
     Represents settings that can be passed to either a Client or a Server, and

--- a/pysoa/common/transport/redis_gateway/settings.py
+++ b/pysoa/common/transport/redis_gateway/settings.py
@@ -85,7 +85,7 @@ class RedisTransportSchema(BasicClassSchema):
                 'receive_timeout_in_seconds': fields.Integer(
                     description='How long to block waiting on a message to be received',
                 ),
-                'serializer_config': BasicClassSchema(
+                'default_serializer_config': BasicClassSchema(
                     object_type=BaseSerializer,
                     description='The configuration for the serializer this transport should use',
                 ),
@@ -98,7 +98,7 @@ class RedisTransportSchema(BasicClassSchema):
                 'queue_capacity',
                 'queue_full_retries',
                 'receive_timeout_in_seconds',
-                'serializer_config',
+                'default_serializer_config',
             ],
             allow_extra_keys=False,
         ),

--- a/tests/common/test_settings.py
+++ b/tests/common/test_settings.py
@@ -230,7 +230,7 @@ class TestSOASettings(unittest.TestCase):
                     'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
                     'kwargs': {
                         'backend_type': REDIS_BACKEND_TYPE_STANDARD,
-                        'serializer_config': {
+                        'default_serializer_config': {
                             'path': 'pysoa.common.serializer:JSONSerializer'
                         }
                     }
@@ -245,7 +245,7 @@ class TestSOASettings(unittest.TestCase):
         assert handler.transport._send_queue_name == 'service.test_service'
         assert isinstance(handler.transport.core, RedisTransportCore)
         assert handler.transport.core.backend_type == REDIS_BACKEND_TYPE_STANDARD
-        assert isinstance(handler.transport.core.serializer, JSONSerializer)
+        assert isinstance(handler.transport.core.default_serializer, JSONSerializer)
 
     # noinspection PyProtectedMember
     def test_server_settings(self):
@@ -259,7 +259,7 @@ class TestSOASettings(unittest.TestCase):
                 'path': 'pysoa.common.transport.redis_gateway.server:RedisServerTransport',
                 'kwargs': {
                     'backend_type': REDIS_BACKEND_TYPE_STANDARD,
-                    'serializer_config': {
+                    'default_serializer_config': {
                         'path': 'pysoa.common.serializer:JSONSerializer'
                     }
                 }
@@ -272,7 +272,7 @@ class TestSOASettings(unittest.TestCase):
         assert server.transport._receive_queue_name == 'service.geo_tag'
         assert isinstance(server.transport.core, RedisTransportCore)
         assert server.transport.core.backend_type == REDIS_BACKEND_TYPE_STANDARD
-        assert isinstance(server.transport.core.serializer, JSONSerializer)
+        assert isinstance(server.transport.core.default_serializer, JSONSerializer)
 
     # noinspection PyProtectedMember
     def test_server_settings_generic_with_defaults(self):
@@ -296,7 +296,7 @@ class TestSOASettings(unittest.TestCase):
         assert server.transport._receive_queue_name == 'service.tag_geo'
         assert isinstance(server.transport.core, RedisTransportCore)
         assert server.transport.core.backend_type == REDIS_BACKEND_TYPE_STANDARD
-        assert isinstance(server.transport.core.serializer, MsgpackSerializer)
+        assert isinstance(server.transport.core.default_serializer, MsgpackSerializer)
 
     def test_server_settings_fails_with_client_transport(self):
         """The server settings fail to validate with client transport"""
@@ -357,7 +357,7 @@ class TestSOASettings(unittest.TestCase):
                 'path': 'pysoa.common.transport.redis_gateway.server:RedisServerTransport',
                 'kwargs': {
                     'backend_type': REDIS_BACKEND_TYPE_STANDARD,
-                    'serializer_config': {
+                    'default_serializer_config': {
                         'path': 'pysoa.server.middleware:ServerMiddleware',
                     }
                 },


### PR DESCRIPTION
This is the first step (commit) in a three-step (three-commit) breaking change to add support for switching the message serializer that the Redis transport uses based on a content-type header. There will be two more breaking commits in two future versions, in order to make migration possible.

Breaking changes in this commit/step:
- The Redis transport setting `serializer_config` has been renamed to `default_serializer_config` (it still defaults to the `MsgpackSerializer` like it did before, and it does not appear to be used anywhere at Eventbrite).
- The Redis transport "core" class attribute `serializer` has been renamed to `default_serializer` (it appeared to only be used in PySOA code).

Explanation of the steps:
- Step 1 (this commit): Rename the configuration setting, make the `receive_message` method use a switched serializer if the content type header is present, and make the `send_message` method use a switched serializer and include a content type header if the `receive_message` method found a content type header. Deploy this to all servers and clients.
- Step 2: Make the `send_message` method always send a content type header. Deploy this to all servers and clients.
- Step 3: Make the `receive_message` method enforce the presence of a content type header. Deploy this to all servers and clients.