### PR TITLE
[PATCH] Fix tests broken by latest PyTest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ test_helper_requirements = [
 
 test_plan_requirements = test_helper_requirements + [
     'pyparsing~=2.2',
-    'pytest>=3.1,<5',
+    'pytest>=3.1,<5,!=4.2.0',  # 4.2.0 has a regression breaking our test plans, fixed in 4.2.1
     'pytz>=2018.4',
 ]
 

--- a/tests/test/plan/first_fixtures/002_advanced_features.pysoa
+++ b/tests/test/plan/first_fixtures/002_advanced_features.pysoa
@@ -56,6 +56,6 @@ stub_job_error: expect: exact job error: code = DOG_ERROR
 
 test name: skipping_works
 test description: This tests that skipping works ... this test case should never be executed
-test skip: This test is skipped to test that skipping works
+test skip: This test is skipped to test that skipping works (002_advanced_features.skipping_works)
 login.0: input: username: pumpkin
 login.0: expect: no errors

--- a/tests/test/plan/skipped_fixtures/global_skip.pysoa
+++ b/tests/test/plan/skipped_fixtures/global_skip.pysoa
@@ -1,5 +1,5 @@
 # Let's make sure that global skipping works
-test skip global: All tests in this fixture should be skipped
+test skip global: All tests in this fixture should be skipped (global_skip.*)
 
 test name: first
 test description: First

--- a/tests/test/plan/test_001_fixtures_work.py
+++ b/tests/test/plan/test_001_fixtures_work.py
@@ -365,7 +365,7 @@ class TestSecondFixtures(PluginTestingOrderOfOperationsTestCase):
         """
         self.get_order_of_operations().append('test_a_regular_case')
 
-    @pytest.mark.skip(reason='Making sure skipping still works')
+    @pytest.mark.skip(reason='Making sure skipping still works (PyTest)')
     def test_a_pytest_skipped_case(self):
         """
         Test that a regular skipped test case works properly
@@ -379,7 +379,7 @@ class TestSecondFixtures(PluginTestingOrderOfOperationsTestCase):
         """
         self.get_order_of_operations().append('test_another_regular_case')
 
-    @unittest.skip(reason='Making sure skipping still works')
+    @unittest.skip(reason='Making sure skipping still works (unittest)')
     def test_a_unittest_skipped_case(self):
         """
         Test that a regular skipped test case works properly
@@ -395,18 +395,26 @@ class TestMockingAndStubbingFixtures(PluginTestingOrderOfOperationsTestCase):
     fixture_path = os.path.dirname(__file__) + '/mocking_and_stubbing'
 
 
-@unittest.skip(reason='Making sure skipping an entire class (and all of its fixtures) works')
+@unittest.skip(reason='Making sure skipping an entire class (and all of its fixtures) works (unittest)')
 class TestUnittestSkippedFixtures(PluginTestingOrderOfOperationsTestCase):
     server_class = SecondStubServer
     server_settings = {}
     fixture_path = os.path.dirname(__file__) + '/second_fixtures'
 
+    def test_should_be_skipped(self):
+        self.get_order_of_operations().append('test_should_be_skipped')
+        self.fail('If this is not skipped, it should fail')
 
-@pytest.mark.skip(reason='Making sure skipping an entire class (and all of its fixtures) works')
+
+@pytest.mark.skip(reason='Making sure skipping an entire class (and all of its fixtures) works (PyTest)')
 class TestPyTestSkippedFixtures(PluginTestingOrderOfOperationsTestCase):
     server_class = SecondStubServer
     server_settings = {}
     fixture_path = os.path.dirname(__file__) + '/second_fixtures'
+
+    def test_should_be_skipped(self):
+        self.get_order_of_operations().append('test_should_be_skipped')
+        self.fail('If this is not skipped, it should fail')
 
 
 @pytest.mark.skipif(sys.version_info > (2, 6), reason='Making sure skipping an entire class with skipif works')
@@ -417,6 +425,10 @@ class TestPyTestSkippedIfFixtures(PluginTestingOrderOfOperationsTestCase):
     custom_fixtures = (
         os.path.dirname(__file__) + '/second_fixtures/walk_and_run.pysoa',
     )
+
+    def test_should_be_skipped(self):
+        self.get_order_of_operations().append('test_should_be_skipped')
+        self.fail('If this is not skipped, it should fail')
 
 
 class TestGlobalSkippedFixtureTests(PluginTestingOrderOfOperationsTestCase):


### PR DESCRIPTION
PyTest 4.2.0 introduced a regression which broke the tests in our test plans, but wasn't a deal-breaker, so we simply adapted to the breakage. The regression was fixed in 4.2.1, but the fix introduced a new feature (not a bug) that `@unittest.skip`-skipped classes won't even be handled by our test plan code, so we can't measure them in the plugin-testing tests. This commit adapts to that change and removes the adaptation to the fixed regression. At also adds some new assertions and information to help ensure this is still working, even with the new changes.