### PR TITLE
[PATCH] Update test compatibility tools to eliminate warnings

### DIFF
--- a/pysoa/test/compatibility.py
+++ b/pysoa/test/compatibility.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
 
+from unittest import TestCase
+
 try:
     import mock
     # First we try to import the Python 2 backport library of Mock, because if the project is using it, we should use it
@@ -16,3 +18,11 @@ except ImportError as e:
 __all__ = (
     'mock'
 )
+
+
+if not hasattr(TestCase, 'assertRegex'):
+    # In Python 2.7, make sure we have the new method name from Python 3.3+
+    TestCase.assertRegex = TestCase.assertRegexpMatches
+if not hasattr(TestCase, 'assertNotRegex'):
+    # In Python 2.7, make sure we have the new method name from Python 3.3+
+    TestCase.assertNotRegex = TestCase.assertNotRegexpMatches

--- a/tests/common/transport/redis_gateway/test_client.py
+++ b/tests/common/transport/redis_gateway/test_client.py
@@ -19,6 +19,7 @@ class TestClientTransport(unittest.TestCase):
     def _get_transport(service='my_service', **kwargs):
         return RedisClientTransport(service, NoOpMetricsRecorder(), **kwargs)
 
+    # noinspection PyCompatibility
     def test_core_args(self, mock_core):
         transport = self._get_transport(hello='world', goodbye='earth')
 
@@ -31,7 +32,7 @@ class TestClientTransport(unittest.TestCase):
             maximum_message_size_in_bytes=DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT,
         )
 
-        self.assertRegexpMatches(transport.client_id, r'^[0-9a-fA-F]{32}$')
+        self.assertRegex(transport.client_id, r'^[0-9a-fA-F]{32}$')
 
         mock_core.reset_mock()
 
@@ -46,7 +47,7 @@ class TestClientTransport(unittest.TestCase):
             maximum_message_size_in_bytes=42,
         )
 
-        self.assertRegexpMatches(transport.client_id, r'^[0-9a-fA-F]{32}$')
+        self.assertRegex(transport.client_id, r'^[0-9a-fA-F]{32}$')
 
     def test_send_request_message(self, mock_core):
         transport = self._get_transport()

--- a/tests/server/test_autoreloader.py
+++ b/tests/server/test_autoreloader.py
@@ -98,6 +98,7 @@ class TestAbstractReloader(unittest.TestCase):
         with self.assertRaises(TypeError):
             AbstractReloader('example_service.name', None)
 
+    # noinspection PyCompatibility
     def test_constructor(self):
         reloader = MockReloader('example_service.standalone', None)
         self.assertEqual('example_service.standalone', reloader.main_module_name)
@@ -114,17 +115,17 @@ class TestAbstractReloader(unittest.TestCase):
         self.assertIsNotNone(reloader.watch_modules)
         self.assertFalse(reloader.signal_forks)
 
-        self.assertRegexpMatches('example_service', reloader.watch_modules)
-        self.assertRegexpMatches('example_service.actions', reloader.watch_modules)
-        self.assertRegexpMatches('example_service.models', reloader.watch_modules)
-        self.assertRegexpMatches('example_service.server', reloader.watch_modules)
-        self.assertRegexpMatches('example_library', reloader.watch_modules)
-        self.assertRegexpMatches('example_library.utils', reloader.watch_modules)
-        self.assertRegexpMatches('pysoa', reloader.watch_modules)
-        self.assertRegexpMatches('pysoa.server', reloader.watch_modules)
-        self.assertRegexpMatches('pysoa.version', reloader.watch_modules)
-        self.assertRegexpMatches('django', reloader.watch_modules)
-        self.assertRegexpMatches('django.conf', reloader.watch_modules)
+        self.assertRegex('example_service', reloader.watch_modules)
+        self.assertRegex('example_service.actions', reloader.watch_modules)
+        self.assertRegex('example_service.models', reloader.watch_modules)
+        self.assertRegex('example_service.server', reloader.watch_modules)
+        self.assertRegex('example_library', reloader.watch_modules)
+        self.assertRegex('example_library.utils', reloader.watch_modules)
+        self.assertRegex('pysoa', reloader.watch_modules)
+        self.assertRegex('pysoa.server', reloader.watch_modules)
+        self.assertRegex('pysoa.version', reloader.watch_modules)
+        self.assertRegex('django', reloader.watch_modules)
+        self.assertRegex('django.conf', reloader.watch_modules)
 
         self.assertFalse(reloader.watch_modules.match('another_library'))
 


### PR DESCRIPTION
We were getting a ton of test warnings about deprecated `unittest.TestCase` methods. This commit allows us to use the new-to-Python-3.3 name in both Python 3 and Python 2.7.