### PR TITLE
[MINOR] Add helper for calling local actions within other actions

### DIFF
--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -3,19 +3,39 @@ from __future__ import (
     unicode_literals,
 )
 
-import attr
+from typing import (  # noqa: F401 TODO Python 3
+    Callable,
+    Dict,
+)
 
-from pysoa.common.types import ActionRequest
+import attr
+import six  # noqa: F401 TODO Python 3
+
+from pysoa.common.constants import (
+    ERROR_CODE_SERVER_ERROR,
+    ERROR_CODE_UNKNOWN,
+)
+from pysoa.common.types import (
+    ActionRequest,
+    ActionResponse,
+    Error,
+)
+from pysoa.server.errors import ActionError
 from pysoa.server.internal.types import RequestSwitchSet
 
 
 @attr.s
 class EnrichedActionRequest(ActionRequest):
     """
-    The action request object that the Server passes to each Action class that it calls.
+    The action request object that the Server passes to each Action class that it calls. It contains all the information
+    from ActionRequest, plus some extra information from the JobRequest, a client that can be used to call other
+    services, and a helper for running asyncio coroutines.
 
-    Contains all the information from ActionRequest, plus some extra information from the
-    JobRequest.
+    Also contains a helper for easily calling other local service actions from within an action.
+
+    Services and intermediate libraries can subclass this class and change the `Server` attribute `request_class` to
+    their subclass in order to use more-advanced request classes. In order for any new attributes such a subclass
+    provides to be copied by `call_local_action`, they must be `attr.ib` attributes with a default value.
     """
     switches = attr.ib(
         default=attr.Factory(RequestSwitchSet),
@@ -24,5 +44,76 @@ class EnrichedActionRequest(ActionRequest):
     context = attr.ib(default=attr.Factory(dict))
     control = attr.ib(default=attr.Factory(dict))
     client = attr.ib(default=None)
-    async_event_loop = attr.ib(default=None)
-    run_coroutine = attr.ib(default=None)
+    async_event_loop = attr.ib(default=None)  # deprecated
+    run_coroutine = attr.ib(default=None)  # replacement for async_event_loop
+
+    def call_local_action(self, action, body, raise_action_errors=True):
+        # type: (six.text_type, Dict, bool) -> ActionResponse
+        """
+        This helper calls another action, locally, that resides on the same service, using the provided action name
+        and body. The called action will receive a copy of this request object with different action and body details.
+
+        The use of this helper differs significantly from using the PySOA client to call an action. Notably:
+
+        * The configured transport is not involved, so no socket activity or serialization/deserialization takes place.
+        * PySOA server metrics are not recorded and post-action cleanup activities do not occur.
+        * No "job request" is ever created or transacted.
+        * No middleware is executed around this action (though, in the future, we might change this decision and add
+          middleware execution to this helper).
+
+        :param action: The action to call (must exist within the `action_class_map` from the `Server` class)
+        :type action: union[str, unicode]
+        :param body: The body to send to the action
+        :type body: dict
+        :param raise_action_errors: If `True` (the default), all action errors will be raised; otherwise, an
+                                    `ActionResponse` containing the errors will be returned.
+        :type raise_action_errors: bool
+
+        :return: the action response.
+        :rtype: ActionResponse
+
+        :raises: ActionError
+        """
+        server = getattr(self, '_server', None)
+        if not server:
+            errors = [Error(
+                code=ERROR_CODE_SERVER_ERROR,
+                message="No `_server` attribute set on action request object (and can't make request without it)",
+            )]
+            if raise_action_errors:
+                raise ActionError(errors)
+            return ActionResponse(action=action, errors=errors)
+
+        if action not in server.action_class_map:
+            errors = [Error(
+                code=ERROR_CODE_UNKNOWN,
+                message='The action "{}" was not found on this server.'.format(action),
+                field='action',
+            )]
+            if raise_action_errors:
+                raise ActionError(errors)
+            return ActionResponse(action=action, errors=errors)
+
+        action_callable = (
+            server.action_class_map[action](server.settings)
+        )  # type: Callable[[ActionRequest], ActionResponse]
+
+        request = self.__class__(
+            action=action,
+            body=body,
+            # Dynamically copy all Attrs attributes so that subclasses introducing other Attrs can still work properly
+            **{a.name: getattr(self, a.name) for a in self.__attrs_attrs__ if a.name not in ('action', 'body')}
+        )
+        request._server = server
+
+        try:
+            response = action_callable(request)
+        except ActionError as e:
+            if raise_action_errors:
+                raise
+            return ActionResponse(action=action, errors=e.errors)
+
+        if raise_action_errors and response.errors:
+            raise ActionError(response.errors)
+
+        return response

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,4 +36,4 @@ known_tests=tests
 test=pytest
 
 [tool:pytest]
-addopts = -s --junitxml=pytests.xml --cov-fail-under=85 --cov=pysoa
+addopts = -p pytest_cov -p pysoa_test_plan -p pysoa_test_fixtures -s --junitxml=pytests.xml --cov-fail-under=85 --cov=pysoa

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ base_requirements = [
     'msgpack-python~=0.5,>=0.5.2',
     'redis~=2.10',
     'six~=1.10',
+    'typing;python_version<"3.5"',
 ]
 
 test_helper_requirements = [
@@ -42,6 +43,7 @@ test_requirements = [
     'lunatic-python-universal~=2.1',
     'mockredispy~=2.9',
     'pytest-cov~=2.6',
+    'pytest~=4.4',
 ] + test_plan_requirements
 
 

--- a/tests/server/test_types.py
+++ b/tests/server/test_types.py
@@ -1,0 +1,190 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import logging
+
+import attr
+import pytest
+
+from pysoa.common.types import (
+    ActionResponse,
+    Error,
+)
+from pysoa.server.errors import ActionError
+from pysoa.server.types import EnrichedActionRequest
+from pysoa.test.compatibility import mock
+
+
+@attr.s
+class SuperEnrichedActionRequest(EnrichedActionRequest):
+    metrics = attr.ib(default=None)
+    analytics_logger = attr.ib(default=None)
+
+
+class TestEnrichedActionRequest(object):
+    def test_call_local_action_no_server(self):
+        r = EnrichedActionRequest(action='foo', body={'bar': 'baz'})
+
+        with pytest.raises(ActionError) as error_context:
+            r.call_local_action('other_foo', {'color': 'red'})
+
+        assert error_context.value.errors[0].code == 'SERVER_ERROR'
+
+        response = r.call_local_action('other_foo', {'color': 'red'}, raise_action_errors=False)
+        assert response.action == 'other_foo'
+        assert response.errors
+        assert response.errors[0].code == 'SERVER_ERROR'
+
+    def test_call_local_action_no_action(self):
+        server = mock.MagicMock()
+        server.action_class_map = {'unused_foo': mock.MagicMock()}
+
+        r = EnrichedActionRequest(action='foo', body={'bar': 'baz'})
+        r._server = server
+
+        with pytest.raises(ActionError) as error_context:
+            r.call_local_action('other_foo', {'color': 'red'})
+
+        assert error_context.value.errors[0].code == 'UNKNOWN'
+        assert error_context.value.errors[0].field == 'action'
+
+        response = r.call_local_action('other_foo', {'color': 'red'}, raise_action_errors=False)
+        assert response.action == 'other_foo'
+        assert response.errors
+        assert response.errors[0].code == 'UNKNOWN'
+        assert response.errors[0].field == 'action'
+
+    def test_call_local_action_standard_request(self):
+        action = mock.MagicMock()
+        action.return_value.side_effect = ActionError([Error('FOO', 'Foo error')])
+
+        server = mock.MagicMock()
+        server.settings = {'a_setting': 'a_value'}
+        server.action_class_map = {'other_foo': action}
+
+        r = EnrichedActionRequest(action='foo', body={'bar': 'baz'})
+        r._server = server
+
+        with pytest.raises(ActionError) as error_context:
+            r.call_local_action('other_foo', {'color': 'red'})
+
+        assert error_context.value.errors[0].code == 'FOO'
+
+        action.assert_called_once_with(server.settings)
+        action.return_value.assert_called_once()
+
+        other_r = action.return_value.call_args[0][0]
+        assert other_r is not r
+        assert other_r != r
+        assert other_r.action == 'other_foo'
+        assert other_r.body == {'color': 'red'}
+        assert other_r.context == {}
+        assert other_r.control == {}
+        assert getattr(other_r, '_server') is server
+
+        action.reset_mock()
+
+        response = r.call_local_action('other_foo', {'color': 'red'}, raise_action_errors=False)
+        assert response.action == 'other_foo'
+        assert response.errors
+        assert response.errors[0].code == 'FOO'
+
+        action.assert_called_once_with(server.settings)
+        action.return_value.assert_called_once()
+
+        other_r = action.return_value.call_args[0][0]
+        assert other_r is not r
+        assert other_r != r
+        assert other_r.action == 'other_foo'
+        assert other_r.body == {'color': 'red'}
+        assert other_r.context == {}
+        assert other_r.control == {}
+        assert getattr(other_r, '_server') is server
+
+    def test_call_local_action_other_request_details(self):
+        action = mock.MagicMock()
+        action.return_value.return_value = ActionResponse(action='another_foo', errors=[Error('BAR', 'Bar error')])
+
+        server = mock.MagicMock()
+        server.settings = {'a_setting': 'a_value'}
+        server.action_class_map = {'another_foo': action}
+
+        r = EnrichedActionRequest(action='foo', body={'bar': 'baz'}, context={'auth': 'abc123'}, control={'speed': 5})
+        r._server = server
+
+        with pytest.raises(ActionError) as error_context:
+            r.call_local_action('another_foo', {'height': '10m'})
+
+        assert error_context.value.errors[0].code == 'BAR'
+
+        action.assert_called_once_with(server.settings)
+        action.return_value.assert_called_once()
+
+        other_r = action.return_value.call_args[0][0]
+        assert other_r is not r
+        assert other_r != r
+        assert other_r.action == 'another_foo'
+        assert other_r.body == {'height': '10m'}
+        assert other_r.context == {'auth': 'abc123'}
+        assert other_r.control == {'speed': 5}
+        assert getattr(other_r, '_server') is server
+
+        action.reset_mock()
+
+        response = r.call_local_action('another_foo', {'height': '10m'}, raise_action_errors=False)
+        assert response.action == 'another_foo'
+        assert response.errors
+        assert response.errors[0].code == 'BAR'
+
+        action.assert_called_once_with(server.settings)
+        action.return_value.assert_called_once()
+
+        other_r = action.return_value.call_args[0][0]
+        assert other_r is not r
+        assert other_r != r
+        assert other_r.action == 'another_foo'
+        assert other_r.body == {'height': '10m'}
+        assert other_r.context == {'auth': 'abc123'}
+        assert other_r.control == {'speed': 5}
+        assert getattr(other_r, '_server') is server
+
+    def test_call_local_action_super_enriched_request(self):
+        action = mock.MagicMock()
+        action.return_value.return_value = ActionResponse(action='another_foo', body={'sweet': 'success'})
+
+        server = mock.MagicMock()
+        server.settings = {'a_setting': 'a_value'}
+        server.action_class_map = {'another_foo': action}
+
+        logger = logging.getLogger('test')
+
+        r = SuperEnrichedActionRequest(
+            action='foo',
+            body={'bar': 'baz'},
+            context={'auth_token': 'def456'},
+            control={'repeat': True},
+            metrics='A custom object',
+            analytics_logger=logger,
+        )
+        r._server = server
+
+        response = r.call_local_action('another_foo', {'entity_id': '1a8t27oh'})
+        assert response.action == 'another_foo'
+        assert response.body == {'sweet': 'success'}
+
+        action.assert_called_once_with(server.settings)
+        action.return_value.assert_called_once()
+
+        other_r = action.return_value.call_args[0][0]
+        assert isinstance(other_r, SuperEnrichedActionRequest)
+        assert other_r is not r
+        assert other_r != r
+        assert other_r.action == 'another_foo'
+        assert other_r.body == {'entity_id': '1a8t27oh'}
+        assert other_r.context == {'auth_token': 'def456'}
+        assert other_r.control == {'repeat': True}
+        assert other_r.metrics == 'A custom object'
+        assert other_r.analytics_logger is logger
+        assert getattr(other_r, '_server') is server


### PR DESCRIPTION
Add a helper method to `EnrichedActionRequest` to make it easy to call other local actions within the same service. Also, make `EnrichedActionRequest` subclassable by adding a `request_class` attribute to the `Server` class.