### PR TITLE
[MINOR] Prevent server shutdown on request with non-unicode context keys

### DIFF
--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -1009,4 +1009,5 @@ class Client(object):
         # Add any extra stuff
         if context_extra:
             context.update(context_extra)
-        return context
+        # context keys need to be guaranteed unicode
+        return {six.text_type(k): v for k, v in six.iteritems(context)}

--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -1009,5 +1009,4 @@ class Client(object):
         # Add any extra stuff
         if context_extra:
             context.update(context_extra)
-        # context keys need to be guaranteed unicode
-        return {six.text_type(k): v for k, v in six.iteritems(context)}
+        return context

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -177,8 +177,12 @@ class Server(object):
         try:
             PySOALogContextFilter.set_logging_request_context(request_id=request_id, **job_request['context'])
         except TypeError:
-            # non unicode keys in job_request['context'] will break keywording of a function call
-            pass
+            # Non unicode keys in job_request['context'] will break keywording of a function call.
+            # Try to recover by coercing the keys
+            PySOALogContextFilter.set_logging_request_context(
+                request_id=request_id,
+                **{six.text_type(k): v for k, v in six.iteritems(job_request['context'])}
+            )
 
         request_for_logging = self.logging_dict_wrapper_class(job_request)
         self.job_logger.log(self.request_log_success_level, 'Job request: %s', request_for_logging)

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -174,7 +174,11 @@ class Server(object):
         self._idle_timer.stop()
         self._idle_timer = None
 
-        PySOALogContextFilter.set_logging_request_context(request_id=request_id, **job_request['context'])
+        try:
+            PySOALogContextFilter.set_logging_request_context(request_id=request_id, **job_request['context'])
+        except TypeError:
+            # non unicode keys in job_request['context'] will break keywording of a function call
+            pass
 
         request_for_logging = self.logging_dict_wrapper_class(job_request)
         self.job_logger.log(self.request_log_success_level, 'Job request: %s', request_for_logging)


### PR DESCRIPTION
Server would shut down entirely if a request was received with non unicode keys in the context.  It appears to be a python issue when unpacking a dict with non-unicode keys into function arguments.

Not sure if something should be logged here.

The exception in this spot caused pysoa to choose to shutdown with:

2018-10-26 15:46:13,786   ERROR -- --: Unhandled server error; shutting down
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/pysoa/server/server.py", line 626, in run
    self.handle_next_request()
  File "/usr/local/lib/python3.5/dist-packages/pysoa/server/server.py", line 177, in handle_next_request
    PySOALogContextFilter.set_logging_request_context(request_id=request_id, **job_request['context'])
TypeError: set_logging_request_context() keywords must be strings
2018-10-26 15:46:13,787    INFO -- --: Server shutting down
2018-10-26 15:46:13,787    INFO -- --: Stopping and closing async event loop
2018-10-26 15:46:13,787    INFO -- --: Closing all Django caches
2018-10-26 15:46:13,787    INFO -- --: Closing and removing heartbeat file