### PR TITLE
[PATCH] Fix documentation introspection in Python 2

### DIFF
--- a/pysoa/server/action/introspection.py
+++ b/pysoa/server/action/introspection.py
@@ -221,8 +221,10 @@ class IntrospectionAction(Action):
 
     @staticmethod
     def _introspect_action(action_class):
+        documentation = getattr(action_class, 'description', action_class.__doc__)
+
         action = {
-            'documentation': getattr(action_class, 'description', action_class.__doc__) or None,
+            'documentation': six.text_type(documentation) if documentation else None,
             'request_schema': None,
             'response_schema': None,
         }


### PR DESCRIPTION
Fix an issue with `IntrospectionAction` that results in a response validation error in
Python 2 when an action doesn't have a unicode description or docstring.