### PR TITLE
[MINOR] Add pre-fork hook method to Server class, clean up prints

### DIFF
--- a/pysoa/server/autoreload.py
+++ b/pysoa/server/autoreload.py
@@ -208,7 +208,8 @@ class AbstractReloader(object):
         while self.watching:
             if self.code_changed():
                 # Signal the server process that we want it to stop (including its forks), and tell the reloader why
-                print('File change detected; reloading server process')
+                sys.stdout.write('File change detected; reloading server process\n')
+                sys.stdout.flush()
                 self.shutting_down_for_reload = True
                 if self.signal_forks:
                     os.kill(os.getpid(), signal.SIGHUP)
@@ -220,7 +221,10 @@ class AbstractReloader(object):
                     time.sleep(0.5)
                     i += 1
                     if i > 12:
-                        print("Process took too long to stop after file change; signaling again (won't restart)")
+                        sys.stdout.write(
+                            "Process took too long to stop after file change; signaling again (won't restart)\n",
+                        )
+                        sys.stdout.flush()
                         os.kill(os.getpid(), signal.SIGTERM)
                         break
                 break

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -812,6 +812,15 @@ class Server(object):
             self._delete_heartbeat_file()
             self.logger.info('Server shutdown complete')
 
+    @classmethod
+    def pre_fork(cls):
+        """
+        Called only if the --fork argument is used to pre-fork multiple worker processes. In this case, it is called
+        by the parent process immediately after signal handlers are set and immediately before the worker sub-processes
+        are spawned. It is never called again in the life span of the parent process, even if a worker process crashes
+        and gets re-spawned.
+        """
+
     # noinspection PyUnusedLocal
     @classmethod
     def initialize(cls, settings):


### PR DESCRIPTION
- Add a `pre_fork` hook to the `Server` class to perform parent-process setup tasks right before spawning child sub-processes.
- Clean up `print` statements that printed out of order, replacing them with usages of `sys.stdout.write` and `sys.stdout.flush`.