### PR TITLE
[PATCH] Run the event loop in a separate thread.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# from the repo
+.dockerignore
+.git
+.gitignore
+.travis.yml
+Dockerfile
+
+# Python + testing artifacts
+*,cover
+*.egg-info
+*.eggs
+*.log
+**/*.pyc
+**/*.pyd
+**/*.pyo
+.cache
+.coverage
+.pytest_cache
+.tox
+**/__pycache__
+coverage.xml
+pytests.xml
+
+# Random
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ dist/
 coverage.xml
 pytests.xml
 .pytest_cache
+
+.tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+from ubuntu:16.04
+
+RUN apt-get update && \
+	apt-get install -y \
+		software-properties-common \
+		wget \
+		pkg-config \
+		lua5.1 \
+		liblua5.1-0-dev
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+	apt-get update && \
+	apt-get install -y \
+		python2.7 \
+		python2.7-dev \
+		python3.4 \
+		python3.4-dev \
+		python3.5 \
+		python3.5-dev \
+		python3.6 \
+		python3.6-dev \
+		python3.7 \
+		python3.7-dev
+RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && \
+	python3.7 /tmp/get-pip.py && \
+	pip install tox
+
+ADD . /test/pysoa
+
+WORKDIR /test/pysoa
+
+CMD ["tox"]

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,4 @@ have the service code in place, and a ``stub_action`` decorator / context manage
 For more information about using these test utilities in your services or service-calling applications, see the testing
 documentation in the `PySOA Documentation <docs/index.rst>`_.
 
-For testing this PySOA library directly, you must first install Lua on your system (on Mac OS X this is done with
-``brew install lua``), ensure Lua is on your ``$PKG_CONFIG_PATH`` environment variable (in Mac OS X), and then install
-dependencies (``pip install -e .[testing]``). After this, you can simply run ``pytest`` or ``setup.py test``.
+For testing this PySOA library directly on your system, you must first install `Docker <https://www.docker.com/get-started>`_. Once installed, the PySOA test image can be built with the following command: ``docker build . -t pysoa-test``. Once the pysoa-test image has been built, run ``docker run pysoa-test`` to execute the test suite. The test suite will run for all supported versions of Python.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+import sys
+
+# Skip event loop tests for Python versions less than 3.5
+collect_ignore = []
+if sys.version_info < (3, 5):
+    collect_ignore.append('tests/server/internal/test_event_loop.py')

--- a/docs/update_reference_docs.py
+++ b/docs/update_reference_docs.py
@@ -471,7 +471,10 @@ def get_class_documentation(class_name, module_name, class_object):
     members = inspect.getmembers(class_object)
 
     if getattr(class_object, '__attrs_attrs__', None):
