### PR TITLE
[MINOR] Add robust support for safe asynchronous code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       name: "Unit Tests: Python 2.7 with PyTest 3.1 and 4.6"
       python: "2.7"
       script:
-        - tox -e py27-pytest31,py27-pytest46,py27-flake8,coverage
+        - tox -e py27-pytest31,py27-pytest46,py27-flake8,py27-coverage
     - stage: build
       name: "Unit Tests: Python 3.5 with and without PyInotify"
       python: "3.5"
@@ -35,10 +35,10 @@ matrix:
         - tox -e py37-attrs17,py37-attrs18,py37-attrs19,py37-flake8,coverage
       dist: xenial
     - stage: build
-      name: "Unit Tests: Python 3.7 with PyTest 3.1, 4.6, and 5.0"
+      name: "Unit Tests: Python 3.7 with PyTest 4.6 and 5.1"
       python: "3.7"
       script:
-        - tox -e py37-pytest31,py37-pytest46,py37-pytest50,py37-flake8,coverage
+        - tox -e py37-pytest46,py37-pytest51,py37-flake8,coverage
       dist: xenial
     - stage: build
       name: "Functional Tests"

--- a/conftest.py
+++ b/conftest.py
@@ -10,3 +10,4 @@ import sys
 collect_ignore = []
 if sys.version_info < (3, 5):
     collect_ignore.append('tests/unit/server/internal/test_event_loop.py')
+    collect_ignore.append('tests/unit/common/test_compatibility_async.py')

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+if [[ "$1" != "--no-flake" ]]
+then
+    if python -c 'import sys; exit(0 if sys.version_info > (3, ) else 1)'
+    then
+        if which flake8-python3 > /dev/null
+        then
+            flake8-python3
+            RET=$?
+        elif which flake8-3 > /dev/null
+        then
+            flake8-3
+            RET=$?
+        else
+            flake8
+            RET=$?
+        fi
+    else
+        flake8
+        RET=$?
+    fi
+else
+    RET=0
+fi
+
+args=(--include \*.py --exclude compatibility.py --exclude-dir .git --exclude-dir build --exclude-dir .eggs --exclude-dir *.egg-info --exclude-dir .tox)
+
+set -o pipefail
+grep -r "${args[@]}" 'threading\.local' . | sed 's/.*/ERROR: Prohibited thread local usage found: &/'
+ret_sub=$?
+if [[ $ret_sub -eq 0 ]] && [[ $RET -eq 0 ]]
+then
+    RET=200
+fi
+
+for f in $(grep -r -l "${args[@]}" 'from threading' .)
+do
+    python - <<____HERE
+import importlib, threading
+m = importlib.import_module('${f}'.strip('.').strip('/').replace('.py', '').replace('/', '.'))
+exit(1 if any(v for v in vars(m).values() if v == threading.local) else 0)
+____HERE
+    ret_sub=$?
+
+    if [[ $ret_sub -gt 0 ]]
+    then
+        echo "ERROR: Prohibited thread local usage found: ${f}"
+        if [[ $RET -eq 0 ]]
+        then
+            RET=200
+        fi
+    fi
+done
+
+exit $RET

