### PR TITLE
[PATCH] Fix exceptions being thrown for missing job request keys

### DIFF
--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -177,7 +177,7 @@ class Server(object):
         self._idle_timer = None
 
         try:
-            PySOALogContextFilter.set_logging_request_context(request_id=request_id, **job_request['context'])
+            PySOALogContextFilter.set_logging_request_context(request_id=request_id, **job_request.get('context', {}))
         except TypeError:
             # Non unicode keys in job_request['context'] will break keywording of a function call.
             # Try to recover by coercing the keys
@@ -207,7 +207,7 @@ class Server(object):
 
             # Send the response message
             try:
-                if not job_request['control'].get('suppress_response', False):
+                if not job_request.get('control', {}).get('suppress_response', False):
                     self.transport.send_response_message(request_id, meta, response_message)
             except MessageTooLarge as e:
                 self.metrics.counter('server.error.response_too_large').increment()

--- a/tests/server/test_server/test_handle_next_request.py
+++ b/tests/server/test_server/test_handle_next_request.py
@@ -1,0 +1,52 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+from unittest import TestCase
+
+from pysoa.server.server import Server
+from pysoa.test import factories
+from pysoa.common.transport.base import ServerTransport
+
+
+class HandleNextRequestServer(Server):
+    """
+    Stub server to test against.
+    """
+    service_name = 'test_service'
+    action_class_map = {}
+
+
+class SimplePassthroughServerTransport(ServerTransport):
+    def set_request(self, request):
+        self._request = request
+
+    def receive_request_message(self):
+        return (0, {}, self._request)
+
+    def send_response_message(self, request_id, meta, body):
+        self._response = body
+
+    def get_response(self):
+        return self._response
+
+
+class ProcessNextRequestsTests(TestCase):
+    def test_emtpy_request_returns_job_response_error(self):
+        """
+        Test that server can handle an emtpy job missing top level elements without throwing exceptions
+        """
+        settings = factories.ServerSettingsFactory()
+        server = HandleNextRequestServer(settings=settings)
+        server.transport = SimplePassthroughServerTransport(server.service_name)
+
+        server.transport.set_request({})
+        server.handle_next_request()
+        response = server.transport.get_response()
+
+        # Make sure we got an error
+        self.assertTrue('errors' in response)
+        errors = response['errors']
+        self.assertEqual(len(errors), 3)
+        self.assertEqual(set(['actions', 'control', 'context']), set([e.get('field', None) for e in errors]))


### PR DESCRIPTION
Servers receiving job requests missing 'control' or 'context' keys
would produce exceptions instead of the expected job response with
error codes.  This change removes assumptions Server.handle_next_request
has about the validity of the job request message and allows usual
error response handling for such messages.