### PR TITLE
[PATCH] Fix issues #152 and #156 resulting in IndexErrors

### DIFF
--- a/tests/client/test_send_receive.py
+++ b/tests/client/test_send_receive.py
@@ -368,6 +368,23 @@ class TestClientSendReceive(TestCase):
         self.assertEqual(response.action, 'action_1')
         self.assertEqual(response.body['foo'], 'bar')
 
+    def test_call_action_job_error_not_raised(self):
+        client = Client({
+            'error_service': {
+                'transport': {
+                    'path': 'pysoa.common.transport.local:LocalClientTransport',
+                    'kwargs': {
+                        'server_class': ErrorServer,
+                        'server_settings': {},
+                    },
+                },
+            }
+        })
+        response = client.call_action('error_service', 'job_error', raise_job_errors=False)
+
+        self.assertIsNotNone(response)
+        self.assertEqual([Error(code='BAD_JOB', message='You are a bad job')], response)
+
 
 class TestClientParallelSendReceive(TestCase):
     """


### PR DESCRIPTION
- Fix issue #152: If `raise_job_errors=False` in `Client.call_action`, be sure to check for `response.errors` and return those instead of trying to return the non-existent `response.actions[0]`
- Fix issue #156: If a job error occurs during an expansion, be sure to capture and (if appropriate) raise it instead of trying to access the non-existent `response.actions[0]`