--- a/pysoa/common/compatibility.py
+++ b/pysoa/common/compatibility.py
@@ -1,0 +1,162 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import sys
+from typing import (  # noqa: F401 TODO Python 3
+    Generic,
+    Optional,
+    TypeVar,
+    cast,
+)
+
+import six
+
+
+try:
+    import contextvars
+    threading = None
+except ImportError:
+    contextvars = None
+    import threading
+
+
+__all__ = (
+    'ContextVar',
+    'set_running_loop',
+)
+
+
+def set_running_loop(_loop):
+    pass
+
+
+if (3, 4) < sys.version_info < (3, 7):
+    # Some context is necessary here. ContextVars were added in Python 3.7, but we need them in Python 3.5+. The
+    # contextvars PyPi library is an API-compatible backport, but it has two drawbacks: It uses thread locals under the
+    # hood (not safe in asyncio contexts) and it doesn't copy the context when a new task is created (like Python 3.7
+    # does). The aiocontextvars PyPi library patches the contextvars PyPi library to correct these deficiencies, but
+    # even it is not complete, as it requires at least Python 3.5.3, and we must support Python 3.5.2 for Ubuntu 16.04.
+    # So we do some extra patching here, then import aiocontextvars to load its patches, and finally do one more patch.
+    import asyncio
+    import asyncio.coroutines
+    import asyncio.futures
+    import concurrent.futures
+
+    if not hasattr(asyncio, '_get_running_loop'):
+        # Python 3.5.0-3.5.3
+        # noinspection PyCompatibility
+        import asyncio.events
+        from threading import local as threading_local
+
+        if not hasattr(asyncio.events, '_get_running_loop'):
+            # Python 3.5.0-3.5.2
+            class _RunningLoop(threading_local):
+                _loop = None
+
+            _running_loop = _RunningLoop()
+
+            def _get_running_loop():
+                return _running_loop._loop
+
+            def set_running_loop(loop):  # noqa: F811
+                _running_loop._loop = loop
+
+            def _get_event_loop():
+                current_loop = _get_running_loop()
+                if current_loop is not None:
+                    return current_loop
+                return asyncio.events.get_event_loop_policy().get_event_loop()
+
+            asyncio.events.get_event_loop = _get_event_loop
+            asyncio.events._get_running_loop = _get_running_loop
+            asyncio.events._set_running_loop = set_running_loop
+
+        asyncio._get_running_loop = asyncio.events._get_running_loop
+        asyncio._set_running_loop = asyncio.events._set_running_loop
+
+    # noinspection PyUnresolvedReferences
+    import aiocontextvars  # noqa
+
+    def _run_coroutine_threadsafe(coro, loop):
+        """
+        Patch to create task in the same thread instead of in the callback. This ensures that contextvars get copied.
+        Python 3.7 copies contextvars without this.
+        """
+        if not asyncio.coroutines.iscoroutine(coro):
+            raise TypeError('A coroutine object is required')
+        future = concurrent.futures.Future()
+
+        # This is the only change to this function: Creating the task here, in the caller thread, instead of within
+        # `callback`, which is executed in the loop's thread. This does not run the task; it just _creates_ it.
+        task = asyncio.ensure_future(coro, loop=loop)
+
+        def callback():
+            try:
+                # noinspection PyProtectedMember,PyUnresolvedReferences
+                asyncio.futures._chain_future(task, future)
+            except Exception as exc:
+                if future.set_running_or_notify_cancel():
+                    future.set_exception(exc)
+                raise
+
+        loop.call_soon_threadsafe(callback)
+        return future
+
+    asyncio.run_coroutine_threadsafe = _run_coroutine_threadsafe
+
+
+_NO_DEFAULT = object()
+
+
+VT = TypeVar('VT')
+
+
+class ContextVar(Generic[VT]):
+    """
+    ContextVars are backwards-compatible with thread locals; that is, you can drop-in replace a thread local with a
+    context variable and the synchronous behavior will remain identical, while the new, asynchronous behavior will work
+    with asynchronous code.
+
+    However, ContextVars exist natively only in Python 3.7+, and the PyPi backport is available only for Python 3.5-3.6.
+    This enables service code to use one API (this class) to access ContextVar when available and thread locals
+    otherwise.
+    """
+    def __init__(self, name, default=cast(VT, _NO_DEFAULT)):  # type: (six.text_type, Optional[VT]) -> None
+        self.name = name
+        self.has_default = default is not _NO_DEFAULT
+        self.default = default
+        if contextvars:
+            if self.has_default:
+                self.variable = contextvars.ContextVar(name, default=default)  # type: contextvars.ContextVar[VT]
+            else:
+                self.variable = contextvars.ContextVar(name)  # type: contextvars.ContextVar[VT]
+        else:
+            self.variable = threading.local()
+
+    def set(self, value):  # type: (VT) -> None
+        if contextvars:
+            self.variable.set(value)
+        else:
+            self.variable.value = value
+
+    def get(self, default=cast(VT, _NO_DEFAULT)):  # type: (VT) -> VT
+        has_default = default is not _NO_DEFAULT
+
+        if contextvars:
+            return self.variable.get(default) if has_default else self.variable.get()
+
+        if has_default or self.has_default:
+            return cast(VT, getattr(self.variable, 'value', default if has_default else self.default))
+
+        try:
+            return cast(VT, self.variable.value)
+        except AttributeError:
+            raise LookupError(self)
+
+    def __repr__(self):  # type: () -> six.text_type
+        return super(ContextVar, self).__repr__().replace(
+            'ContextVar object at',
+            "ContextVar name='{}' at".format(self.name),
+        )

--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -5,6 +5,10 @@ from __future__ import (
 
 import copy
 import itertools
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+)
 
 from conformity import fields
 from conformity.error import ValidationError
