### PR TITLE
[MAJOR] Support UTC-aware datetime objects in MsgpackSerializer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ base_requirements = [
     'currint>=1.6,<3',
     'enum34;python_version<"3.4"',
     'msgpack-python~=0.5,>=0.5.2',
+    'pytz>=2019.1',
     'redis~=2.10',
     'six~=1.10',
     'typing;python_version<"3.5"',
@@ -41,7 +42,6 @@ test_plan_requirements = test_helper_requirements + [
     'pyparsing~=2.2',
     'pytest>=3.1,<6,!=4.2.0',  # 4.2.0 has a regression breaking our test plans, fixed in 4.2.1
     'pytest-asyncio;python_version>"3.4"',
-    'pytz>=2019.1',
 ]
 
 test_requirements = [


### PR DESCRIPTION
`MsgpackSerializer` now supports both naive and UTC-aware `datetime.datetime` objects. Other time zones, however, are not supported. This is a breaking change, because sending a UTC-aware `datetime` from a client to a server on an older version will cause deserialization errors and you will get an error response. Be sure that all servers are running this version of PySOA before sending requests contaiting UTC-aware `datetime` objects.