-        documentation += '\n\n.. _{module_name}.{class_name}-attrs-docs:\n\nAttrs Properties\n****************\n'.format(
+        documentation += (
+            '\n\n.. _{module_name}.{class_name}-attrs-docs:'
+            '\n\nAttrs Properties\n****************\n'
+        ).format(
             module_name=module_name,
             class_name=class_name,
         )

--- a/pysoa/server/internal/event_loop.py
+++ b/pysoa/server/internal/event_loop.py
@@ -2,8 +2,7 @@ import asyncio
 import threading
 
 
-def _loop_stop_callback():
-    loop = asyncio.get_running_loop()
+def _loop_stop_callback(loop):
     loop.stop()
 
 
@@ -20,7 +19,7 @@ class AsyncEventLoopThread(threading.Thread):
             self.loop.run_forever()
         finally:
             try:
-                pending_tasks = asyncio.all_tasks(self.loop)
+                pending_tasks = asyncio.Task.all_tasks(self.loop)
                 self.loop.run_until_complete(asyncio.gather(*pending_tasks))
             finally:
                 self.loop.close()
@@ -29,7 +28,7 @@ class AsyncEventLoopThread(threading.Thread):
 
     def join(self):
         if self.loop.is_running():
-            self.loop.call_soon_threadsafe(_loop_stop_callback)
+            self.loop.call_soon_threadsafe(_loop_stop_callback, self.loop)
         self._done.wait()
 
     def run_coroutine(self, coroutine):

--- a/pysoa/server/internal/event_loop.py
+++ b/pysoa/server/internal/event_loop.py
@@ -2,15 +2,14 @@ import asyncio
 import threading
 
 
-def _loop_stop_callback(loop):
-    loop.stop()
-
-
 class AsyncEventLoopThread(threading.Thread):
     def __init__(self):
         super().__init__()
         self.loop = asyncio.new_event_loop()
         self._done = threading.Event()
+
+    def _loop_stop_callback(self):
+        self.loop.stop()
 
     def run(self):
         self._done.clear()
@@ -28,7 +27,7 @@ class AsyncEventLoopThread(threading.Thread):
 
     def join(self):
         if self.loop.is_running():
-            self.loop.call_soon_threadsafe(_loop_stop_callback, self.loop)
+            self.loop.call_soon_threadsafe(self._loop_stop_callback)
         self._done.wait()
 
     def run_coroutine(self, coroutine):

--- a/pysoa/server/internal/event_loop.py
+++ b/pysoa/server/internal/event_loop.py
@@ -1,0 +1,36 @@
+import asyncio
+import threading
+
+
+def _loop_stop_callback():
+    loop = asyncio.get_running_loop()
+    loop.stop()
+
+
+class AsyncEventLoopThread(threading.Thread):
+    def __init__(self):
+        super().__init__()
+        self.loop = asyncio.new_event_loop()
+        self._done = threading.Event()
+
+    def run(self):
+        self._done.clear()
+        asyncio.set_event_loop(self.loop)
+        try:
+            self.loop.run_forever()
+        finally:
+            try:
+                pending_tasks = asyncio.all_tasks(self.loop)
+                self.loop.run_until_complete(asyncio.gather(*pending_tasks))
+            finally:
+                self.loop.close()
+                asyncio.set_event_loop(None)
+                self._done.set()
+
+    def join(self):
+        if self.loop.is_running():
+            self.loop.call_soon_threadsafe(_loop_stop_callback)
+        self._done.wait()
+
+    def run_coroutine(self, coroutine):
+        return asyncio.run_coroutine_threadsafe(coroutine, self.loop)

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -22,3 +22,4 @@ class EnrichedActionRequest(ActionRequest):
     control = attr.ib(default=attr.Factory(dict))
     client = attr.ib(default=None)
     async_event_loop = attr.ib(default=None)
+    run_coroutine = attr.ib(default=None)

--- a/tests/server/internal/test_event_loop.py
+++ b/tests/server/internal/test_event_loop.py
@@ -1,0 +1,42 @@
+import threading
+import unittest
+
+try:
+    import asyncio
+    from pysoa.server.internal.event_loop import AsyncEventLoopThread
+
+    class AsyncEventLoopThreadTests(unittest.TestCase):
+        def setUp(self):
+            super(AsyncEventLoopThreadTests, self).setUp()
+            self.thread = AsyncEventLoopThread()
+            self.thread.start()
+
+        def tearDown(self):
+            self.thread.join()
+
+        def test_loop_runs_in_another_thread(self):
+            async def test_threads(thread):
+                assert thread is not threading.current_thread()
+
+            future = self.thread.run_coroutine(test_threads(threading.current_thread()))
+            future.result()
+
+        def test_loop_executes_pending_tasks_before_close(self):
+            async def test_execs_pending():
+                await asyncio.sleep(1)
+                return 1
+
+            def callback():
+                assert future.done()
+                assert future.result() == 1
+
+            future = self.thread.run_coroutine(test_execs_pending())
+            future.add_done_callback(callback)
+
+        def test_join_stops_and_closes_loop(self):
+            self.thread.join()
+            assert not self.thread.loop.is_running()
+            assert self.thread.loop.is_closed()
+
+except ImportError:
+    pass

--- a/tests/server/internal/test_event_loop.py
+++ b/tests/server/internal/test_event_loop.py
@@ -15,14 +15,14 @@ class AsyncEventLoopThreadTests(unittest.TestCase):
         self.thread.join()
 
     def test_loop_runs_in_another_thread(self):
-        async def test_threads(thread):
+        async def test_threads(thread):  # noqa E999
             assert thread is not threading.current_thread()
 
         future = self.thread.run_coroutine(test_threads(threading.current_thread()))
         future.result()
 
     def test_loop_executes_pending_tasks_before_close(self):
-        async def test_execs_pending():
+        async def test_execs_pending():  # noqa E999
             await asyncio.sleep(1)
             return 1
 

--- a/tests/server/internal/test_event_loop.py
+++ b/tests/server/internal/test_event_loop.py
@@ -1,42 +1,39 @@
+import asyncio
 import threading
 import unittest
 
-try:
-    import asyncio
-    from pysoa.server.internal.event_loop import AsyncEventLoopThread
+from pysoa.server.internal.event_loop import AsyncEventLoopThread
 
-    class AsyncEventLoopThreadTests(unittest.TestCase):
-        def setUp(self):
-            super(AsyncEventLoopThreadTests, self).setUp()
-            self.thread = AsyncEventLoopThread()
-            self.thread.start()
 
-        def tearDown(self):
-            self.thread.join()
+class AsyncEventLoopThreadTests(unittest.TestCase):
+    def setUp(self):
+        super(AsyncEventLoopThreadTests, self).setUp()
+        self.thread = AsyncEventLoopThread()
+        self.thread.start()
 
-        def test_loop_runs_in_another_thread(self):
-            async def test_threads(thread):
-                assert thread is not threading.current_thread()
+    def tearDown(self):
+        self.thread.join()
 
-            future = self.thread.run_coroutine(test_threads(threading.current_thread()))
-            future.result()
+    def test_loop_runs_in_another_thread(self):
+        async def test_threads(thread):
+            assert thread is not threading.current_thread()
 
-        def test_loop_executes_pending_tasks_before_close(self):
-            async def test_execs_pending():
-                await asyncio.sleep(1)
-                return 1
+        future = self.thread.run_coroutine(test_threads(threading.current_thread()))
+        future.result()
 
-            def callback():
-                assert future.done()
-                assert future.result() == 1
+    def test_loop_executes_pending_tasks_before_close(self):
+        async def test_execs_pending():
+            await asyncio.sleep(1)
+            return 1
 
-            future = self.thread.run_coroutine(test_execs_pending())
-            future.add_done_callback(callback)
+        def callback():
+            assert future.done()
+            assert future.result() == 1
 
-        def test_join_stops_and_closes_loop(self):
-            self.thread.join()
-            assert not self.thread.loop.is_running()
-            assert self.thread.loop.is_closed()
+        future = self.thread.run_coroutine(test_execs_pending())
+        future.add_done_callback(callback)
 
-except ImportError:
-    pass
+    def test_join_stops_and_closes_loop(self):
+        self.thread.join()
+        assert not self.thread.loop.is_running()
+        assert self.thread.loop.is_closed()

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
 [testenv:py27-flake8]
 skip_install = true
 deps = flake8
-commands = flake8 --exclude=.tox,.eggs --extend-ignore=E999
+commands = flake8 --exclude=.tox,.eggs
 
 [testenv:py37-flake8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist =
+    py{27,34,35,36,37}-pysoa
+    py{27,37}-flake8
+
+[testenv]
+deps =
+    -e .[testing]
+commands =
+    pytest
+
+[testenv:py27-flake8]
+skip_install = true
+deps = flake8
+commands = flake8 --exclude=.tox,.eggs --extend-ignore=E999
+
+[testenv:py37-flake8]
+skip_install = true
+deps = flake8
+commands = flake8 --exclude=.tox,.eggs


### PR DESCRIPTION
The PySOA server currently creates an `asyncio` event loop (if `asyncio` is available) and makes it available to jobs/actions. However, this event loop is never started and will never run scheduled tasks and coroutines.

This change creates and runs an `asyncio` event loop in a separate thread. This allows users to run async coroutines/tasks in the background.

NOTE: all coroutines/callbacks scheduled against this event loop must use the `*_threadsafe` methods. See the documentation here: https://docs.python.org/3/library/asyncio-dev.html#concurrency-and-multithreading