@@ -66,8 +70,8 @@ class Settings(object):
     will merge any passed values into its defaults.
     """
 
-    schema = {}
-    defaults = {}
+    schema = {}  # type: Dict[six.text_type, fields.Base]
+    defaults = {}  # type: Dict[six.text_type, Any]
 
     class ImproperlyConfigured(Exception):
         """Raised when a configuration validation fails."""
@@ -127,9 +131,9 @@ class SOASettings(Settings):
             description='The list of all middleware objects that should be applied to this server or client',
         ),
         'metrics': MetricsSchema(),
-    }
+    }  # type: Dict[six.text_type, fields.Base]
 
     defaults = {
         'middleware': [],
         'metrics': {'path': 'pysoa.common.metrics:NoOpMetricsRecorder'},
-    }
+    }  # type: Dict[six.text_type, Any]

--- a/pysoa/server/coroutine.py
+++ b/pysoa/server/coroutine.py
@@ -1,0 +1,97 @@
+# The __future__ imports are only here to satisfy isort; they are not needed.
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import logging
+
+from conformity import fields
+
+# noinspection PyUnresolvedReferences
+import pysoa.common.compatibility  # noqa To make sure patching happens
+
+
+try:
+    from typing import Coroutine  # python 3.5.3+
+except ImportError:
+    # noinspection PyCompatibility
+    from collections.abc import Coroutine  # python 3.5.1-2 (Ubuntu 16.04, unfortunately)
+
+
+__all__ = (
+    'Coroutine',
+    'CoroutineMiddleware',
+    'DefaultCoroutineMiddleware',
+)
+
+
+_logger = logging.getLogger(__name__)
+
+
+class CoroutineMiddleware:
+    def before_run_coroutine(self):
+        """
+        When `request.run_coroutine` is called, this method will be invoked, synchronously, in the calling context
+        (e.g., the calling thread), to execute any logic necessary before handing the coroutine off to the async event
+        loop.
+
+        The advantage of implementing this method instead of or in addition to implementing `coroutine` is that, when
+        multiple middleware are configured, this method will be called in the same order the middleware are configured,
+        while `coroutine` will be called in the reverse order the middleware are configured (in order to create a
+        coroutine call stack in the same order the middleware are configured).
+        """
+
+    def coroutine(self, coroutine: Coroutine) -> Coroutine:  # noqa: E999
+        """
+        Returns a coroutine (`async def ...`) that wraps the given coroutine. This wrapping coroutine can be used to
+        execute code before and after the target coroutine. The wrapping pattern is identical to server and client
+        middleware except that it deals with coroutines instead of callables.
+
+        Example:
+
+        .. code-block:: python
+
+            class CustomCoroutineMiddleware:
+                ...
+
+                def coroutine(self, coroutine):
+                    async def wrapper():
+                        do_stuff_before_coroutine()
+
+                        await coroutine
+
+                        do_stuff_after_coroutine()
+
+                    return wrapper()
+
+        Note: When multiple middleware are configured, this method will be called in the reverse order the middleware
+        are configured, in order to create a coroutine call stack in the same order the middleware are configured. For
+        example, if `Middleware1` and `Middleware2` are configured in that order, `Middleware2.coroutine()` will be
+        called before `Middleware1.coroutine()`, so that the coroutine call stack will be `middleware_wrapper_1` ->
+        `middleware_wrapper_2` -> `coroutine`.
+
+        :param coroutine: The target coroutine (or coroutine returned by the previous middleware)
+
+        :return: The new, wrapping coroutine (or the unmodified coroutine argument, if no wrapping necessary).
+        """
+        return coroutine
+
+
+@fields.ClassConfigurationSchema.provider(
+    fields.Dictionary({}, description='The default coroutine middleware has no constructor arguments'),
+)
+class DefaultCoroutineMiddleware(CoroutineMiddleware):
+    """
+    Your server should have this middleware configured as the very first coroutine middleware. All of your custom
+    coroutine middleware should be configured after this.
+    """
+    def coroutine(self, coroutine: Coroutine) -> Coroutine:
+        # noinspection PyCompatibility
+        async def handler():
+            try:
+                await coroutine
+            except Exception:
+                _logger.exception('Error occurred while awaiting coroutine in request.run_coroutine')
+
+        return handler()

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,5 @@ test = pytest
 
 [tool:pytest]
 addopts = -s
+filterwarnings =
+    error:.*Coroutine functions are not natively supported.*

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,12 @@ base_requirements = [
     'redis~=2.10',
     'six~=1.10',
     'typing;python_version<"3.5"',
+
+    # For context, see the comment in pysoa.common.compatibility. Due to the peculiarities of the patching detailed
+    # there, we pin these dependencies to hard versions, or else things might break when they update. When new versions
+    # come out, we'll bump and adjust our patching or, hopefully, relax and remove our patching.
+    'contextvars==2.4;python_version>"3.4" and python_version<"3.7"',
+    'aiocontextvars==0.2.2;python_version>"3.4" and python_version<"3.7"',
 ]
 
 test_helper_requirements = [
@@ -34,6 +40,7 @@ test_helper_requirements = [
 test_plan_requirements = test_helper_requirements + [
     'pyparsing~=2.2',
     'pytest>=3.1,<6,!=4.2.0',  # 4.2.0 has a regression breaking our test plans, fixed in 4.2.1
+    'pytest-asyncio;python_version>"3.4"',
     'pytz>=2019.1',
 ]
 

--- a/test.sh
+++ b/test.sh
@@ -19,4 +19,12 @@ then
     RET=$ret_sub
 fi
 
+echo "Inspecting code..."
+./lint.sh
+ret_sub=$?
+if [[ $ret_sub -gt 0 ]] && [[ $RET -eq 0 ]]
+then
+    RET=$ret_sub
+fi
+
 exit $RET

--- a/tests/unit/common/test_compatibility_async.py
+++ b/tests/unit/common/test_compatibility_async.py
@@ -1,0 +1,317 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+# noinspection PyCompatibility
+import asyncio
+import sys
+import threading
+import time
+
+import pytest
+
+from pysoa.common.compatibility import (
+    ContextVar,
+    set_running_loop,
+)
+
+
+# noinspection PyCompatibility
+@pytest.mark.asyncio
+async def test_task_creation_patching():  # noqa: E999
+    var = ContextVar('test_task_creation_patching')
+    var.set(12)
+
+    test_context = {'var': None, 'new_var': None}
+
+    # noinspection PyCompatibility
+    async def coroutine():
+        test_context['var'] = var.get('default')
+        var.set(15)
+        test_context['new_var'] = var.get('default')
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(coroutine())
+
+    if sys.version_info < (3, 7):
+        # noinspection PyUnresolvedReferences
+        assert var.variable in task.context
+        # noinspection PyUnresolvedReferences
+        assert task.context[var.variable] == 12
+
+    await task
+
+    assert test_context['var'] == 12
+    assert test_context['new_var'] == 15
+    assert var.get(12)
+
+
+# noinspection PyCompatibility
+class SimpleLoopThread(threading.Thread):
+    def __init__(self):
+        super().__init__()
+        self.loop = asyncio.new_event_loop()
+
+    def run(self):
+        asyncio.set_event_loop(self.loop)
+        set_running_loop(self.loop)
+        try:
+            self.loop.run_forever()
+        finally:
+            try:
+                self.loop.run_until_complete(asyncio.gather(
+                    *(getattr(asyncio, 'all_tasks', None) or getattr(asyncio.Task, 'all_tasks'))(self.loop)
+                ))
+            finally:
+                self.loop.close()
+                # noinspection PyTypeChecker
+                asyncio.set_event_loop(None)  # type: ignore
+                set_running_loop(None)
+
+    def join(self, timeout=None):
+        if self.loop.is_running():
+            self.loop.call_soon_threadsafe(self.loop.stop)
+
+        # noinspection PyCompatibility
+        super().join(timeout)
+
+
+# noinspection PyCompatibility
+@pytest.mark.asyncio
+async def test_multiple_coroutines_async():
+    var1 = ContextVar('test_multiple_threads1')
+    var2 = ContextVar('test_multiple_threads1')
+
+    test_context = {
+        'c1_called': False,
+        'c1_complete': False,
+        'c2_called': False,
+        'c2_complete': False,
+        'var1_thread1_start': None,
+        'var2_thread1_start': None,
+        'var1_thread1_mid': None,
+        'var2_thread1_mid': None,
+        'var1_thread1_end': None,
+        'var2_thread1_end': None,
+        'var1_thread2_start': None,
+        'var2_thread2_start': None,
+        'var1_thread2_mid': None,
+        'var2_thread2_mid': None,
+        'var1_thread2_end': None,
+        'var2_thread2_end': None,
+    }
+
+    # noinspection PyCompatibility
+    async def c1():
+        test_context['c1_called'] = True
+        test_context['var1_thread1_start'] = var1.get('default1_thread1')
+        test_context['var2_thread1_start'] = var2.get('default2_thread1')
+
+        var1.set('value1')
+        var2.set('value2')
+
+        await asyncio.sleep(0.1)
+
+        test_context['var1_thread1_mid'] = var1.get()
+        test_context['var2_thread1_mid'] = var2.get()
+
+        await asyncio.sleep(0.3)
+
+        test_context['var1_thread1_end'] = var1.get()
+        test_context['var2_thread1_end'] = var2.get()
+        test_context['c1_complete'] = True
+
+    # noinspection PyCompatibility
+    async def c2():
+        test_context['c2_called'] = True
+        test_context['var1_thread2_start'] = var1.get('default1_thread2')
+        test_context['var2_thread2_start'] = var2.get('default2_thread2')
+
+        var1.set('value3')
+        var2.set('value4')
+
+        await asyncio.sleep(0.3)
+
+        test_context['var1_thread2_mid'] = var1.get()
+        test_context['var2_thread2_mid'] = var2.get()
+
+        await asyncio.sleep(0.1)
+
+        test_context['var1_thread2_end'] = var1.get()
+        test_context['var2_thread2_end'] = var2.get()
+        test_context['c2_complete'] = True
+
+    loop_thread = SimpleLoopThread()
+    loop_thread.start()
+
+    var1.set('super1')
+    var2.set('super2')
+
+    asyncio.run_coroutine_threadsafe(c1(), loop_thread.loop)
+    asyncio.run_coroutine_threadsafe(c2(), loop_thread.loop)
+
+    # It's _extremely_ unlikely that _both_ have already started and completed, and we want to ensure that our patched
+    # run_coroutine_threadsafe hasn't run them both to completion before returning.
+    assert (
+        test_context['c1_called'] is False or
+        test_context['c1_complete'] is False or
+        test_context['c2_called'] is False or
+        test_context['c2_complete'] is False
+    )
+
+    try:
+        assert var1.get('default1_main') == 'super1'
+        assert var2.get('default2_main') == 'super2'
+
+        var1.set('value5')
+        var2.set('value6')
+
+        await asyncio.sleep(0.2)
+
+        assert var1.get() == 'value5'
+        assert var2.get() == 'value6'
+
+        await asyncio.sleep(0.2)
+
+        assert var1.get() == 'value5'
+        assert var2.get() == 'value6'
+    finally:
+        loop_thread.join()
+
+    assert test_context['c1_called'] is True
+    assert test_context['c1_complete'] is True
+    assert test_context['var1_thread1_start'] == 'super1'
+    assert test_context['var2_thread1_start'] == 'super2'
+    assert test_context['var1_thread1_mid'] == 'value1'
+    assert test_context['var2_thread1_mid'] == 'value2'
+    assert test_context['var1_thread1_end'] == 'value1'
+    assert test_context['var2_thread1_end'] == 'value2'
+
+    assert test_context['c2_called'] is True
+    assert test_context['c2_complete'] is True
+    assert test_context['var1_thread2_start'] == 'super1'
+    assert test_context['var2_thread2_start'] == 'super2'
+    assert test_context['var1_thread2_mid'] == 'value3'
+    assert test_context['var2_thread2_mid'] == 'value4'
+    assert test_context['var1_thread2_end'] == 'value3'
+    assert test_context['var2_thread2_end'] == 'value4'
+
+
+def test_multiple_coroutines_sync():
+    var1 = ContextVar('test_multiple_threads1')
+    var2 = ContextVar('test_multiple_threads1')
+
+    test_context = {
+        'c1_called': False,
+        'c1_complete': False,
+        'c2_called': False,
+        'c2_complete': False,
+        'var1_thread1_start': None,
+        'var2_thread1_start': None,
+        'var1_thread1_mid': None,
+        'var2_thread1_mid': None,
+        'var1_thread1_end': None,
+        'var2_thread1_end': None,
+        'var1_thread2_start': None,
+        'var2_thread2_start': None,
+        'var1_thread2_mid': None,
+        'var2_thread2_mid': None,
+        'var1_thread2_end': None,
+        'var2_thread2_end': None,
+    }
+
+    # noinspection PyCompatibility
+    async def c1():
+        test_context['c1_called'] = True
+        test_context['var1_thread1_start'] = var1.get('default1_thread1')
+        test_context['var2_thread1_start'] = var2.get('default2_thread1')
+
+        var1.set('value1')
+        var2.set('value2')
+
+        await asyncio.sleep(0.1)
+
+        test_context['var1_thread1_mid'] = var1.get()
+        test_context['var2_thread1_mid'] = var2.get()
+
+        await asyncio.sleep(0.3)
+
+        test_context['var1_thread1_end'] = var1.get()
+        test_context['var2_thread1_end'] = var2.get()
+        test_context['c1_complete'] = True
+
+    # noinspection PyCompatibility
+    async def c2():
+        test_context['c2_called'] = True
+        test_context['var1_thread2_start'] = var1.get('default1_thread2')
+        test_context['var2_thread2_start'] = var2.get('default2_thread2')
+
+        var1.set('value3')
+        var2.set('value4')
+
+        await asyncio.sleep(0.3)
+
+        test_context['var1_thread2_mid'] = var1.get()
+        test_context['var2_thread2_mid'] = var2.get()
+
+        await asyncio.sleep(0.1)
+
+        test_context['var1_thread2_end'] = var1.get()
+        test_context['var2_thread2_end'] = var2.get()
+        test_context['c2_complete'] = True
+
+    loop_thread = SimpleLoopThread()
+    loop_thread.start()
+
+    var1.set('super1')
+    var2.set('super2')
+
+    asyncio.run_coroutine_threadsafe(c1(), loop_thread.loop)
+    asyncio.run_coroutine_threadsafe(c2(), loop_thread.loop)
+
+    # It's _extremely_ unlikely that _both_ have already started and completed, and we want to ensure that our patched
+    # run_coroutine_threadsafe hasn't run them both to completion before returning.
+    assert (
+        test_context['c1_called'] is False or
+        test_context['c1_complete'] is False or
+        test_context['c2_called'] is False or
+        test_context['c2_complete'] is False
+    )
+
+    try:
+        assert var1.get('default1_main') == 'super1'
+        assert var2.get('default2_main') == 'super2'
+
+        var1.set('value5')
+        var2.set('value6')
+
+        time.sleep(0.2)
+
+        assert var1.get() == 'value5'
+        assert var2.get() == 'value6'
+
+        time.sleep(0.2)
+
+        assert var1.get() == 'value5'
+        assert var2.get() == 'value6'
+    finally:
+        loop_thread.join()
+
+    assert test_context['c1_called'] is True
+    assert test_context['c1_complete'] is True
+    assert test_context['var1_thread1_start'] == 'super1'
+    assert test_context['var2_thread1_start'] == 'super2'
+    assert test_context['var1_thread1_mid'] == 'value1'
+    assert test_context['var2_thread1_mid'] == 'value2'
+    assert test_context['var1_thread1_end'] == 'value1'
+    assert test_context['var2_thread1_end'] == 'value2'
+
+    assert test_context['c2_called'] is True
+    assert test_context['c2_complete'] is True
+    assert test_context['var1_thread2_start'] == 'super1'
+    assert test_context['var2_thread2_start'] == 'super2'
+    assert test_context['var1_thread2_mid'] == 'value3'
+    assert test_context['var2_thread2_mid'] == 'value4'
+    assert test_context['var1_thread2_end'] == 'value3'
+    assert test_context['var2_thread2_end'] == 'value4'

--- a/tests/unit/common/test_compatibility_threading.py
+++ b/tests/unit/common/test_compatibility_threading.py
@@ -1,0 +1,149 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import threading
+import time
+
+import pytest
+import six
+
+from pysoa.common.compatibility import ContextVar
+
+
+try:
+    import contextvars
+except ImportError:
+    contextvars = None
+
+
+def test_one_thread():
+    var = ContextVar('test_one_thread1')
+
+    with pytest.raises(LookupError) as error_context:
+        var.get()
+
+    if six.PY2:
+        assert error_context.value.args[0] is var
+        assert "pysoa.common.compatibility.ContextVar name='test_one_thread1' at " in repr(var)
+        assert isinstance(var.variable, getattr(threading, 'local'))
+    else:
+        assert "ContextVar name='test_one_thread1' at " in repr(var)
+        assert isinstance(var.variable, contextvars.ContextVar)
+
+    assert var.get('default1') == 'default1'
+    assert var.get(default='default2') == 'default2'
+
+    var.set('set1')
+    assert var.get() == 'set1'
+
+    var = ContextVar('test_one_thread2', 'default3')
+
+    assert var.get() == 'default3'
+    assert var.get('default4') == 'default4'
+
+    var.set('set2')
+    assert var.get() == 'set2'
+
+    var = ContextVar('test_one_thread3', default='default5')
+
+    assert var.get() == 'default5'
+    assert var.get('default6') == 'default6'
+
+    var.set('set3')
+    assert var.get() == 'set3'
+
+
+def test_multiple_threads():
+    var1 = ContextVar('test_multiple_threads1')
+    var2 = ContextVar('test_multiple_threads1')
+
+    test_context = {
+        'var1_thread1_start': None,
+        'var2_thread1_start': None,
+        'var1_thread1_mid': None,
+        'var2_thread1_mid': None,
+        'var1_thread1_end': None,
+        'var2_thread1_end': None,
+        'var1_thread2_start': None,
+        'var2_thread2_start': None,
+        'var1_thread2_mid': None,
+        'var2_thread2_mid': None,
+        'var1_thread2_end': None,
+        'var2_thread2_end': None,
+    }
+
+    def t1():
+        test_context['var1_thread1_start'] = var1.get('default1_thread1')
+        test_context['var2_thread1_start'] = var2.get('default2_thread1')
+
+        var1.set('value1')
+        var2.set('value2')
+
+        time.sleep(0.1)
+
+        test_context['var1_thread1_mid'] = var1.get()
+        test_context['var2_thread1_mid'] = var2.get()
+
+        time.sleep(0.3)
+
+        test_context['var1_thread1_end'] = var1.get()
+        test_context['var2_thread1_end'] = var2.get()
+
+    def t2():
+        test_context['var1_thread2_start'] = var1.get('default1_thread2')
+        test_context['var2_thread2_start'] = var2.get('default2_thread2')
+
+        var1.set('value3')
+        var2.set('value4')
+
+        time.sleep(0.3)
+
+        test_context['var1_thread2_mid'] = var1.get()
+        test_context['var2_thread2_mid'] = var2.get()
+
+        time.sleep(0.1)
+
+        test_context['var1_thread2_end'] = var1.get()
+        test_context['var2_thread2_end'] = var2.get()
+
+    thread1 = threading.Thread(target=t1)
+    thread2 = threading.Thread(target=t2)
+
+    thread1.start()
+    thread2.start()
+
+    try:
+        assert var1.get('default1_main') == 'default1_main'
+        assert var2.get('default2_main') == 'default2_main'
+
+        var1.set('value5')
+        var2.set('value6')
+
+        time.sleep(0.2)
+
+        assert var1.get() == 'value5'
+        assert var2.get() == 'value6'
+
+        time.sleep(0.2)
+
+        assert var1.get() == 'value5'
+        assert var2.get() == 'value6'
+    finally:
+        thread1.join()
+        thread2.join()
+
+    assert test_context['var1_thread1_start'] == 'default1_thread1'
+    assert test_context['var2_thread1_start'] == 'default2_thread1'
+    assert test_context['var1_thread1_mid'] == 'value1'
+    assert test_context['var2_thread1_mid'] == 'value2'
+    assert test_context['var1_thread1_end'] == 'value1'
+    assert test_context['var2_thread1_end'] == 'value2'
+
+    assert test_context['var1_thread2_start'] == 'default1_thread2'
+    assert test_context['var2_thread2_start'] == 'default2_thread2'
+    assert test_context['var1_thread2_mid'] == 'value3'
+    assert test_context['var2_thread2_mid'] == 'value4'
+    assert test_context['var1_thread2_end'] == 'value3'
+    assert test_context['var2_thread2_end'] == 'value4'

--- a/tests/unit/server/internal/test_event_loop.py
+++ b/tests/unit/server/internal/test_event_loop.py
@@ -3,17 +3,38 @@ from __future__ import (
     unicode_literals,
 )
 
+# noinspection PyCompatibility
 import asyncio
+# noinspection PyCompatibility
+import contextvars
 import threading
+from typing import (
+    Any,
+    Dict,
+    List,
+)
 import unittest
 
-from pysoa.server.internal.event_loop import AsyncEventLoopThread
+from conformity import fields
+from conformity.error import ValidationError
+import pytest
+
+from pysoa.server.coroutine import (
+    CoroutineMiddleware,
+    DefaultCoroutineMiddleware,
+)
+from pysoa.server.internal.event_loop import (
+    AsyncEventLoopThread,
+    coroutine_middleware_config,
+)
+from pysoa.test.compatibility import mock
 
 
+# noinspection PyCompatibility
 class AsyncEventLoopThreadTests(unittest.TestCase):
     def setUp(self):
         super(AsyncEventLoopThreadTests, self).setUp()
-        self.thread = AsyncEventLoopThread()
+        self.thread = AsyncEventLoopThread([])
         self.thread.start()
 
     def tearDown(self):
@@ -42,3 +63,161 @@ class AsyncEventLoopThreadTests(unittest.TestCase):
         self.thread.join()
         assert not self.thread.loop.is_running()
         assert self.thread.loop.is_closed()
+
+
+before_call_trace = []  # type: List[str]
+create_call_trace = []  # type: List[str]
+run_call_trace_pre = []  # type: List[str]
+run_call_trace_post = []  # type: List[str]
+
+
+@fields.ClassConfigurationSchema.provider(
+    fields.Dictionary({'var_value': fields.Integer()}),
+)
+class SpecialCoroutineMiddleware(CoroutineMiddleware):
+    def __init__(self, var_value):
+        self.var_value = var_value
+
+    def before_run_coroutine(self):
+        before_call_trace.append('SpecialCoroutineMiddleware')
+
+    def coroutine(self, coroutine):
+        create_call_trace.append('SpecialCoroutineMiddleware')
+
+        # noinspection PyCompatibility
+        async def wrapper():
+            var = contextvars.ContextVar('middleware_var')
+            var.set(self.var_value)
+
+            run_call_trace_pre.append('SpecialCoroutineMiddleware')
+
+            await coroutine
+
+            run_call_trace_post.append('SpecialCoroutineMiddleware')
+
+        return wrapper()
+
+
+@fields.ClassConfigurationSchema.provider(fields.Dictionary({}))
+class TracingCoroutineMiddleware(CoroutineMiddleware):
+    def before_run_coroutine(self):
+        before_call_trace.append('TracingCoroutineMiddleware')
+
+    def coroutine(self, coroutine):
+        create_call_trace.append('TracingCoroutineMiddleware')
+
+        # noinspection PyCompatibility
+        async def wrapper():
+            run_call_trace_pre.append('TracingCoroutineMiddleware')
+
+            await coroutine
+
+            run_call_trace_post.append('TracingCoroutineMiddleware')
+
+        return wrapper()
+
+
+@fields.ClassConfigurationSchema.provider(fields.Dictionary({}))
+class NotCoroutineMiddleware:
+    pass
+
+
+def test_coroutine_middleware_config():
+    coroutine_middleware_config.contents.instantiate_from({
+        'path': 'tests.unit.server.internal.test_event_loop:SpecialCoroutineMiddleware',
+        'kwargs': {'var_value': 12},
+    })
+
+    with pytest.raises(ValidationError):
+        coroutine_middleware_config.contents.instantiate_from({
+            'path': 'tests.unit.server.internal.test_event_loop:SpecialCoroutineMiddleware',
+        })
+
+    with pytest.raises(ValidationError):
+        coroutine_middleware_config.contents.instantiate_from({
+            'path': 'tests.unit.server.internal.test_event_loop:SpecialCoroutineMiddleware',
+            'kwargs': {},
+        })
+
+    with pytest.raises(ValidationError):
+        coroutine_middleware_config.contents.instantiate_from({
+            'path': 'tests.unit.server.internal.test_event_loop:SpecialCoroutineMiddleware',
+            'kwargs': {'var_value': 'not_an_int'},
+        })
+
+    with pytest.raises(ValidationError):
+        coroutine_middleware_config.contents.instantiate_from({
+            'path': 'tests.unit.server.internal.test_event_loop:NotCoroutineMiddleware',
+        })
+
+
+# noinspection PyCompatibility
+@pytest.mark.asyncio
+async def test_coroutine_middleware():
+    before_call_trace.clear()
+    create_call_trace.clear()
+    run_call_trace_pre.clear()
+    run_call_trace_post.clear()
+
+    var = contextvars.ContextVar('caller_var')
+    var.set('yes man')
+
+    test_context = {
+        'caller_var': None,
+        'middleware_var': None
+    }  # type: Dict[str, Any]
+
+    # noinspection PyCompatibility
+    async def coroutine():
+        run_call_trace_pre.append('target')
+
+        test_context['caller_var'] = var.get('default_cv')
+        for context_var in contextvars.copy_context().keys():
+            if context_var.name == 'middleware_var':
+                test_context['middleware_var'] = context_var.get('default_mv')
+        await asyncio.sleep(0.05)
+
+        run_call_trace_post.append('target')
+
+    thread = AsyncEventLoopThread([
+        SpecialCoroutineMiddleware(42),
+        TracingCoroutineMiddleware(),
+    ])
+    thread.start()
+
+    thread.run_coroutine(coroutine())
+
+    await asyncio.sleep(0.2)
+
+    thread.join()
+
+    assert before_call_trace == ['SpecialCoroutineMiddleware', 'TracingCoroutineMiddleware']
+    assert create_call_trace == ['TracingCoroutineMiddleware', 'SpecialCoroutineMiddleware']
+    assert run_call_trace_pre == ['SpecialCoroutineMiddleware', 'TracingCoroutineMiddleware', 'target']
+    assert run_call_trace_post == ['target', 'TracingCoroutineMiddleware', 'SpecialCoroutineMiddleware']
+
+    assert test_context['caller_var'] == 'yes man'
+    assert test_context['middleware_var'] == 42
+
+
+# noinspection PyCompatibility
+@pytest.mark.asyncio
+async def test_default_coroutine_middleware():
+    class SpecialError(Exception):
+        pass
+
+    # noinspection PyCompatibility
+    async def coroutine():
+        raise SpecialError()
+
+    thread = AsyncEventLoopThread([DefaultCoroutineMiddleware()])
+    thread.start()
+
+    with mock.patch('logging.Logger.exception') as mock_log_exception:
+        thread.run_coroutine(coroutine())
+
+        await asyncio.sleep(0.2)
+
+        thread.join()
+
+    mock_log_exception.assert_called_once_with('Error occurred while awaiting coroutine in request.run_coroutine')

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,12 @@ envlist =
     py36-currint{16,20}
     py37-attrs{17,18,19}
     py27-pytest{31,46}
-    py37-pytest{31,46,50}
+    py37-pytest{46,51}
     py{27,37}-flake8
 #    py27-conformity_branch
 #    py37-conformity_branch
     coverage
+    py27-coverage
 
 [testenv]
 usedevelop=True
@@ -24,12 +25,17 @@ deps =
     pytest31: pytest~=3.1.3
     pytest31: pytest-cov==2.6.0
     pytest46: pytest~=4.6.4
-    pytest50: pytest~=5.0.1
+    pytest51: pytest~=5.1.0
 #    ipdb
 commands =
 #    conformity_branch: pip uninstall -y conformity
 #    conformity_branch: pip install git+https://github.com/eventbrite/conformity.git@insert_branch_name_here
     coverage run --parallel-mode -m pytest tests/unit tests/integration
+
+[testenv:py37-pytest51]
+commands =
+    coverage run --parallel-mode -m pytest tests/unit tests/integration
+    ./lint.sh --no-flake
 
 [testenv:py27-flake8]
 skip_install = true
@@ -47,3 +53,10 @@ deps = coverage
 commands =
     coverage combine
     coverage report
+
+[testenv:py27-coverage]
+skip_install = true
+deps = coverage
+commands =
+    coverage combine
+    coverage report --omit=pysoa/server/coroutine.py,pysoa/server/internal/event_loop.py


### PR DESCRIPTION
- Add a compatibility layer with a `ContextVar` wrapper that uses thread locals in Python 2.7, the `contextvars` backport in Python 3.5-3.6, and the standard `contextvars` in Python 3.7+.
- Add a new middleware layer for wrapping coroutines executed by the `AsyncEventLoopThread` (`request.run_coroutine`): `CoroutineMiddleware`.
- Remove all uses of thread locals and replace them with the `ContextVar` compatibility layer.