### PR TITLE
[PATCH] Use Tox to add tests for PyInotify

### DIFF
--- a/pysoa/server/autoreload.py
+++ b/pysoa/server/autoreload.py
@@ -327,7 +327,7 @@ class AbstractReloader(object):
 class _PyInotifyReloader(AbstractReloader):
     """
     This concrete class completes the reloader by using the PyInotify API. It is only supported on Linux operating
-    systems with kernel version >= 2.6.13.
+    systems with kernel version >= 2.6.13 and projects with PyInotify installed.
     """
 
     def __init__(self, main_module_name, watch_modules, signal_forks=False):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{27,35,36}
+    py35-pyinotify
     py37-attrs{17,18,19}
     py{27,37}-flake8
     coverage
@@ -12,6 +13,7 @@ deps =
     attrs17: attrs~=17.4
     attrs18: attrs~=18.2
     attrs19: attrs~=19.1
+    pyinotify: pyinotify~=0.9
 #    ipdb
 commands =
     pytest --cov-append --cov-fail-under=1 --cov-report=


### PR DESCRIPTION
Added another Tox config to run tests with PyInotify installed. Added additional tests that run only when PyInotify is installed. New tests pass without any changes to code.