### PR TITLE
[MAJOR] Step 2 in the message serializer content type header

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@
 Dockerfile
 
 # Python + testing artifacts
-*,cover
+*.cover
 *.egg-info
 *.eggs
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip install -U pip setuptools flake8
 script:
   - flake8 .
-  - python setup.py test
+  - python setup.py test --addopts "--cov-report term-missing"
 jobs:
    include:
      - stage: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from ubuntu:16.04
+FROM ubuntu:16.04
 
 RUN apt-get update && \
 	apt-get install -y \
@@ -24,8 +24,8 @@ RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && \
 	python3.7 /tmp/get-pip.py && \
 	pip install tox
 
-ADD . /test/pysoa
-
 WORKDIR /test/pysoa
 
 CMD ["tox"]
+
+ADD . /test/pysoa

--- a/README.rst
+++ b/README.rst
@@ -182,4 +182,21 @@ have the service code in place, and a ``stub_action`` decorator / context manage
 For more information about using these test utilities in your services or service-calling applications, see the testing
 documentation in the `PySOA Documentation <docs/index.rst>`_.
 
-For testing this PySOA library directly on your system, you must first install `Docker <https://www.docker.com/get-started>`_. Once installed, the PySOA test image can be built with the following command: ``docker build . -t pysoa-test``. Once the pysoa-test image has been built, run ``docker run pysoa-test`` to execute the test suite. The test suite will run for all supported versions of Python.
+For testing this PySOA library directly on your system, you must first install `Docker
+<https://www.docker.com/get-started>`_. One installed, you can run tests across all supported environments using one
+or more of the following commands::
+
+    # Run all tests in Python 2.7, 3.5, 3.6, and 3.7, do Flake8 analysis, and do code coverage analysis
+    ./tox.sh
+
+    # Run all tests in Python 3.5
+    ./tox.sh -e py35
+
+    # Run all tests in Python 2.7 and 3.7
+    ./tox.sh -e py27,py37
+
+    # Run all tests in Python 3.5, 3.6, and 3.7 and do code coverage analysis
+    ./tox.sh -e py35,py36,py37,coverage
+
+    # Run Flake8 analysis standalone
+    ./tox.sh -e py27-flake8,py37-flake8

--- a/pysoa/server/action/status.py
+++ b/pysoa/server/action/status.py
@@ -159,11 +159,13 @@ class BaseStatusAction(Action):
             check_methods = [getattr(self, x) for x in dir(self) if x.startswith('check_')]
             for check_method in check_methods:
                 # Call the check, and see if it returned anything
-                # TODO: Remove the try/except before 1.0.0, after all uses have been updated to accept an argument
                 try:
                     problems = check_method(request)
-                except TypeError:
-                    problems = check_method()
+                except TypeError as e:
+                    raise RuntimeError(
+                        'Status action check_* methods must accept a single argument of type ActionRequest',
+                        e,
+                    )
                 if problems:
                     for is_error, code, description in problems:
                         # Parcel out the values into the right return list

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ python-tag=py27.py35.py36
 license_file = LICENSE
 
 [flake8]
-exclude = .git,.env/*,docs/*,build/*,.eggs/*,*.egg-info/*
+exclude = .git,.env/*,docs/*,build/*,.eggs/*,*.egg-info/*,.tox
 max-line-length = 120
 
 [isort]
@@ -36,4 +36,4 @@ known_tests=tests
 test=pytest
 
 [tool:pytest]
-addopts = -s --junitxml=pytests.xml --cov-report term-missing --cov-fail-under=80 --cov=pysoa
+addopts = -s --junitxml=pytests.xml --cov-fail-under=85 --cov=pysoa

--- a/tests/server/action/test_status.py
+++ b/tests/server/action/test_status.py
@@ -33,18 +33,18 @@ class _ComplexStatusAction(BaseStatusAction):
 
     _build = 'complex_service-28381-7.8.9-16_04'
 
-    def check_good(self):
+    def check_good(self, _request):
         self.diagnostics['check_good_called'] = True
 
     @staticmethod
-    def check_warnings():
+    def check_warnings(_request):
         return (
             (False, 'FIRST_CODE', 'First warning'),
             (False, 'SECOND_CODE', 'Second warning'),
         )
 
     @staticmethod
-    def check_errors():
+    def check_errors(_request):
         return [
             [True, 'ANOTHER_CODE', 'This is an error'],
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,28 @@
 [tox]
 envlist =
-    py{27,34,35,36,37}-pysoa
+    py{27,35,36,37}
     py{27,37}-flake8
+    coverage
 
 [testenv]
+usedevelop=True
 deps =
-    -e .[testing]
+    .[testing]
+#    ipdb
 commands =
-    pytest
+    pytest --cov-append --cov-fail-under=1 --cov-report=
 
 [testenv:py27-flake8]
 skip_install = true
 deps = flake8
-commands = flake8 --exclude=.tox,.eggs
+commands = flake8
 
 [testenv:py37-flake8]
 skip_install = true
 deps = flake8
-commands = flake8 --exclude=.tox,.eggs
+commands = flake8
+
+[testenv:coverage]
+skip_install = true
+deps = coverage
+commands = coverage report -m --fail-under 85

--- a/tox.sh
+++ b/tox.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+docker build -t pysoa-test .
+
+if [[ -z "$1" ]]
+then
+    docker run -it --rm pysoa-test
+else
+    docker run -it --rm pysoa-test tox "$@"
+fi


### PR DESCRIPTION
This is the second step (commit) in a three-step (three-commit) breaking change to add support for switching the message serializer that the Redis transport uses based on a content-type header. There will be one more breaking commit in a future version, in order to make migration possible.

Breaking changes in this commit/step:
- All request and response messages the Redis transport sends now contain a leading content-type header containing the MIME type used for selecting the proper deserializer on the receiving end. Before you upgrade to PySOA version 0.58.0 and get this change, you must first upgrade all clients and servers to at least 0.55.0 but still less than 0.58.0; otherwise, older clients or servers might not understand messages they receive from clients and servers running 0.58.0 or newer.
- (Unrelated) A previously-announced breaking change has been finalized: `check_*` methods in actions extending the `BaseStatusAction` must now accept exactly one parameter, which will be the `ActionRequest`.

Explanation of the steps:
- Step 1 (1cc1d28787d630fc3973497911a0e6ecf4867cd4): Rename the configuration setting, make the `receive_message` method use a switched serializer if the content type header is present, and make the `send_message` method use a switched serializer and include a content type header if the `receive_message` method found a content type header. Deploy this to all servers and clients.
- Step 2 (this commit): Make the `send_message` method always send a content type header. Deploy this to all servers and clients.
- Step 3: Make the `receive_message` method enforce the presence of a content type header. Deploy this to all servers and clients.