### PR TITLE
[MAJOR] Add support for response chunking to Redis Gateway transport

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -821,6 +821,15 @@ The Redis Gateway transport takes the following extra keyword arguments for conf
   messages larger than this (set this to 0 to disable the warning)
 - ``maximum_message_size_in_bytes``: Defaults to 102,400 bytes on the client and 256,000 bytes on the server, defines
   the threshold at which ``MessageTooLarge`` will be raised.
+- ``chunk_messages_larger_than_bytes``: This option exists only for the Server transport and not for the Client
+  transport and controls the threshold at which responses will be chunked. Chunked responses allows your servers to
+  return very large responses back to clients without blocking single-threaded Redis for long periods of time with the
+  I/O from a single very large response. With chunking, each small chunk will compete for Redis resources as if it were
+  its own response, resulting in an infrastructure more torerable to large responses. By default, this is -1 (disabled).
+  If you configure this value, it must be at least 102,400 bytes, and ``maximum_message_size_in_bytes`` must also be
+  configured to be at least 5 times larger (because maximum message sizes can still be enforced, above which not even
+  chunking is allowed). You will probably also want to increase ``log_messages_larger_than_bytes`` to avoid verbose
+  response logging.
 
 
 Middleware

--- a/functional.sh
+++ b/functional.sh
@@ -13,6 +13,13 @@ then
     exit 0
 fi
 
+verbose="false"
+if [[ "$1" == "verbose" ]]
+then
+    verbose="true"
+    shift
+fi
+
 set -ex
 
 docker build --tag pysoa-test-mysql --file tests/functional/docker/Dockerfile-mysql .
@@ -46,7 +53,7 @@ echo  "Running functional tests..."
 #docker-compose -f $DCF exec -T test pytest tests/functional
 docker-compose -f $DCF exec -T test \
     coverage run --concurrency=multiprocessing --rcfile=/srv/run/.coveragerc -m \
-    pytest -vv -p no:pysoa_test_plan tests/functional
+    pytest -vv -p no:pysoa_test_plan tests/functional "$@"
 RET=$?
 
 # Stop these now, so that coverage files get written
@@ -83,7 +90,7 @@ fi
 
 docker-compose -f $DCF stop
 
-if [[ "$1" == "verbose" ]]
+if [[ "$verbose" == "true" ]]
 then
     docker-compose -f $DCF logs
 fi

--- a/pysoa/common/metrics.py
+++ b/pysoa/common/metrics.py
@@ -5,6 +5,11 @@ from __future__ import (
 
 import abc
 import enum
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Optional,
+    Union,
+)
 
 from conformity import fields
 import six
@@ -17,13 +22,27 @@ class Counter(object):
     """
 
     @abc.abstractmethod
-    def increment(self, amount=1):
+    def increment(self, amount=1):  # type: (int) -> None
         """
         Increments the counter.
 
         :param amount: The amount by which to increment the counter, which must default to 1.
         """
-        raise NotImplementedError()
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Histogram(object):
+    """
+    Defines an interface for tracking an arbitrary number of something per named activity.
+    """
+
+    @abc.abstractmethod
+    def set(self, value=None):  # type: (Optional[Union[int, float]]) -> None
+        """
+        Sets the histogram value.
+
+        :param value: The histogram value.
+        """
 
 
 class TimerResolution(enum.IntEnum):
@@ -33,37 +52,36 @@ class TimerResolution(enum.IntEnum):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Timer(object):
+class Timer(Histogram):
     """
-    Defines an interface for timing activity. Can be used as a context manager to time wrapped activity.
+    Defines an interface for timing activity. Can be used as a context manager to time wrapped activity. Exists as a
+    special Histogram whose value can be set based on starting and stopping the timer.
     """
 
     @abc.abstractmethod
-    def start(self):
+    def start(self):  # type: () -> None
         """
         Starts the timer.
         """
-        raise NotImplementedError()
 
     @abc.abstractmethod
-    def stop(self):
+    def stop(self):  # type: () -> None
         """
         Stops the timer.
         """
-        raise NotImplementedError()
 
-    def __enter__(self):
+    def __enter__(self):  # type: () -> Timer
         """
-        Starts the timer at the start of the context manager.
+        Starts the timer at the start of the context manager. Returns self.
         """
         self.start()
+        return self
 
-    def __exit__(self, *_, **__):
+    def __exit__(self, exc_type, exc_value, traceback):  # type: (Any, Any, Any) -> bool
         """
         Stops the timer at the end of the context manager. All parameters are ignored. Always returns ``False``.
 
         :return: ``False``
-        :rtype: bool
         """
         self.stop()
         return False
@@ -73,30 +91,39 @@ class Timer(object):
 class MetricsRecorder(object):
     """
     Defines an interface for recording metrics. All metrics recorders registered with PySOA must implement this
-    interface. Note that counters and timers with the same name will not be recorded. If your metrics backend needs
+    interface. Note that counters and timers with the same name may not be recorded. If your metrics backend needs
     timers to also have associated counters, your implementation of this recorder must take care of filling that gap.
     """
 
     @abc.abstractmethod
-    def counter(self, name, **kwargs):
+    def counter(self, name, **kwargs):  # type: (six.text_type, Any) -> Counter
         """
-        Returns a counter that can be incremented. Implementations do not have to return an instance of `Counter`, but
-        they must at least return an object that matches the interface for `Counter`.
+        Returns a counter that can be incremented.
 
         :param name: The name of the counter
-        :param kwargs: Any other arguments that may be needed
+        :param kwargs: Any other arguments that may be needed (unrecognized keyword arguments should be treated as
+                       metric "tags" and either passed to the metrics backend, if supported, or ignored)
 
         :return: a counter object.
-        :rtype: Counter
         """
-        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def histogram(self, name, **kwargs):  # type: (six.text_type, Any) -> Histogram
+        """
+        Returns a histogram that can be set.
+
+        :param name: The name of the histogram
+        :param kwargs: Any other arguments that may be needed (unrecognized keyword arguments should be treated as
+                       metric "tags" and either passed to the metrics backend, if supported, or ignored)
+
+        :return: a histogram object.
+        """
 
     @abc.abstractmethod
     def timer(self, name, resolution=TimerResolution.MILLISECONDS, **kwargs):
+        # type: (six.text_type, TimerResolution, Any) -> Timer
         """
-        Returns a timer that can be started and stopped. Implementations do not have to return an instance of `Timer`,
-        but they must at least return an object that matches the interface for `Timer`, including serving as a context
-        manager.
+        Returns a timer that can be started and stopped.
 
         :param name: The name of the timer
         :param resolution: The resolution at which this timer should operate, defaulting to milliseconds. Its value
@@ -105,14 +132,13 @@ class MetricsRecorder(object):
                            ever be access as a keyword argument, never as a positional argument, so it is not necessary
                            for this to be the second positional argument in your equivalent recorder class.
         :type resolution: enum.IntEnum
-        :param kwargs: Any other arguments that may be needed
+        :param kwargs: Any other arguments that may be needed (unrecognized keyword arguments should be treated as
+                       metric "tags" and either passed to the metrics backend, if supported, or ignored)
 
-        :return: a timer object
-        :rtype: Timer
+        :return: a timer object.
         """
-        raise NotImplementedError()
 
-    def commit(self):
+    def commit(self):  # type: () -> None
         """
         Commits the recorded metrics, if necessary, to the storage medium in which they reside. Can simply be a
         no-op if metrics are recorded immediately.
@@ -130,54 +156,73 @@ class NoOpMetricsRecorder(MetricsRecorder):
     metrics-recording settings have been configured.
     """
     class NoOpCounter(Counter):
-        def increment(self, amount=1):
+        def increment(self, amount=1):  # type: (int) -> None
             """
             Does nothing.
             :param amount: Unused
             """
 
-    class NoOpTimer(Timer):
-        def start(self):
+    class NoOpHistogram(Histogram):
+        def set(self, value=None):  # type: (Optional[Union[int, float]]) -> None
+            """
+            Does nothing.
+            :param value: Unused
+            """
+
+    class NoOpTimer(Timer, NoOpHistogram):
+        def start(self):  # type: () -> None
             """
             Does nothing.
             """
 
-        def stop(self):
+        def stop(self):  # type: () -> None
             """
             Does nothing.
             """
 
     no_op_counter = NoOpCounter()
+    no_op_histogram = NoOpHistogram()
     no_op_timer = NoOpTimer()
 
-    def __init__(self, *_, **__):
+    def __init__(self, *_, **__):  # type: (Any, Any) -> None
         """
         A dummy constructor that ignores all arguments
         """
 
-    def counter(self, name, **kwargs):
+    def counter(self, name, **kwargs):  # type: (six.text_type, Any) -> Counter
         """
         Returns a counter that does nothing.
 
         :param name: Unused
 
         :return: A do-nothing counter
-        :rtype: NoOpMetricsRecorder.NoOpCounter
         """
         return self.no_op_counter
 
-    def timer(self, name, **kwargs):
+    def histogram(self, name, **kwargs):  # type: (six.text_type, Any) -> Histogram
+        """
+        Returns a histogram that does nothing.
+
+        :param name: Unused
+
+        :return: A do-nothing histogram
+        """
+        return self.no_op_histogram
+
+    def timer(self, name, resolution=TimerResolution.MILLISECONDS, **kwargs):
+        # type: (six.text_type, TimerResolution, Any) -> Timer
         """
         Returns a timer that does nothing.
 
         :param name: Unused
+        :param resolution: Unused
 
         :return: A do-nothing timer
-        :rtype: NoOpMetricsRecorder.NoOpTimer
         """
         return self.no_op_timer
 
     def commit(self):
+        # type: () -> None
         """
         Does nothing
         """

--- a/pysoa/common/serializer/base.py
+++ b/pysoa/common/serializer/base.py
@@ -4,6 +4,7 @@ from __future__ import (
 )
 
 import abc
+from typing import Dict  # noqa: F401 TODO Python 3
 
 import six
 
@@ -50,13 +51,13 @@ class Serializer(object):
     mime_type = None
 
     @classmethod
-    def resolve_serializer(cls, mime_type):
+    def resolve_serializer(cls, mime_type):  # type: (six.text_type) -> Serializer
         if mime_type not in cls.all_supported_mime_types:
             raise ValueError('Mime type {} is not supported'.format(mime_type))
         return cls._mime_type_to_serializer_map[mime_type]()
 
     @abc.abstractmethod
-    def dict_to_blob(self, message_dict):
+    def dict_to_blob(self, message_dict):  # type: (Dict) -> six.binary_type
         """
         Take a message in the form of a dict and return a serialized message in the form of bytes (string).
 
@@ -68,7 +69,7 @@ class Serializer(object):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def blob_to_dict(self, blob):
+    def blob_to_dict(self, blob):  # type: (six.binary_type) -> Dict
         """
         Take a serialized message in the form of bytes (string) and return a dict.
 

--- a/pysoa/common/serializer/json_serializer.py
+++ b/pysoa/common/serializer/json_serializer.py
@@ -4,6 +4,7 @@ from __future__ import (
 )
 
 import json
+from typing import Dict  # noqa: F401 TODO Python 3
 
 from conformity import fields
 import six
@@ -29,14 +30,15 @@ class JSONSerializer(BaseSerializer):
     """
     mime_type = 'application/json'
 
-    def dict_to_blob(self, data_dict):
-        assert isinstance(data_dict, dict), 'Input must be a dict'
+    def dict_to_blob(self, data_dict):  # type: (Dict) -> six.binary_type
+        if not isinstance(data_dict, dict):
+            raise ValueError('Input must be a dict')
         try:
             return json.dumps(data_dict).encode('utf-8')
         except TypeError as e:
             raise InvalidField(*e.args)
 
-    def blob_to_dict(self, blob):
+    def blob_to_dict(self, blob):  # type: (six.binary_type) -> Dict
         try:
             if six.PY3 and isinstance(blob, six.binary_type):
                 blob = blob.decode('utf-8')

--- a/pysoa/common/transport/redis_gateway/backend/sentinel.py
+++ b/pysoa/common/transport/redis_gateway/backend/sentinel.py
@@ -6,12 +6,20 @@ from __future__ import (
 import itertools
 import random
 import time
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+)
 
 import redis
 import redis.sentinel
 import six
 
-from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.redis_gateway.backend.base import (
     BaseRedisClient,
     CannotGetConnectionError,
@@ -37,36 +45,39 @@ class SentinelRedisClient(BaseRedisClient):
 
     def __init__(
         self,
-        hosts=None,
-        connection_kwargs=None,
-        sentinel_services=None,
-        sentinel_failover_retries=0,
+        hosts=None,  # type: Iterable[Tuple[six.text_type, int]]
+        connection_kwargs=None,  # type: Dict[six.text_type, Any]
+        sentinel_services=None,  # type: Iterable[six.text_type]
+        sentinel_failover_retries=0,  # type: int
     ):
+        # type: (...) -> None
         # Master client caching
-        self._master_clients = {}
+        self._master_clients = {}  # type: Dict[six.text_type, redis.StrictRedis]
 
         # Master failover behavior
-        assert sentinel_failover_retries >= 0
+        if sentinel_failover_retries < 0:
+            raise ValueError('sentinel_failover_retries must be >= 0')
         self._sentinel_failover_retries = sentinel_failover_retries
 
         self._sentinel = redis.sentinel.Sentinel(self._setup_hosts(hosts), **(connection_kwargs or {}))
         if sentinel_services:
             self._validate_service_names(sentinel_services)
-            self._services = sentinel_services
+            self._services = list(sentinel_services)  # type: List[six.text_type]
         else:
-            self._services = self._get_service_names()
+            self._services = self._get_service_names()  # type: List[six.text_type]
         self._ring_size = len(self._services)
-        self._connection_index_generator = itertools.cycle(range(self._ring_size))
-
-        self.metrics_counter_getter = None
+        self._connection_index_generator = itertools.cycle(range(self._ring_size))  # type: Iterator[int]
 
         super(SentinelRedisClient, self).__init__(ring_size=len(self._services))
 
     def reset_clients(self):
-        self._master_clients = {}
+        self._master_clients = {}  # type: Dict[six.text_type, redis.StrictRedis]
 
     @staticmethod
-    def _setup_hosts(hosts):
+    def _setup_hosts(
+        hosts,  # type: Iterable[Tuple[six.text_type, int]]
+    ):
+        # type: (...) -> List[Tuple[six.text_type, int]]
         if not hosts:
             hosts = [('localhost', 26379)]
 
@@ -77,19 +88,23 @@ class SentinelRedisClient(BaseRedisClient):
         for entry in hosts:
             if isinstance(entry, six.string_types):
                 raise ValueError('Sentinel Redis host entries must be specified as tuples, not strings.')
-            else:
+            elif isinstance(entry, tuple):
                 final_hosts.append(entry)
+            else:
+                raise ValueError(
+                    'Sentinel Redis hosts entries must be specified as tuples, not {}.'.format(type(entry)),
+                )
         return final_hosts
 
     @staticmethod
-    def _validate_service_names(services):
+    def _validate_service_names(services):  # type: (Iterable[six.text_type]) -> None
         if isinstance(services, six.string_types):
             raise ValueError('Sentinel service types must be specified as an iterable list of strings.')
         for entry in services:
             if not isinstance(entry, six.string_types):
                 raise ValueError('Sentinel service types must be specified as strings.')
 
-    def _get_service_names(self):
+    def _get_service_names(self):  # type: () -> List[six.text_type]
         """
         Get a list of service names from Sentinel. Tries Sentinel hosts until one succeeds; if none succeed,
         raises a ConnectionError.
@@ -113,14 +128,14 @@ class SentinelRedisClient(BaseRedisClient):
             )
         return list(master_info.keys())
 
-    def _get_master_client_for(self, service_name):
+    def _get_master_client_for(self, service_name):  # type: (six.text_type) -> redis.StrictRedis
         if service_name not in self._master_clients:
             self._get_counter('backend.sentinel.populate_master_client').increment()
             self._master_clients[service_name] = self._sentinel.master_for(service_name)
 
         return self._master_clients[service_name]
 
-    def _get_connection(self, index=None):
+    def _get_connection(self, index=None):  # type: (Optional[int]) -> redis.StrictRedis
         if index is None:
             index = self._get_random_index()
 
@@ -142,8 +157,5 @@ class SentinelRedisClient(BaseRedisClient):
                 self._get_counter('backend.sentinel.master_not_found_retry').increment()
                 time.sleep((2 ** i + random.random()) / 4.0)
 
-    def _get_random_index(self):
+    def _get_random_index(self):  # type: () -> int
         return random.randint(0, len(self._services) - 1)
-
-    def _get_counter(self, name):
-        return self.metrics_counter_getter(name) if self.metrics_counter_getter else NoOpMetricsRecorder.no_op_counter

--- a/pysoa/common/transport/redis_gateway/backend/standard.py
+++ b/pysoa/common/transport/redis_gateway/backend/standard.py
@@ -3,6 +3,16 @@ from __future__ import (
     unicode_literals,
 )
 
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
 import redis
 import six
 
@@ -10,14 +20,24 @@ from pysoa.common.transport.redis_gateway.backend.base import BaseRedisClient
 
 
 class StandardRedisClient(BaseRedisClient):
-    def __init__(self, hosts=None, connection_kwargs=None):
+    def __init__(
+        self,
+        hosts=None,  # type: Iterable[Union[six.text_type, Tuple[six.text_type, int]]]
+        connection_kwargs=None,  # type: Dict[six.text_type, Any]
+    ):
+        # type: (...) -> None
         self._hosts = self._setup_hosts(hosts)
-        self._connection_list = [redis.Redis.from_url(host, **(connection_kwargs or {})) for host in self._hosts]
+        self._connection_list = [
+            redis.Redis.from_url(host, **(connection_kwargs or {})) for host in self._hosts
+        ]  # type: List[redis.Redis]
 
         super(StandardRedisClient, self).__init__(ring_size=len(self._hosts))
 
     @staticmethod
-    def _setup_hosts(hosts):
+    def _setup_hosts(
+        hosts,  # type: Iterable[Union[six.text_type, Tuple[six.text_type, int]]]
+    ):
+        # type: (...) -> List[six.text_type]
         if not hosts:
             hosts = [('localhost', 6379)]
 
@@ -32,7 +52,7 @@ class StandardRedisClient(BaseRedisClient):
                 final_hosts.append('redis://{name}:{port:d}/0'.format(name=entry[0], port=entry[1]))
         return final_hosts
 
-    def _get_connection(self, index=None):
+    def _get_connection(self, index=None):  # type: (Optional[int]) -> redis.StrictRedis
         # If index is explicitly None, pick a random server
         if index is None:
             index = self._get_random_index()

--- a/pysoa/common/transport/redis_gateway/client.py
+++ b/pysoa/common/transport/redis_gateway/client.py
@@ -3,27 +3,53 @@ from __future__ import (
     unicode_literals,
 )
 
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+    Optional,
+)
 import uuid
 
 from conformity import fields
+import six  # noqa: F401 TODO Python 3
 
-from pysoa.common.metrics import TimerResolution
+from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+    MetricsRecorder,
+    TimerResolution,
+)
 from pysoa.common.transport.base import (
     ClientTransport,
+    ReceivedMessage,
     get_hex_thread_id,
 )
 from pysoa.common.transport.exceptions import MessageReceiveTimeout
 from pysoa.common.transport.redis_gateway.backend.base import BaseRedisClient
-from pysoa.common.transport.redis_gateway.constants import DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT
-from pysoa.common.transport.redis_gateway.core import RedisTransportCore
+from pysoa.common.transport.redis_gateway.constants import ProtocolVersion
+from pysoa.common.transport.redis_gateway.core import RedisTransportClientCore
 from pysoa.common.transport.redis_gateway.settings import RedisTransportSchema
 from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 
 
-@fields.ClassConfigurationSchema.provider(RedisTransportSchema())
+@fields.ClassConfigurationSchema.provider(RedisTransportSchema().extend(
+    contents={
+        'protocol_version': fields.Any(
+            fields.Integer(),
+            fields.ObjectInstance(valid_type=ProtocolVersion),
+            description='The default protocol version between clients and servers was Version 1 prior to PySOA '
+                        '0.67.0, Version 2 as of 0.67.0, and will be Version 3 as of 1.0.0. The server can only '
+                        'detect what protocol the client is speaking and respond with the same protocol. However, '
+                        'the client cannot pre-determine what protocol the server is speaking. So, if you need to '
+                        'differ from the default (currently Version 2), use this setting to tell the client which '
+                        'protocol to speak.',
+        ),
+    },
+    optional_keys=('protocol_version', ),
+    description='The constructor kwargs for the Redis client transport.',
+))
 class RedisClientTransport(ClientTransport):
 
     def __init__(self, service_name, metrics, **kwargs):
+        # type: (six.text_type, MetricsRecorder, **Any) -> None
         """
         In addition to the two named positional arguments, this constructor expects keyword arguments abiding by the
         Redis transport settings schema.
@@ -36,9 +62,6 @@ class RedisClientTransport(ClientTransport):
         """
         super(RedisClientTransport, self).__init__(service_name, metrics)
 
-        if 'maximum_message_size_in_bytes' not in kwargs:
-            kwargs['maximum_message_size_in_bytes'] = DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT
-
         self.client_id = uuid.uuid4().hex
         self._send_queue_name = make_redis_queue_name(service_name)
         self._receive_queue_name = '{send_queue_name}.{client_id}{response_queue_specifier}'.format(
@@ -47,10 +70,11 @@ class RedisClientTransport(ClientTransport):
             response_queue_specifier=BaseRedisClient.RESPONSE_QUEUE_SPECIFIER,
         )
         self._requests_outstanding = 0
-        self.core = RedisTransportCore(service_name=service_name, metrics=metrics, metrics_prefix='client', **kwargs)
+        # noinspection PyArgumentList
+        self.core = RedisTransportClientCore(service_name=service_name, metrics=metrics, **kwargs)
 
     @property
-    def requests_outstanding(self):
+    def requests_outstanding(self):  # type: () -> int
         """
         Indicates the number of requests currently outstanding, which still need to be received. If this value is less
         than 1, calling `receive_response_message` will result in a return value of `(None, None, None)` instead of
@@ -59,6 +83,7 @@ class RedisClientTransport(ClientTransport):
         return self._requests_outstanding
 
     def send_request_message(self, request_id, meta, body, message_expiry_in_seconds=None):
+        # type: (int, Dict[six.text_type, Any], Dict[six.text_type, Any], Optional[int]) -> None
         self._requests_outstanding += 1
         meta['reply_to'] = '{receive_queue_name}{thread_id}'.format(
             receive_queue_name=self._receive_queue_name,
@@ -69,10 +94,11 @@ class RedisClientTransport(ClientTransport):
             self.core.send_message(self._send_queue_name, request_id, meta, body, message_expiry_in_seconds)
 
     def receive_response_message(self, receive_timeout_in_seconds=None):
+        # type: (Optional[int]) -> ReceivedMessage
         if self._requests_outstanding > 0:
             with self.metrics.timer('client.transport.redis_gateway.receive', resolution=TimerResolution.MICROSECONDS):
                 try:
-                    request_id, meta, response = self.core.receive_message(
+                    received_message = self.core.receive_message(
                         '{receive_queue_name}{thread_id}'.format(
                             receive_queue_name=self._receive_queue_name,
                             thread_id=get_hex_thread_id(),
@@ -83,7 +109,7 @@ class RedisClientTransport(ClientTransport):
                     self.metrics.counter('client.transport.redis_gateway.receive.error.timeout').increment()
                     raise
             self._requests_outstanding -= 1
-            return request_id, meta, response
+            return received_message
         else:
             # This tells Client.get_all_responses to stop waiting for more.
-            return None, None, None
+            return ReceivedMessage(None, None, None)

--- a/pysoa/common/transport/redis_gateway/constants.py
+++ b/pysoa/common/transport/redis_gateway/constants.py
@@ -3,6 +3,24 @@ from __future__ import (
     unicode_literals,
 )
 
+import enum
+import re
+from typing import Tuple  # noqa: F401 TODO Python 3
+
+import six  # noqa: F401 TODO Python 3
+
+
+__all__ = (
+    'DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT',
+    'DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER',
+    'MINIMUM_CHUNKED_MESSAGE_BYTES',
+    'ProtocolFeature',
+    'ProtocolVersion',
+    'REDIS_BACKEND_TYPE_SENTINEL',
+    'REDIS_BACKEND_TYPE_STANDARD',
+    'REDIS_BACKEND_TYPES',
+)
+
 
 # Common Redis constants for discovery and transport classes
 REDIS_BACKEND_TYPE_STANDARD = 'redis.standard'
@@ -15,3 +33,35 @@ REDIS_BACKEND_TYPES = (
 
 DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT = 1024 * 100
 DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER = 1024 * 250
+MINIMUM_CHUNKED_MESSAGE_BYTES = 1024 * 100
+
+
+PROTOCOL_VERSION_RE = re.compile(b'pysoa-redis/(?P<version>[0-9]+)//')
+
+
+class ProtocolVersion(enum.IntEnum):
+    VERSION_1 = 1
+    VERSION_2 = 2
+    VERSION_3 = 3
+
+    @property
+    def prefix(self):  # type: () -> six.binary_type
+        return b'pysoa-redis/%d//' % self.value
+
+    @staticmethod
+    def extract_version(message_data):  # type: (six.binary_type) -> Tuple[ProtocolVersion, six.binary_type]
+        match = PROTOCOL_VERSION_RE.match(message_data)
+        if match:
+            return ProtocolVersion(int(match.group('version'))), message_data[match.end():]
+        if message_data.startswith(b'content-type'):
+            return ProtocolVersion.VERSION_2, message_data
+        return ProtocolVersion.VERSION_1, message_data
+
+
+class ProtocolFeature(enum.Enum):
+    CONTENT_TYPE_HEADER = (1, ProtocolVersion.VERSION_2)
+    VERSION_MARKER = (2, ProtocolVersion.VERSION_3)
+    CHUNKED_RESPONSES = (3, ProtocolVersion.VERSION_3)
+
+    def supported_in(self, version):  # type: (ProtocolVersion) -> bool
+        return version >= self.value[1]

--- a/pysoa/common/transport/redis_gateway/core.py
+++ b/pysoa/common/transport/redis_gateway/core.py
@@ -1,25 +1,43 @@
 from __future__ import (
     absolute_import,
+    division,
     unicode_literals,
 )
 
+import abc
 from copy import deepcopy
 import logging
+import math
 import random
+import re
 import time
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+    FrozenSet,
+    Hashable,
+    List,
+    Optional,
+    Tuple,
+    cast,
+)
 
 import attr
 import redis
 import six
 
 from pysoa.common.logging import RecursivelyCensoredDictWrapper
-from pysoa.common.metrics import (
+from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+    Counter,
+    Histogram,
     MetricsRecorder,
     NoOpMetricsRecorder,
+    Timer,
     TimerResolution,
 )
 from pysoa.common.serializer.base import Serializer
 from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer
+from pysoa.common.transport.base import ReceivedMessage
 from pysoa.common.transport.exceptions import (
     InvalidMessageError,
     MessageReceiveError,
@@ -27,26 +45,50 @@ from pysoa.common.transport.exceptions import (
     MessageSendError,
     MessageTooLarge,
 )
-from pysoa.common.transport.redis_gateway.backend.base import CannotGetConnectionError
+from pysoa.common.transport.redis_gateway.backend.base import (  # noqa: F401 TODO Python 3
+    BaseRedisClient,
+    CannotGetConnectionError,
+)
 from pysoa.common.transport.redis_gateway.backend.sentinel import SentinelRedisClient
 from pysoa.common.transport.redis_gateway.backend.standard import StandardRedisClient
 from pysoa.common.transport.redis_gateway.constants import (
     DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT,
+    DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER,
+    MINIMUM_CHUNKED_MESSAGE_BYTES,
     REDIS_BACKEND_TYPE_SENTINEL,
     REDIS_BACKEND_TYPES,
+    ProtocolFeature,
+    ProtocolVersion,
 )
 from pysoa.utils import dict_to_hashable
+
+
+__all__ = (
+    'RedisTransportCore',
+    'RedisTransportClientCore',
+    'RedisTransportServerCore',
+)
 
 
 _oversized_message_logger = logging.getLogger('pysoa.transport.oversized_message')
 
 
-def valid_backend_type(_, __, value):
+def _valid_backend_type(_, __, value):
     if not value or value not in REDIS_BACKEND_TYPES:
         raise ValueError('backend_type must be one of {}, got {}'.format(REDIS_BACKEND_TYPES, value))
 
 
-@attr.s()
+def _valid_chunk_threshold(_, __, value):
+    if 0 <= value < MINIMUM_CHUNKED_MESSAGE_BYTES:
+        # Negative values are fine; that just means "disabled."
+        raise ValueError(
+            'If chunk_messages_larger_than_bytes is enabled (non-negative), it must be >= {}, '
+            'got {}'.format(MINIMUM_CHUNKED_MESSAGE_BYTES, value),
+        )
+
+
+@attr.s
+@six.add_metaclass(abc.ABCMeta)
 class RedisTransportCore(object):
     """Handles communication with Redis."""
 
@@ -54,73 +96,76 @@ class RedisTransportCore(object):
     # Given identical input settings, two given backend layer instances will operate identically, and so we cash using
     # input variables as a key. This applies even across services--backend layers have no service-specific code, so
     # a single backend can be used for multiple services if those services' backend settings are the same.
-    _backend_layer_cache = {}
+    _backend_layer_cache = {}  # type: Dict[Tuple[six.text_type, FrozenSet[Tuple[Hashable, ...]]], BaseRedisClient]
 
-    backend_type = attr.ib(validator=valid_backend_type)
+    SUPPORTED_HEADERS_RE = re.compile(
+        b'(?P<header_name>content-type|chunk-count|chunk-id)\\s*:\\s*(?P<header_value>[a-zA-Z0-9_/.-]+)\\s*;',
+    )
+
+    backend_type = attr.ib(validator=_valid_backend_type)  # type: six.text_type
 
     backend_layer_kwargs = attr.ib(
         # Keyword args for the backend layer (Standard Redis and Sentinel Redis modes)
         default={},
         validator=attr.validators.instance_of(dict),
-    )
+    )  # type: Dict[six.text_type, Any]
 
     log_messages_larger_than_bytes = attr.ib(
         default=DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT,
         converter=int,
-    )
+    )  # type: int
 
     maximum_message_size_in_bytes = attr.ib(
         default=DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT,
         converter=int,
-    )
+    )  # type: int
+
+    chunk_messages_larger_than_bytes = -1
 
     message_expiry_in_seconds = attr.ib(
         # How long after a message is sent before it's considered "expired" and not received by default, unless
         # overridden in the send_message argument `message_expiry_in_seconds`
         default=60,
         converter=int,
-    )
+    )  # type: int
 
     metrics = attr.ib(
         default=NoOpMetricsRecorder(),
         validator=attr.validators.instance_of(MetricsRecorder),
-    )
-
-    metrics_prefix = attr.ib(
-        default='',
-        validator=attr.validators.instance_of(six.text_type),
-    )
+    )  # type: MetricsRecorder
 
     queue_capacity = attr.ib(
         # The capacity for queues to which messages are sent
         default=10000,
         converter=int,
-    )
+    )  # type: int
 
     queue_full_retries = attr.ib(
         # Number of times to retry when the send queue is full
         default=10,
         converter=int,
-    )
+    )  # type: int
 
     receive_timeout_in_seconds = attr.ib(
         # How long to block when waiting to receive a message by default, unless overridden in the receive_message
         # argument `receive_timeout_in_seconds`
         default=5,
         converter=int,
-    )
+    )  # type: int
 
     default_serializer_config = attr.ib(
         # Configuration for which serializer should be used by this transport
         default={'object': MsgpackSerializer, 'kwargs': {}},
         converter=dict,
-    )
+    )  # type: Dict[six.text_type, Any]
 
     service_name = attr.ib(
         # Service name used for error messages
         default='',
         validator=attr.validators.instance_of(six.text_type),
-    )
+    )  # type: six.text_type
+
+    protocol_version = ProtocolVersion.VERSION_2
 
     EXPONENTIAL_BACK_OFF_FACTOR = 4.0
     QUEUE_NAME_PREFIX = 'pysoa:'
@@ -136,7 +181,7 @@ class RedisTransportCore(object):
                 elif isinstance(host, six.string_types):
                     final_hosts.append((host, self.backend_layer_kwargs.get('redis_port', 6379)))
                 else:
-                    raise Exception("connection_kwargs['hosts'] must be a list of tuples of (host, port), or strings")
+                    raise ValueError("connection_kwargs['hosts'] must be a list of tuples of (host, port), or strings")
             self.backend_layer_kwargs['hosts'] = final_hosts
 
         if self.backend_layer_kwargs.get('redis_db') is not None:
@@ -145,12 +190,19 @@ class RedisTransportCore(object):
         self.backend_layer_kwargs.pop('redis_db', None)
         self.backend_layer_kwargs.pop('redis_port', None)
 
-        self._backend_layer = None
-        self._default_serializer = None
+        self._backend_layer = None  # type: Optional[BaseRedisClient]
+        self._default_serializer = None  # type: Optional[Serializer]
+
+    @property
+    @abc.abstractmethod
+    def is_server(self):  # type: () -> bool
+        """
+        Indicates whether this is a server or a client.
+        """
 
     # noinspection PyAttributeOutsideInit
     @property
-    def backend_layer(self):
+    def backend_layer(self):  # type: () -> BaseRedisClient
         if self._backend_layer is None:
             cache_key = (self.backend_type, dict_to_hashable(self.backend_layer_kwargs))
             if cache_key not in self._backend_layer_cache:
@@ -164,33 +216,101 @@ class RedisTransportCore(object):
             self._backend_layer = self._backend_layer_cache[cache_key]
 
         # Each time the backend layer is accessed, use _this_ transport's metrics recorder for the backend layer
-        self._backend_layer.metrics_counter_getter = lambda name: self._get_counter(name)
+        self._backend_layer.metrics_counter_getter = self._get_counter
         return self._backend_layer
 
     # noinspection PyAttributeOutsideInit
     @property
-    def default_serializer(self):
+    def default_serializer(self):  # type: () -> Serializer
         if self._default_serializer is None:
-            self._default_serializer = self.default_serializer_config['object'](
-                **self.default_serializer_config.get('kwargs', {})
+            self._default_serializer = cast(
+                Serializer,
+                self.default_serializer_config['object'](**self.default_serializer_config.get('kwargs', {})),
             )
 
         return self._default_serializer
 
-    def send_message(self, queue_name, request_id, meta, body, message_expiry_in_seconds=None):
+    def _get_redis_connection(self, for_send, queue_key):
+        # type: (bool, six.text_type) -> redis.StrictRedis
+        try:
+            with self._get_timer('{}.get_redis_connection'.format('send' if for_send else 'receive')):
+                return self.backend_layer.get_connection(queue_key)
+        except CannotGetConnectionError as e:
+            self._get_counter('{}.error.connection'.format('send' if for_send else 'receive')).increment()
+            raise (MessageSendError if for_send else MessageReceiveError)('Cannot get connection: {}'.format(e.args[0]))
+
+    def _serialize_check_and_chunk_message(
+        self,
+        protocol_version,  # type: ProtocolVersion
+        message,  # type: Dict[six.text_type, Any]
+        serializer,  # type: Serializer
+    ):
+        # type: (...) -> List[six.binary_type]
+        with self._get_timer('send.serialize'):
+            serialized_message = serializer.dict_to_blob(message)
+
+            message_size_in_bytes = len(serialized_message)
+            self._get_histogram('send.message_size').set(message_size_in_bytes)
+
+            if message_size_in_bytes > self.maximum_message_size_in_bytes:
+                self._get_counter('send.error.message_too_large').increment()
+                raise MessageTooLarge(message_size_in_bytes, 'Message exceeds maximum message size')
+
+            if self.log_messages_larger_than_bytes and message_size_in_bytes > self.log_messages_larger_than_bytes:
+                _oversized_message_logger.warning(
+                    'Oversized message sent for PySOA service {}'.format(self.service_name),
+                    extra={'data': {
+                        'message': RecursivelyCensoredDictWrapper(message),
+                        'serialized_length_in_bytes': message_size_in_bytes,
+                        'threshold': self.log_messages_larger_than_bytes,
+                    }},
+                )
+
+            content_type_header = 'content-type:{};'.format(serializer.mime_type).encode('utf-8')
+
+            if self.is_server and 0 < self.chunk_messages_larger_than_bytes < message_size_in_bytes:
+                # chunking is enabled on the server and the message is big enough to chunk
+                if not ProtocolFeature.CHUNKED_RESPONSES.supported_in(protocol_version):
+                    self._get_counter('send.error.message_too_large').increment()
+                    raise MessageTooLarge(
+                        message_size_in_bytes,
+                        'Message exceeds chunking threshold but client does not support chunking',
+                    )
+
+                chunk_count = int(math.ceil(message_size_in_bytes / self.chunk_messages_larger_than_bytes))
+                self._get_histogram('send.chunk_count').set(chunk_count)
+                headers = protocol_version.prefix + content_type_header + (b'chunk-count:%d;' % (chunk_count, ))
+                return [
+                    headers + (b'chunk-id:%d;' % (i + 1, )) + serialized_message[
+                         i * self.chunk_messages_larger_than_bytes:
+                         (i + 1) * self.chunk_messages_larger_than_bytes
+                    ]
+                    for i in range(chunk_count)
+                ]
+
+            if ProtocolFeature.CONTENT_TYPE_HEADER.supported_in(protocol_version):
+                serialized_message = content_type_header + serialized_message
+            if ProtocolFeature.VERSION_MARKER.supported_in(protocol_version):
+                serialized_message = protocol_version.prefix + serialized_message
+            return [serialized_message]
+
+    def send_message(
+        self,
+        queue_name,  # type: six.text_type
+        request_id,  # type: int
+        meta,  # type: Dict[six.text_type, Any]
+        body,  # type: Dict[six.text_type, Any]
+        message_expiry_in_seconds=None,  # type: Optional[int]
+    ):
+        # type: (...) -> None
         """
         Send a message to the specified queue in Redis.
 
         :param queue_name: The name of the queue to which to send the message
-        :type queue_name: union(str, unicode)
         :param request_id: The message's request ID
-        :type request_id: int
         :param meta: The message meta information, if any (should be an empty dict if no metadata)
-        :type meta: dict
         :param body: The message body (should be a dict)
-        :type body: dict
         :param message_expiry_in_seconds: The optional message expiry, which defaults to the setting with the same name
-        :type message_expiry_in_seconds: int
 
         :raise: InvalidMessageError, MessageTooLarge, MessageSendError
         """
@@ -205,110 +325,86 @@ class RedisTransportCore(object):
             redis_expiry = self.message_expiry_in_seconds
 
         meta['__expiry__'] = message_expiry
+        protocol_version = meta.pop('protocol_version', self.protocol_version)  # type: ProtocolVersion
 
         message = {'request_id': request_id, 'meta': meta, 'body': body}
 
-        with self._get_timer('send.serialize'):
-            serializer = self.default_serializer
-            if 'serializer' in meta:
-                # TODO: Breaking change: Assume a MIME type is always specified. This should not be done until all
-                # TODO servers and clients have Step 2 code. This will be a Step 3 breaking change.
-                serializer = meta.pop('serializer')
-            serialized_message = (
-                'content-type:{};'.format(serializer.mime_type).encode('utf-8') + serializer.dict_to_blob(message)
-            )
-
-        message_size_in_bytes = len(serialized_message)
-        if message_size_in_bytes > self.maximum_message_size_in_bytes:
-            self._get_counter('send.error.message_too_large').increment()
-            raise MessageTooLarge(message_size_in_bytes)
-        elif self.log_messages_larger_than_bytes and message_size_in_bytes > self.log_messages_larger_than_bytes:
-            _oversized_message_logger.warning(
-                'Oversized message sent for PySOA service {}'.format(self.service_name),
-                extra={'data': {
-                    'message': RecursivelyCensoredDictWrapper(message),
-                    'serialized_length_in_bytes': message_size_in_bytes,
-                    'threshold': self.log_messages_larger_than_bytes,
-                }},
-            )
-
-        queue_key = self.QUEUE_NAME_PREFIX + queue_name
-
-        # Try at least once, up to queue_full_retries times, then error
-        for i in range(-1, self.queue_full_retries):
-            if i >= 0:
-                time.sleep((2 ** i + random.random()) / self.EXPONENTIAL_BACK_OFF_FACTOR)
-                self._get_counter('send.queue_full_retry').increment()
-                self._get_counter('send.queue_full_retry.retry_{}'.format(i + 1)).increment()
-            try:
-                with self._get_timer('send.get_redis_connection'):
-                    connection = self.backend_layer.get_connection(queue_key)
-
-                with self._get_timer('send.send_message_to_redis_queue'):
-                    self.backend_layer.send_message_to_queue(
-                        queue_key=queue_key,
-                        message=serialized_message,
-                        expiry=redis_expiry,
-                        capacity=self.queue_capacity,
-                        connection=connection,
-                    )
-                return
-            except redis.exceptions.ResponseError as e:
-                # The Lua script handles capacity checking and sends the "full" error back
-                if e.args[0] == 'queue full':
-                    continue
-                self._get_counter('send.error.response').increment()
-                raise MessageSendError('Redis error sending message for service {}'.format(self.service_name), *e.args)
-            except CannotGetConnectionError as e:
-                self._get_counter('send.error.connection').increment()
-                raise MessageSendError('Cannot get connection: {}'.format(e.args[0]))
-            except Exception as e:
-                self._get_counter('send.error.unknown').increment()
-                raise MessageSendError(
-                    'Unknown error sending message for service {}'.format(self.service_name),
-                    six.text_type(type(e).__name__),
-                    *e.args
-                )
-
-        self._get_counter('send.error.redis_queue_full').increment()
-        raise MessageSendError(
-            'Redis queue {queue_name} was full after {retries} retries'.format(
-                queue_name=queue_name,
-                retries=self.queue_full_retries,
-            )
+        messages_to_send = self._serialize_check_and_chunk_message(
+            protocol_version,
+            message,
+            cast(Serializer, meta.pop('serializer', self.default_serializer)),
         )
 
-    def receive_message(self, queue_name, receive_timeout_in_seconds=None):
-        """
-        Receive a message from the specified queue in Redis.
-
-        :param queue_name: The name of the queue to which to send the message
-        :type queue_name: union(str, unicode)
-        :param receive_timeout_in_seconds: The optional timeout, which defaults to the setting with the same name
-        :type receive_timeout_in_seconds: int
-
-        :return: A tuple of request ID, message meta-information dict, and message body dict
-        :rtype: tuple(int, dict, dict)
-
-        :raise: MessageReceiveError, MessageReceiveTimeout, InvalidMessageError
-        """
         queue_key = self.QUEUE_NAME_PREFIX + queue_name
 
+        connection = self._get_redis_connection(for_send=True, queue_key=queue_key)
+
+        for message_to_send in messages_to_send:
+            # Try at least once, up to queue_full_retries times, then error
+            for i in range(-1, self.queue_full_retries):
+                if i >= 0:
+                    time.sleep((2 ** i + random.random()) / self.EXPONENTIAL_BACK_OFF_FACTOR)
+                    self._get_counter('send.queue_full_retry').increment()
+                    self._get_counter('send.queue_full_retry.retry_{}'.format(i + 1)).increment()
+                try:
+                    with self._get_timer('send.send_message_to_redis_queue'):
+                        self.backend_layer.send_message_to_queue(
+                            queue_key=queue_key,
+                            message=message_to_send,
+                            expiry=redis_expiry,
+                            capacity=self.queue_capacity,
+                            connection=connection,
+                        )
+                    break
+                except redis.exceptions.ResponseError as e:
+                    # The Lua script handles capacity checking and sends the "full" error back
+                    if e.args[0] == 'queue full':
+                        continue
+                    self._get_counter('send.error.response').increment()
+                    raise MessageSendError(
+                        'Redis error sending message for service {}'.format(self.service_name), *e.args
+                    )
+                except Exception as e:
+                    self._get_counter('send.error.unknown').increment()
+                    raise MessageSendError(
+                        'Unknown error sending message for service {}'.format(self.service_name),
+                        six.text_type(type(e).__name__),
+                        *e.args
+                    )
+            else:
+                # The loop (number of retries) was exhausted; it was not terminated with break / successful send.
+                self._get_counter('send.error.redis_queue_full').increment()
+                raise MessageSendError(
+                    'Redis queue {queue_name} was full after {retries} retries'.format(
+                        queue_name=queue_name,
+                        retries=self.queue_full_retries,
+                    )
+                )
+
+    @classmethod
+    def _extract_supported_headers(cls, serialized_message):
+        # type: (six.binary_type) -> Tuple[Dict[six.text_type, six.text_type], six.binary_type]
+        headers = {}  # type: Dict[six.text_type, six.text_type]
+        match = cls.SUPPORTED_HEADERS_RE.match(serialized_message)
+        while match:
+            headers[match.group('header_name').decode('utf-8')] = match.group('header_value').decode('utf-8')
+
+            # Using lstrip() instead of strip() is important here. It's possible for the last bytes in a msgpack packet
+            # to be interpreted as whitespace, and removing it causes msgpack to fail.
+            serialized_message = serialized_message[match.end():].lstrip()
+            match = cls.SUPPORTED_HEADERS_RE.match(serialized_message)
+
+        return headers, serialized_message
+
+    def _receive_message(self, connection, queue_key, receive_timeout_in_seconds):
+        # type: (redis.StrictRedis, six.text_type, int) -> six.binary_type
         try:
-            with self._get_timer('receive.get_redis_connection'):
-                connection = self.backend_layer.get_connection(queue_key)
             # returns message or None if no new messages within timeout
             with self._get_timer('receive.pop_from_redis_queue'):
-                result = connection.blpop(
-                    [queue_key],
-                    timeout=receive_timeout_in_seconds or self.receive_timeout_in_seconds,
-                )
-            serialized_message = None
+                result = connection.blpop([queue_key], timeout=receive_timeout_in_seconds)
+            serialized_message = None  # type: Optional[six.binary_type]
             if result:
-                serialized_message = result[1]
-        except CannotGetConnectionError as e:
-            self._get_counter('receive.error.connection').increment()
-            raise MessageReceiveError('Cannot get connection: {}'.format(e.args[0]))
+                serialized_message = cast(six.binary_type, result[1])
         except Exception as e:
             self._get_counter('receive.error.unknown').increment()
             raise MessageReceiveError(
@@ -320,18 +416,75 @@ class RedisTransportCore(object):
         if serialized_message is None:
             raise MessageReceiveTimeout('No message received for service {}'.format(self.service_name))
 
-        with self._get_timer('receive.deserialize'):
-            serializer = self.default_serializer
-            if serialized_message.startswith(b'content-type'):
-                # TODO: Breaking change: Assume all messages start with a content type. This should not be done until
-                # TODO all servers and clients have Step 2 code. This will be a Step 3 breaking change.
-                header, serialized_message = serialized_message.split(b';', 1)
-                mime_type = header.split(b':', 1)[1].decode('utf-8').strip()
-                if mime_type in Serializer.all_supported_mime_types:
-                    serializer = Serializer.resolve_serializer(mime_type)
+        return serialized_message
 
+    def receive_message(self, queue_name, receive_timeout_in_seconds=None):
+        # type: (six.text_type, Optional[int]) -> ReceivedMessage
+        """
+        Receive a message from the specified queue in Redis.
+
+        :param queue_name: The name of the queue to which to send the message
+        :param receive_timeout_in_seconds: The optional timeout, which defaults to the setting with the same name
+
+        :return: A tuple of request ID, message meta-information dict, and message body dict
+
+        :raise: MessageReceiveError, MessageReceiveTimeout, InvalidMessageError
+        """
+        queue_key = self.QUEUE_NAME_PREFIX + queue_name
+        receive_timeout_in_seconds = receive_timeout_in_seconds or self.receive_timeout_in_seconds
+
+        connection = self._get_redis_connection(for_send=False, queue_key=queue_key)
+        serialized_message = self._receive_message(connection, queue_key, receive_timeout_in_seconds)
+
+        with self._get_timer('receive.deserialize') as deserialize_timer:
+            protocol_version, serialized_message = ProtocolVersion.extract_version(serialized_message)
+            headers, serialized_message = self._extract_supported_headers(serialized_message)
+
+            serializer = self.default_serializer
+            if 'content-type' in headers and headers['content-type'] in Serializer.all_supported_mime_types:
+                serializer = Serializer.resolve_serializer(headers['content-type'])
+
+        if 'chunk-count' in headers:
+            if self.is_server:
+                raise InvalidMessageError('Unsupported chunked request on server Redis backend')
+            if 'chunk-id' not in headers:
+                raise InvalidMessageError(
+                    'Invalid chunked response missing chunk ID for service {}'.format(self.service_name),
+                )
+
+            chunk_headers = headers
+            chunk_id, chunk_count = int(chunk_headers['chunk-id']), int(chunk_headers['chunk-count'])
+            while chunk_id < chunk_count:
+                expected_chunk = chunk_id + 1
+                next_chunk = self._receive_message(connection, queue_key, receive_timeout_in_seconds)
+
+                with deserialize_timer:
+                    protocol_version, next_chunk = ProtocolVersion.extract_version(next_chunk)
+                    chunk_headers, next_chunk = self._extract_supported_headers(next_chunk)
+                    serialized_message += next_chunk
+
+                if 'chunk-count' not in chunk_headers or 'chunk-id' not in chunk_headers:
+                    raise InvalidMessageError(
+                        'Invalid chunked response missing chunk headers expecting chunk {} of {} for service '
+                        '{}.'.format(expected_chunk, chunk_count, self.service_name)
+                    )
+                if int(chunk_headers['chunk-count']) != chunk_count:
+                    raise InvalidMessageError(
+                        'Invalid chunked response has different chunk count {} expecting chunk {} of {} for service '
+                        '{}.'.format(chunk_headers['chunk-count'], expected_chunk, chunk_count, self.service_name)
+                    )
+                if int(chunk_headers['chunk-id']) != expected_chunk:
+                    raise InvalidMessageError(
+                        'Invalid chunked response has incorrect chunk ID {} expected {} of {} for service '
+                        '{}.'.format(chunk_headers['chunk-id'], expected_chunk, chunk_count, self.service_name)
+                    )
+
+                chunk_id, chunk_count = int(chunk_headers['chunk-id']), int(chunk_headers['chunk-count'])
+
+        with deserialize_timer:
             message = serializer.blob_to_dict(serialized_message)
             message.setdefault('meta', {})['serializer'] = serializer
+            message['meta']['protocol_version'] = protocol_version
 
         if self._is_message_expired(message):
             self._get_counter('receive.error.message_expired').increment()
@@ -342,20 +495,73 @@ class RedisTransportCore(object):
             self._get_counter('receive.error.no_request_id').increment()
             raise InvalidMessageError('No request ID for service {}'.format(self.service_name))
 
-        return request_id, message.get('meta', {}), message.get('body')
+        return ReceivedMessage(request_id, message.get('meta', {}), message.get('body'))
 
     @staticmethod
-    def _is_message_expired(message):
+    def _is_message_expired(message):  # type: (Dict[six.text_type, Any]) -> bool
         return message.get('meta', {}).get('__expiry__') and message['meta']['__expiry__'] < time.time()
 
-    def _get_metric_name(self, name):
-        if self.metrics_prefix:
-            return '{prefix}.transport.redis_gateway.{name}'.format(prefix=self.metrics_prefix, name=name)
-        else:
-            return 'transport.redis_gateway.{}'.format(name)
+    @abc.abstractmethod
+    def _get_metric_name(self, name):  # type: (six.text_type) -> six.text_type
+        """
+        Get a suitable full metric name including appropriate client or server prefix.
+        """
 
-    def _get_counter(self, name):
+    def _get_counter(self, name):  # type: (six.text_type) -> Counter
         return self.metrics.counter(self._get_metric_name(name))
 
-    def _get_timer(self, name):
+    def _get_histogram(self, name):  # type: (six.text_type) -> Histogram
+        return self.metrics.histogram(self._get_metric_name(name))
+
+    def _get_timer(self, name):  # type: (six.text_type) -> Timer
         return self.metrics.timer(self._get_metric_name(name), resolution=TimerResolution.MICROSECONDS)
+
+
+@attr.s
+class RedisTransportClientCore(RedisTransportCore):
+    protocol_version = attr.ib(
+        default=ProtocolVersion.VERSION_2,
+        converter=lambda v: v if isinstance(v, ProtocolVersion) else ProtocolVersion(v),
+    )  # type: ProtocolVersion
+
+    @property
+    def is_server(self):  # type: () -> bool
+        return False
+
+    def _get_metric_name(self, name):  # type: (six.text_type) -> six.text_type
+        return 'client.transport.redis_gateway.{name}'.format(name=name)
+
+
+@attr.s
+class RedisTransportServerCore(RedisTransportCore):
+    log_messages_larger_than_bytes = attr.ib(
+        default=DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER,
+        converter=int,
+    )  # type: int
+
+    maximum_message_size_in_bytes = attr.ib(
+        default=DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER,
+        converter=int,
+    )  # type: int
+
+    chunk_messages_larger_than_bytes = attr.ib(
+        default=-1,
+        converter=int,
+        validator=_valid_chunk_threshold,
+    )  # type: int
+
+    def __attrs_post_init__(self):
+        super(RedisTransportServerCore, self).__attrs_post_init__()
+
+        if self.maximum_message_size_in_bytes < self.chunk_messages_larger_than_bytes * 5:
+            raise ValueError(
+                'If chunk_messages_larger_than_bytes is enabled (non-negative), maximum_message_size_in_bytes must '
+                'be at least 5 times larger to allow for multiple chunks to be sent.',
+            )
+
+    @property
+    def is_server(self):  # type: () -> bool
+        return True
+
+    def _get_metric_name(self, name):  # type: (six.text_type) -> six.text_type
+        return 'server.transport.redis_gateway.{name}'.format(name=name)

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -3,24 +3,48 @@ from __future__ import (
     unicode_literals,
 )
 
-from conformity import fields
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+)
 
-from pysoa.common.metrics import TimerResolution
-from pysoa.common.transport.base import ServerTransport
+from conformity import fields
+import six  # noqa: F401 TODO Python 3
+
+from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+    MetricsRecorder,
+    TimerResolution,
+)
+from pysoa.common.transport.base import (  # noqa: F401 TODO Python 3
+    ReceivedMessage,
+    ServerTransport,
+)
 from pysoa.common.transport.exceptions import (
     InvalidMessageError,
     MessageReceiveTimeout,
 )
-from pysoa.common.transport.redis_gateway.constants import DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER
-from pysoa.common.transport.redis_gateway.core import RedisTransportCore
+from pysoa.common.transport.redis_gateway.core import RedisTransportServerCore
 from pysoa.common.transport.redis_gateway.settings import RedisTransportSchema
 from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 
 
-@fields.ClassConfigurationSchema.provider(RedisTransportSchema())
+@fields.ClassConfigurationSchema.provider(RedisTransportSchema().extend(
+    contents={
+        'chunk_messages_larger_than_bytes': fields.Integer(
+            description='If set, responses larger than this setting will be chunked and sent back to the client in '
+                        'pieces, to prevent blocking single-threaded Redis for long periods of time to handle large '
+                        'responses. When set, this value must be greater than or equal to 102400, and '
+                        '`maximum_message_size_in_bytes` must also be set and must be at least 5 times greater than '
+                        'this value (because `maximum_message_size_in_bytes` is still enforced).',
+        ),
+    },
+    optional_keys=('chunk_messages_larger_than_bytes', ),
+    description='The constructor kwargs for the Redis server transport.',
+))
 class RedisServerTransport(ServerTransport):
 
     def __init__(self, service_name, metrics, **kwargs):
+        # type: (six.text_type, MetricsRecorder, **Any) -> None
         """
         In addition to the two named positional arguments, this constructor expects keyword arguments abiding by the
         Redis transport settings schema.
@@ -32,13 +56,12 @@ class RedisServerTransport(ServerTransport):
         """
         super(RedisServerTransport, self).__init__(service_name, metrics)
 
-        if 'maximum_message_size_in_bytes' not in kwargs:
-            kwargs['maximum_message_size_in_bytes'] = DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER
-
         self._receive_queue_name = make_redis_queue_name(service_name)
-        self.core = RedisTransportCore(service_name=service_name, metrics=metrics, metrics_prefix='server', **kwargs)
+        # noinspection PyArgumentList
+        self.core = RedisTransportServerCore(service_name=service_name, metrics=metrics, **kwargs)
 
     def receive_request_message(self):
+        # type: () -> ReceivedMessage
         timer = self.metrics.timer('server.transport.redis_gateway.receive', resolution=TimerResolution.MICROSECONDS)
         timer.start()
         stop_timer = True
@@ -52,6 +75,7 @@ class RedisServerTransport(ServerTransport):
                 timer.stop()
 
     def send_response_message(self, request_id, meta, body):
+        # type: (int, Dict[six.text_type, Any], Dict[six.text_type, Any]) -> None
         try:
             queue_name = meta['reply_to']
         except KeyError:

--- a/pysoa/server/action/__init__.py
+++ b/pysoa/server/action/__init__.py
@@ -5,13 +5,11 @@ from __future__ import (
 
 from pysoa.server.action.base import (
     Action,
-    ActionError,
-    ActionResponse,
+    ActionType,
 )
 
 
 __all__ = (
     'Action',
-    'ActionError',
-    'ActionResponse',
+    'ActionType',
 )

--- a/pysoa/server/action/base.py
+++ b/pysoa/server/action/base.py
@@ -4,6 +4,14 @@ from __future__ import (
 )
 
 import abc
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Callable,
+    Dict,
+    Optional,
+    Type,
+    Union,
+)
 
 import six
 
@@ -14,6 +22,14 @@ from pysoa.common.types import (
 from pysoa.server.errors import (
     ActionError,
     ResponseValidationError,
+)
+from pysoa.server.settings import ServerSettings
+from pysoa.server.types import EnrichedActionRequest
+
+
+__all__ = (
+    'Action',
+    'ActionType',
 )
 
 
@@ -34,7 +50,7 @@ class Action(object):
     request_schema = None
     response_schema = None
 
-    def __init__(self, settings=None):
+    def __init__(self, settings=None):  # type: (Optional[ServerSettings]) -> None
         """
         Construct a new action. Concrete classes can override this and define a different interface, but they must
         still pass the server settings to this base constructor by calling `super`.
@@ -45,7 +61,7 @@ class Action(object):
         self.settings = settings
 
     @abc.abstractmethod
-    def run(self, request):
+    def run(self, request):  # type: (EnrichedActionRequest) -> Dict[str, Any]
         """
         Override this to perform your business logic, and either return a value abiding by the `response_schema` or
         raise an `ActionError`.
@@ -60,7 +76,7 @@ class Action(object):
         """
         raise NotImplementedError()
 
-    def validate(self, request):
+    def validate(self, request):  # type: (EnrichedActionRequest) -> None
         """
         Override this to perform custom validation logic before the `run()` method is run. Raise `ActionError` if you
         find issues, otherwise return (the return value is ignored). If this method raises an error, `run()` will not
@@ -74,7 +90,7 @@ class Action(object):
         """
         pass
 
-    def __call__(self, action_request):
+    def __call__(self, action_request):  # type: (EnrichedActionRequest) -> ActionResponse
         """
         Main entry point for actions from the `Server` (or potentially from tests). Validates that the request matches
         the `request_schema`, then calls `validate()`, then calls `run()` if `validate()` raised no errors, and then
@@ -120,3 +136,9 @@ class Action(object):
             )
         else:
             return ActionResponse(action=action_request.action)
+
+
+ActionType = Union[
+    Type[Action],
+    Callable[[ServerSettings], Callable[[EnrichedActionRequest], ActionResponse]],
+]

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -16,7 +16,12 @@ import threading
 import time
 import traceback
 from types import FrameType  # noqa: F401 TODO Python 3
-from typing import Type  # noqa: F401 TODO Python 3
+from typing import (  # noqa: F401 TODO Python 3
+    Callable,
+    Mapping,
+    Optional,
+    Type,
+)
 
 import attr
 import six
@@ -47,6 +52,7 @@ from pysoa.common.types import (
     JobResponse,
     UnicodeKeysDict,
 )
+from pysoa.server.action.base import ActionType  # noqa: F401 TODO Python 3
 from pysoa.server.errors import (
     ActionError,
     JobError,
@@ -110,9 +116,9 @@ class Server(object):
     request_class = EnrichedActionRequest  # type: Type[EnrichedActionRequest]
     client_class = Client  # type: Type[Client]
 
-    use_django = False
-    service_name = None
-    action_class_map = {}
+    use_django = False  # type: bool
+    service_name = None  # type: Optional[six.text_type]
+    action_class_map = {}  # type: Mapping[six.text_type, ActionType]
 
     def __init__(self, settings, forked_process_id=None):
         """

--- a/pysoa/utils.py
+++ b/pysoa/utils.py
@@ -4,6 +4,14 @@ from __future__ import (
     unicode_literals,
 )
 
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+    FrozenSet,
+    Hashable,
+    Tuple,
+)
+
 import six
 
 
@@ -12,7 +20,7 @@ __all__ = (
 )
 
 
-def dict_to_hashable(d):
+def dict_to_hashable(d):  # type: (Dict[Hashable, Any]) -> FrozenSet[Tuple[Hashable, ...]]
     """
     Takes a dict and returns an immutable, hashable version of that dict that can be used as a key in dicts or as a
     set value. Any two dicts passed in with the same content are guaranteed to return the same value. Any two dicts

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,12 @@ test_plan_requirements = test_helper_requirements + [
 ]
 
 test_requirements = [
+    'coverage~=4.5',
     'factory_boy~=2.11.1',
     'freezegun~=0.3',
     'lunatic-python-universal~=2.1',
     'mockredispy~=2.9',
-    'coverage~=4.5',
+    'mypy;python_version>"3.4"',
 ] + test_plan_requirements
 
 

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -8,50 +8,8 @@ from typing import List  # noqa: F401 TODO Python 3
 
 import six  # noqa: F401 TODO Python 3
 
-from pysoa.client.client import Client
-from pysoa.common.transport.redis_gateway.constants import (
-    REDIS_BACKEND_TYPE_SENTINEL,
-    REDIS_BACKEND_TYPE_STANDARD,
-)
-
 
 COMPOSE_FILE = 'tests/functional/docker/docker-compose.yaml'
-
-
-_standard = {
-    'backend_layer_kwargs': {'hosts': [('redis.pysoa', 6379)]},
-    'backend_type': REDIS_BACKEND_TYPE_STANDARD,
-}
-
-_sentinel = {
-    'backend_layer_kwargs': {'hosts': [('redis-sentinel.pysoa', 26379)]},
-    'backend_type': REDIS_BACKEND_TYPE_SENTINEL,
-}
-
-
-pysoa_client = Client(
-    config={
-        'echo': {
-            'transport': {
-                'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
-                'kwargs': _standard,
-            },
-        },
-        'meta': {
-            'transport': {
-                'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
-                'kwargs': _standard,
-            },
-        },
-        'user': {
-            'transport': {
-                'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
-                'kwargs': _sentinel,
-            },
-        },
-    },
-    expansion_config={},  # TODO
-)
 
 
 def call_command_in_container(container, command):  # type: (six.text_type, List[six.text_type]) -> six.text_type

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,90 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import copy
+
+import pytest
+
+from pysoa.client.client import Client
+from pysoa.common.transport.redis_gateway.constants import (
+    REDIS_BACKEND_TYPE_SENTINEL,
+    REDIS_BACKEND_TYPE_STANDARD,
+    ProtocolVersion,
+)
+
+
+_standard = {
+    'backend_layer_kwargs': {'hosts': [('redis.pysoa', 6379)]},
+    'backend_type': REDIS_BACKEND_TYPE_STANDARD,
+}
+
+_sentinel = {
+    'backend_layer_kwargs': {'hosts': [('redis-sentinel.pysoa', 26379)]},
+    'backend_type': REDIS_BACKEND_TYPE_SENTINEL,
+}
+
+_base_config = {
+    'echo': {
+        'transport': {
+            'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
+            'kwargs': _standard,
+        },
+    },
+    'meta': {
+        'transport': {
+            'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
+            'kwargs': _standard,
+        },
+    },
+    'user': {
+        'transport': {
+            'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
+            'kwargs': _sentinel,
+        },
+    },
+}
+
+_expansion_config = {
+    # TODO
+}
+
+_json_serializer = {'path': 'pysoa.common.serializer:JSONSerializer'}
+
+
+@pytest.fixture(scope='package')
+def pysoa_client():
+    return Client(
+        config=_base_config,
+        expansion_config=_expansion_config,
+    )
+
+
+@pytest.fixture(scope='package')
+def pysoa_client_protocol_v3():
+    config = copy.deepcopy(_base_config)
+    config['echo']['transport']['kwargs']['protocol_version'] = ProtocolVersion.VERSION_3
+    config['meta']['transport']['kwargs']['protocol_version'] = ProtocolVersion.VERSION_3
+    config['user']['transport']['kwargs']['protocol_version'] = ProtocolVersion.VERSION_3
+
+    return Client(
+        config=config,
+        expansion_config=_expansion_config,
+    )
+
+
+@pytest.fixture(scope='package')
+def pysoa_client_json():
+    config = copy.deepcopy(_base_config)
+    config['echo']['transport']['kwargs']['default_serializer_config'] = _json_serializer
+    config['echo']['transport']['kwargs']['protocol_version'] = ProtocolVersion.VERSION_3
+    config['meta']['transport']['kwargs']['default_serializer_config'] = _json_serializer
+    config['meta']['transport']['kwargs']['protocol_version'] = ProtocolVersion.VERSION_3
+    config['user']['transport']['kwargs']['default_serializer_config'] = _json_serializer
+    config['user']['transport']['kwargs']['protocol_version'] = ProtocolVersion.VERSION_3
+
+    return Client(
+        config=config,
+        expansion_config=_expansion_config,
+    )

--- a/tests/functional/docker/Dockerfile-test
+++ b/tests/functional/docker/Dockerfile-test
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install pytest pytz docker-compose
+RUN pip install pytest pytz docker-compose ipdb
 COPY conftest.py /srv/pysoa/
 COPY tests/functional /srv/pysoa/tests/functional/
 

--- a/tests/functional/services/meta/meta_service/server.py
+++ b/tests/functional/services/meta/meta_service/server.py
@@ -1,6 +1,14 @@
 from pysoa.server.server import Server as BaseServer
+from pysoa.server.action.base import Action
+
+
+class VeryLargeResponseAction(Action):
+    def run(self, request):
+        return {'key-{}'.format(i): 'value-{}'.format(i) for i in range(10000, 47000)}
 
 
 class Server(BaseServer):
     service_name = 'meta'
-    action_class_map = {}
+    action_class_map = {
+        'very_large_response': VeryLargeResponseAction,
+    }

--- a/tests/functional/services/meta/meta_service/settings.py
+++ b/tests/functional/services/meta/meta_service/settings.py
@@ -8,6 +8,9 @@ SOA_SERVER_SETTINGS = {
         'kwargs': {
             'backend_layer_kwargs': {'hosts': [('redis.pysoa', 6379)]},
             'backend_type': REDIS_BACKEND_TYPE_STANDARD,
+            'chunk_messages_larger_than_bytes': 102400,
+            'maximum_message_size_in_bytes': 1048576,
+            'log_messages_larger_than_bytes': 800000,
         },
     },
 }

--- a/tests/functional/test_forking_and_reloading.py
+++ b/tests/functional/test_forking_and_reloading.py
@@ -12,13 +12,12 @@ from pysoa.common.transport.exceptions import MessageReceiveTimeout
 
 from tests.functional import (
     get_container_process_list,
-    pysoa_client,
     read_file_from_container,
     write_file_to_container,
 )
 
 
-def test_heartbeat_file_watching_no_forking():
+def test_heartbeat_file_watching_no_forking(pysoa_client):
     original_ts = float(read_file_from_container('meta_service', '/srv/meta_service-{{fid}}.heartbeat'))
     assert original_ts > 0
     time.sleep(2.5)
@@ -30,7 +29,7 @@ def test_heartbeat_file_watching_no_forking():
     assert new_ts > original_ts
 
 
-def test_heartbeat_file_forking_no_watching():
+def test_heartbeat_file_forking_no_watching(pysoa_client):
     original_ts_1 = float(read_file_from_container('user_service', '/srv/user_service-1.heartbeat'))
     original_ts_2 = float(read_file_from_container('user_service', '/srv/user_service-2.heartbeat'))
     original_ts_3 = float(read_file_from_container('user_service', '/srv/user_service-3.heartbeat'))
@@ -61,7 +60,7 @@ def test_heartbeat_file_forking_no_watching():
     assert new_ts_4 > original_ts_4
 
 
-def test_heartbeat_file_forking_and_watching():
+def test_heartbeat_file_forking_and_watching(pysoa_client):
     original_ts_1 = float(read_file_from_container('echo_service', '/srv/echo_service-1.heartbeat'))
     original_ts_2 = float(read_file_from_container('echo_service', '/srv/echo_service-2.heartbeat'))
     original_ts_3 = float(read_file_from_container('echo_service', '/srv/echo_service-3.heartbeat'))
@@ -88,7 +87,7 @@ def test_heartbeat_file_forking_and_watching():
     assert new_ts_3 > original_ts_3
 
 
-def test_reload_no_forking():
+def test_reload_no_forking(pysoa_client):
     print(get_container_process_list('meta_service'))
 
     assert read_file_from_container('meta_service', '/srv/meta/meta_service/version.py') == "__version__ = '2.1.7'"
@@ -103,7 +102,7 @@ def test_reload_no_forking():
     assert response.body['version'] == '7.1.2'
 
 
-def test_reload_with_forking():
+def test_reload_with_forking(pysoa_client):
     print(get_container_process_list('echo_service'))
 
     assert read_file_from_container('echo_service', '/srv/echo/echo_service/version.py') == "__version__ = '9.5.3'"
@@ -125,7 +124,7 @@ def test_reload_with_forking():
         assert response.body['version'] == '9.8.0'
 
 
-def test_no_reload_no_watcher():
+def test_no_reload_no_watcher(pysoa_client):
     print(get_container_process_list('user_service'))
 
     assert read_file_from_container('user_service', '/srv/user/user_service/version.py') == "__version__ = '1.0.17'"
@@ -147,7 +146,7 @@ def test_no_reload_no_watcher():
         assert response.body['version'] == '1.0.17'
 
 
-def test_harakiri_graceful_restart():
+def test_harakiri_graceful_restart(pysoa_client):
     original_ts_1 = float(read_file_from_container('echo_service', '/srv/echo_service-1.heartbeat'))
     original_ts_2 = float(read_file_from_container('echo_service', '/srv/echo_service-2.heartbeat'))
     original_ts_3 = float(read_file_from_container('echo_service', '/srv/echo_service-3.heartbeat'))
@@ -174,7 +173,7 @@ def test_harakiri_graceful_restart():
     assert new_ts_3 > original_ts_3
 
 
-def test_harakiri_forceful_restart():
+def test_harakiri_forceful_restart(pysoa_client):
     original_ts_1 = float(read_file_from_container('echo_service', '/srv/echo_service-1.heartbeat'))
     original_ts_2 = float(read_file_from_container('echo_service', '/srv/echo_service-2.heartbeat'))
     original_ts_3 = float(read_file_from_container('echo_service', '/srv/echo_service-3.heartbeat'))

--- a/tests/functional/test_very_large_responses.py
+++ b/tests/functional/test_very_large_responses.py
@@ -1,0 +1,27 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import pytest
+
+from pysoa.common.constants import ERROR_CODE_RESPONSE_TOO_LARGE
+
+
+def test_very_large_response_protocol_v2(pysoa_client):
+    with pytest.raises(pysoa_client.JobError) as error_context:
+        pysoa_client.call_action('meta', 'very_large_response')
+
+    assert error_context.value.errors[0].code == ERROR_CODE_RESPONSE_TOO_LARGE
+
+
+def test_very_large_response_protocol_v3(pysoa_client_protocol_v3):
+    response = pysoa_client_protocol_v3.call_action('meta', 'very_large_response')
+
+    assert response.body == {'key-{}'.format(i): 'value-{}'.format(i) for i in range(10000, 47000)}
+
+
+def test_very_large_response_protocol_v3_json(pysoa_client_json):
+    response = pysoa_client_json.call_action('meta', 'very_large_response')
+
+    assert response.body == {'key-{}'.format(i): 'value-{}'.format(i) for i in range(10000, 47000)}

--- a/tests/unit/common/transport/redis_gateway/test_client.py
+++ b/tests/unit/common/transport/redis_gateway/test_client.py
@@ -3,17 +3,16 @@ from __future__ import (
     unicode_literals,
 )
 
+import random
 import unittest
-import uuid
 
 from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.base import get_hex_thread_id
 from pysoa.common.transport.redis_gateway.client import RedisClientTransport
-from pysoa.common.transport.redis_gateway.constants import DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT
 from pysoa.test.compatibility import mock
 
 
-@mock.patch('pysoa.common.transport.redis_gateway.client.RedisTransportCore')
+@mock.patch('pysoa.common.transport.redis_gateway.client.RedisTransportClientCore')
 class TestClientTransport(unittest.TestCase):
     @staticmethod
     def _get_transport(service='my_service', **kwargs):
@@ -28,8 +27,6 @@ class TestClientTransport(unittest.TestCase):
             hello='world',
             goodbye='earth',
             metrics=transport.metrics,
-            metrics_prefix='client',
-            maximum_message_size_in_bytes=DEFAULT_MAXIMUM_MESSAGE_BYTES_CLIENT,
         )
 
         self.assertRegex(transport.client_id, r'^[0-9a-fA-F]{32}$')
@@ -43,7 +40,6 @@ class TestClientTransport(unittest.TestCase):
             hello='world',
             goodbye='earth',
             metrics=transport.metrics,
-            metrics_prefix='client',
             maximum_message_size_in_bytes=42,
         )
 
@@ -52,7 +48,7 @@ class TestClientTransport(unittest.TestCase):
     def test_send_request_message(self, mock_core):
         transport = self._get_transport()
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         meta = {'app': 'ppa'}
         message = {'test': 'payload'}
 
@@ -75,7 +71,7 @@ class TestClientTransport(unittest.TestCase):
     def test_send_request_message_another_service(self, mock_core):
         transport = self._get_transport('geo')
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         message = {'another': 'message'}
 
         transport.send_request_message(request_id, {}, message, 25)
@@ -97,7 +93,7 @@ class TestClientTransport(unittest.TestCase):
         transport = self._get_transport()
         transport._requests_outstanding = 1
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         meta = {'app': 'ppa'}
         message = {'test': 'payload'}
 
@@ -121,7 +117,7 @@ class TestClientTransport(unittest.TestCase):
         transport = self._get_transport('geo')
         transport._requests_outstanding = 1
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         meta = {}
         message = {'another': 'message'}
 
@@ -145,13 +141,13 @@ class TestClientTransport(unittest.TestCase):
         transport = self._get_transport('geo')
         self.assertEqual(0, transport.requests_outstanding)
 
-        transport.send_request_message(uuid.uuid4().hex, {}, {})
+        transport.send_request_message(random.randint(1, 1000), {}, {})
         self.assertEqual(1, transport.requests_outstanding)
 
-        transport.send_request_message(uuid.uuid4().hex, {}, {})
+        transport.send_request_message(random.randint(1, 1000), {}, {})
         self.assertEqual(2, transport.requests_outstanding)
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         mock_core.return_value.receive_message.return_value = request_id, {}, {}
 
         self.assertEqual((request_id, {}, {}), transport.receive_response_message())

--- a/tests/unit/common/transport/redis_gateway/test_core.py
+++ b/tests/unit/common/transport/redis_gateway/test_core.py
@@ -6,10 +6,10 @@ from __future__ import (
 import datetime
 import time
 import timeit
-import unittest
 
 import attr
 import freezegun
+import pytest
 
 from pysoa.common.serializer.json_serializer import JSONSerializer
 from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer
@@ -24,8 +24,13 @@ from pysoa.common.transport.redis_gateway.backend.base import CannotGetConnectio
 from pysoa.common.transport.redis_gateway.constants import (
     REDIS_BACKEND_TYPE_SENTINEL,
     REDIS_BACKEND_TYPE_STANDARD,
+    ProtocolVersion,
 )
-from pysoa.common.transport.redis_gateway.core import RedisTransportCore
+from pysoa.common.transport.redis_gateway.core import (
+    RedisTransportClientCore,
+    RedisTransportCore,
+    RedisTransportServerCore,
+)
 from pysoa.test.compatibility import mock
 
 # To ensure all the patching over there happens over here
@@ -39,34 +44,37 @@ class MockSerializer(object):
 
 
 @mock.patch('redis.Redis', new=mockredis.mock_redis_client)
-class TestRedisTransportCore(unittest.TestCase):
-    def setUp(self):
+class TestRedisTransportCore(object):
+    def setup_method(self, _method):
         RedisTransportCore._backend_layer_cache = {}
 
     def test_invalid_backend_type(self):
-        with self.assertRaises(ValueError):
-            RedisTransportCore(backend_type='hello')
+        with pytest.raises(ValueError):
+            # noinspection PyArgumentList
+            RedisTransportServerCore(backend_type='hello')
 
     @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
     @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
     def test_standard_client_created_with_defaults(self, mock_standard, mock_sentinel):
-        core = RedisTransportCore(backend_type=REDIS_BACKEND_TYPE_STANDARD)
+        # noinspection PyArgumentList
+        core = RedisTransportServerCore(backend_type=REDIS_BACKEND_TYPE_STANDARD)
         core.backend_layer.anything()
 
-        self.assertEqual(60, core.message_expiry_in_seconds)
-        self.assertEqual(10000, core.queue_capacity)
-        self.assertEqual(10, core.queue_full_retries)
-        self.assertEqual(5, core.receive_timeout_in_seconds)
-        self.assertIsInstance(core.default_serializer, MsgpackSerializer)
+        assert core.message_expiry_in_seconds == 60
+        assert core.queue_capacity == 10000
+        assert core.queue_full_retries == 10
+        assert core.receive_timeout_in_seconds == 5
+        assert isinstance(core.default_serializer, MsgpackSerializer)
 
         mock_standard.assert_called_once_with()
         mock_standard.return_value.anything.assert_called_once_with()
-        self.assertFalse(mock_sentinel.called)
+        assert not mock_sentinel.called
 
     @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
     @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
     def test_standard_client_created(self, mock_standard, mock_sentinel):
-        core = RedisTransportCore(
+        # noinspection PyArgumentList
+        core = RedisTransportServerCore(
             service_name='example',
             backend_type=REDIS_BACKEND_TYPE_STANDARD,
             backend_layer_kwargs={
@@ -82,25 +90,26 @@ class TestRedisTransportCore(unittest.TestCase):
         )
         core.backend_layer.anything()
 
-        self.assertEqual('example', core.service_name)
-        self.assertEqual(30, core.message_expiry_in_seconds)
-        self.assertEqual(100, core.queue_capacity)
-        self.assertEqual(7, core.queue_full_retries)
-        self.assertEqual(10, core.receive_timeout_in_seconds)
-        self.assertIsInstance(core.default_serializer, MockSerializer)
-        self.assertEqual('hello', core.default_serializer.kwarg1)
+        assert core.service_name == 'example'
+        assert core.message_expiry_in_seconds == 30
+        assert core.queue_capacity == 100
+        assert core.queue_full_retries == 7
+        assert core.receive_timeout_in_seconds == 10
+        assert isinstance(core.default_serializer, MockSerializer)
+        assert core.default_serializer.kwarg1 == 'hello'
 
         mock_standard.assert_called_once_with(
             hosts=[('localhost', 6379), ('far_away_host', 1098)],
             connection_kwargs={'db': 2},
         )
         mock_standard.return_value.anything.assert_called_once_with()
-        self.assertFalse(mock_sentinel.called)
+        assert not mock_sentinel.called
 
     @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
     @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
     def test_sentinel_client_created(self, mock_standard, mock_sentinel):
-        core = RedisTransportCore(
+        # noinspection PyArgumentList
+        core = RedisTransportServerCore(
             backend_type=REDIS_BACKEND_TYPE_SENTINEL,
             backend_layer_kwargs={
                 'connection_kwargs': {'hello': 'world'},
@@ -119,12 +128,12 @@ class TestRedisTransportCore(unittest.TestCase):
         )
         core.backend_layer.anything()
 
-        self.assertEqual(45, core.message_expiry_in_seconds)
-        self.assertEqual(7500, core.queue_capacity)
-        self.assertEqual(4, core.queue_full_retries)
-        self.assertEqual(6, core.receive_timeout_in_seconds)
-        self.assertIsInstance(core.default_serializer, MockSerializer)
-        self.assertEqual('goodbye', core.default_serializer.kwarg2)
+        assert core.message_expiry_in_seconds == 45
+        assert core.queue_capacity == 7500
+        assert core.queue_full_retries == 4
+        assert core.receive_timeout_in_seconds == 6
+        assert isinstance(core.default_serializer, MockSerializer)
+        assert core.default_serializer.kwarg2 == 'goodbye'
 
         mock_sentinel.assert_called_once_with(
             hosts=[('another_host', 6379)],
@@ -134,120 +143,279 @@ class TestRedisTransportCore(unittest.TestCase):
             sentinel_failover_retries=5,
         )
         mock_sentinel.return_value.anything.assert_called_once_with()
-        self.assertFalse(mock_standard.called)
+        assert not mock_standard.called
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_chunking_not_supported_on_client(self, mock_standard, mock_sentinel):
+        with pytest.raises(TypeError) as error_context:
+            # noinspection PyArgumentList
+            RedisTransportClientCore(
+                backend_type=REDIS_BACKEND_TYPE_SENTINEL,
+                backend_layer_kwargs={
+                    'connection_kwargs': {'hello': 'world'},
+                    'hosts': [('another_host', 6379)],
+                    'redis_db': 5,
+                    'redis_port': 1098,
+                    'sentinel_refresh_interval': 13,
+                    'sentinel_services': ['svc1', 'svc2', 'svc3'],
+                    'sentinel_failover_retries': 5,
+                },
+                message_expiry_in_seconds=45,
+                queue_capacity=7500,
+                queue_full_retries=4,
+                receive_timeout_in_seconds=6,
+                default_serializer_config={'object': MockSerializer, 'kwargs': {'kwarg2': 'goodbye'}},
+                chunk_messages_larger_than_bytes=102400,
+            )
+
+        assert "unexpected keyword argument 'chunk_messages_larger_than_bytes'" in error_context.value.args[0]
+
+        assert not mock_standard.called
+        assert not mock_sentinel.called
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_chunking_too_small_on_server(self, mock_standard, mock_sentinel):
+        with pytest.raises(ValueError) as error_context:
+            # noinspection PyArgumentList
+            RedisTransportServerCore(
+                backend_type=REDIS_BACKEND_TYPE_SENTINEL,
+                backend_layer_kwargs={
+                    'connection_kwargs': {'hello': 'world'},
+                    'hosts': [('another_host', 6379)],
+                    'redis_db': 5,
+                    'redis_port': 1098,
+                    'sentinel_refresh_interval': 13,
+                    'sentinel_services': ['svc1', 'svc2', 'svc3'],
+                    'sentinel_failover_retries': 5,
+                },
+                message_expiry_in_seconds=45,
+                queue_capacity=7500,
+                queue_full_retries=4,
+                receive_timeout_in_seconds=6,
+                default_serializer_config={'object': MockSerializer, 'kwargs': {'kwarg2': 'goodbye'}},
+                chunk_messages_larger_than_bytes=1024,
+            )
+
+        assert 'must be >= 102400' in error_context.value.args[0]
+
+        assert not mock_standard.called
+        assert not mock_sentinel.called
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_max_message_size_not_bigger_enough_than_chunking_on_server(self, mock_standard, mock_sentinel):
+        with pytest.raises(ValueError) as error_context:
+            # noinspection PyArgumentList
+            RedisTransportServerCore(
+                backend_type=REDIS_BACKEND_TYPE_SENTINEL,
+                backend_layer_kwargs={
+                    'connection_kwargs': {'hello': 'world'},
+                    'hosts': [('another_host', 6379)],
+                    'redis_db': 5,
+                    'redis_port': 1098,
+                    'sentinel_refresh_interval': 13,
+                    'sentinel_services': ['svc1', 'svc2', 'svc3'],
+                    'sentinel_failover_retries': 5,
+                },
+                message_expiry_in_seconds=45,
+                queue_capacity=7500,
+                queue_full_retries=4,
+                receive_timeout_in_seconds=6,
+                default_serializer_config={'object': MockSerializer, 'kwargs': {'kwarg2': 'goodbye'}},
+                chunk_messages_larger_than_bytes=102400,
+                maximum_message_size_in_bytes=(102400 * 5) - 2,
+            )
+
+        assert 'at least 5 times larger' in error_context.value.args[0]
+
+        assert not mock_standard.called
+        assert not mock_sentinel.called
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_chunking_supported_on_server(self, mock_standard, mock_sentinel):
+        # noinspection PyArgumentList
+        core = RedisTransportServerCore(
+            backend_type=REDIS_BACKEND_TYPE_SENTINEL,
+            backend_layer_kwargs={
+                'connection_kwargs': {'hello': 'world'},
+                'hosts': [('another_host', 6379)],
+                'redis_db': 5,
+                'redis_port': 1098,
+                'sentinel_refresh_interval': 13,
+                'sentinel_services': ['svc1', 'svc2', 'svc3'],
+                'sentinel_failover_retries': 5,
+            },
+            message_expiry_in_seconds=45,
+            queue_capacity=7500,
+            queue_full_retries=4,
+            receive_timeout_in_seconds=6,
+            default_serializer_config={'object': MockSerializer, 'kwargs': {'kwarg2': 'goodbye'}},
+            chunk_messages_larger_than_bytes=102400,
+            maximum_message_size_in_bytes=102400 * 5,
+        )
+        core.backend_layer.anything()
+
+        assert core.message_expiry_in_seconds == 45
+        assert core.queue_capacity == 7500
+        assert core.queue_full_retries == 4
+        assert core.receive_timeout_in_seconds == 6
+        assert core.chunk_messages_larger_than_bytes == 102400
+        assert core.maximum_message_size_in_bytes == 102400 * 5
+        assert isinstance(core.default_serializer, MockSerializer)
+        assert core.default_serializer.kwarg2 == 'goodbye'
+
+        mock_sentinel.assert_called_once_with(
+            hosts=[('another_host', 6379)],
+            connection_kwargs={'db': 5, 'hello': 'world'},
+            sentinel_refresh_interval=13,
+            sentinel_services=['svc1', 'svc2', 'svc3'],
+            sentinel_failover_retries=5,
+        )
+        mock_sentinel.return_value.anything.assert_called_once_with()
+        assert not mock_standard.called
 
     @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
     @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
     def test_cannot_get_connection_error_on_send(self, mock_standard, mock_sentinel):
-        core = RedisTransportCore(backend_type=REDIS_BACKEND_TYPE_STANDARD)
+        # noinspection PyArgumentList
+        core = RedisTransportServerCore(backend_type=REDIS_BACKEND_TYPE_STANDARD)
 
         mock_standard.return_value.get_connection.side_effect = CannotGetConnectionError('This is my error')
 
-        with self.assertRaises(MessageSendError) as error_context:
+        with pytest.raises(MessageSendError) as error_context:
             core.send_message('my_queue', 71, {}, {})
 
-        self.assertEqual('Cannot get connection: This is my error', error_context.exception.args[0])
+        assert error_context.value.args[0] == 'Cannot get connection: This is my error'
 
-        self.assertFalse(mock_sentinel.called)
+        assert not mock_sentinel.called
         mock_standard.return_value.get_connection.assert_called_once_with('pysoa:my_queue')
 
     @mock.patch('pysoa.common.transport.redis_gateway.core.SentinelRedisClient')
     @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
     def test_cannot_get_connection_error_on_receive(self, mock_standard, mock_sentinel):
-        core = RedisTransportCore(backend_type=REDIS_BACKEND_TYPE_STANDARD)
+        # noinspection PyArgumentList
+        core = RedisTransportServerCore(backend_type=REDIS_BACKEND_TYPE_STANDARD)
 
         mock_standard.return_value.get_connection.side_effect = CannotGetConnectionError('This is another error')
 
-        with self.assertRaises(MessageReceiveError) as error_context:
+        with pytest.raises(MessageReceiveError) as error_context:
             core.receive_message('your_queue')
 
-        self.assertEqual('Cannot get connection: This is another error', error_context.exception.args[0])
+        assert error_context.value.args[0] == 'Cannot get connection: This is another error'
 
-        self.assertFalse(mock_sentinel.called)
+        assert not mock_sentinel.called
         mock_standard.return_value.get_connection.assert_called_once_with('pysoa:your_queue')
 
     @staticmethod
-    def _get_core(**kwargs):
-        return RedisTransportCore(backend_type=REDIS_BACKEND_TYPE_STANDARD, **kwargs)
+    def _get_server_core(**kwargs):
+        # noinspection PyArgumentList
+        return RedisTransportServerCore(backend_type=REDIS_BACKEND_TYPE_STANDARD, **kwargs)
+
+    @staticmethod
+    def _get_client_core(**kwargs):
+        # noinspection PyArgumentList
+        return RedisTransportClientCore(backend_type=REDIS_BACKEND_TYPE_STANDARD, **kwargs)
 
     def test_invalid_request_id(self):
-        core = self._get_core()
+        core = self._get_server_core()
 
-        with self.assertRaises(InvalidMessageError):
+        with pytest.raises(InvalidMessageError):
             # noinspection PyTypeChecker
             core.send_message('test_invalid_request_id', None, {}, {'test': 'payload'})
 
-    def test_message_too_large(self):
-        core = self._get_core()
+    def test_message_too_large_client_default(self):
+        core = self._get_client_core()
 
         message = {'test': ['payload%i' % i for i in range(1000, 9530)]}  # This creates a message > 102,400 bytes
 
-        with self.assertRaises(MessageTooLarge):
-            core.send_message('test_message_too_large', 0, {}, message)
+        with pytest.raises(MessageTooLarge):
+            core.send_message('test_message_too_large_client_default', 0, {}, message)
+
+    def test_message_too_large_server_default(self):
+        core = self._get_server_core()
+
+        message = {'test': ['payload%i' % i for i in range(1000, 9530)]}  # This creates a message > 102,400 bytes
+        core.send_message('test_message_too_large_server_default_ok', 0, {}, message)
+
+        message = {'test': ['payload%i' % i for i in range(10000, 29900)]}  # This creates a message > 257,024 bytes
+
+        with pytest.raises(MessageTooLarge):
+            core.send_message('test_message_too_large_server_default_not_ok', 0, {}, message)
 
     def test_message_too_large_configurable(self):
-        core = self._get_core(maximum_message_size_in_bytes=150)
+        core = self._get_server_core(maximum_message_size_in_bytes=150)
 
         message = {'test': ['payload%i' % i for i in range(100, 110)]}  # This creates a message > 150 bytes
 
-        with self.assertRaises(MessageTooLarge):
+        with pytest.raises(MessageTooLarge):
             core.send_message('test_message_too_large', 1, {}, message)
 
     def test_oversized_message_is_logged(self):
-        core = self._get_core(log_messages_larger_than_bytes=150)
+        core = self._get_server_core(log_messages_larger_than_bytes=150)
 
         message = {'test': ['payload%i' % i for i in range(100, 110)]}  # This creates a message > 150 bytes
 
         core.send_message('test_message_too_large', 1, {}, message)
 
     def test_simple_send_and_receive_default_expiry(self):
-        core = self._get_core()
+        core = self._get_server_core()
 
         request_id = 27
         meta = {'app': 52}
         message = {'test': 'payload'}
 
         t = time.time()
-        core.send_message('test_simple_send_and_receive', request_id, meta, message)
+        core.send_message('test_simple_send_and_receive_default_expiry', request_id, meta, message)
 
-        response = core.receive_message('test_simple_send_and_receive')
+        response = core.receive_message('test_simple_send_and_receive_default_expiry')
 
-        self.assertEqual(request_id, response[0])
-        self.assertEqual(52, response[1]['app'])
-        self.assertIn('serializer', response[1])
-        self.assertIn('__expiry__', response[1])
-        self.assertEqual(3, len(response[1]))
-        self.assertEqual(message, response[2])
+        assert response.request_id == request_id
+        assert response.meta['app'] == 52
+        assert 'serializer' in response.meta
+        assert 'protocol_version' in response.meta
+        assert '__expiry__' in response.meta
+        assert len(response.meta) == 4
+        assert response.body == message
 
-        self.assertIn('__expiry__', meta)
-        self.assertEqual(meta['__expiry__'], response[1]['__expiry__'])
-        self.assertTrue((t + 59.9) < meta['__expiry__'] < (t + 61.1))
+        assert '__expiry__' in meta
+        assert response[1]['__expiry__'] == meta['__expiry__']
+        assert (t + 59.9) < meta['__expiry__'] < (t + 61.1)
 
     def test_simple_send_and_receive_expiry_override(self):
-        core = self._get_core()
+        core = self._get_server_core()
 
         request_id = 31
         meta = {'application': 79}
         message = {'test': 'payload'}
 
         t = time.time()
-        core.send_message('test_simple_send_and_receive', request_id, meta, message, message_expiry_in_seconds=10)
+        core.send_message(
+            'test_simple_send_and_receive_expiry_override',
+            request_id,
+            meta,
+            message,
+            message_expiry_in_seconds=10,
+        )
 
-        response = core.receive_message('test_simple_send_and_receive')
+        response = core.receive_message('test_simple_send_and_receive_expiry_override')
 
-        self.assertEqual(request_id, response[0])
-        self.assertEqual(79, response[1]['application'])
-        self.assertIn('serializer', response[1])
-        self.assertIn('__expiry__', response[1])
-        self.assertEqual(3, len(response[1]))
-        self.assertEqual(message, response[2])
+        assert response.request_id == request_id
+        assert response.meta['application'] == 79
+        assert 'serializer' in response.meta
+        assert 'protocol_version' in response.meta
+        assert '__expiry__' in response.meta
+        assert len(response.meta) == 4
+        assert response.body == message
 
-        self.assertIn('__expiry__', meta)
-        self.assertEqual(meta['__expiry__'], response[1]['__expiry__'])
-        self.assertTrue((t + 9.9) < meta['__expiry__'] < (t + 10.1))
+        assert '__expiry__' in meta
+        assert response[1]['__expiry__'] == meta['__expiry__']
+        assert (t + 9.9) < meta['__expiry__'] < (t + 10.1)
 
     def test_send_queue_full(self):
-        core = self._get_core(queue_full_retries=1, queue_capacity=3)
+        core = self._get_server_core(queue_full_retries=1, queue_capacity=3)
 
         request_id1 = 32
         request_id2 = 33
@@ -259,64 +427,64 @@ class TestRedisTransportCore(unittest.TestCase):
         core.send_message('test_send_queue_full', request_id2, {}, {'test': 'payload2'})
         core.send_message('test_send_queue_full', request_id3, {}, {'test': 'payload3'})
 
-        with self.assertRaises(MessageSendError) as error_context:
+        with pytest.raises(MessageSendError) as error_context:
             core.send_message('test_send_queue_full', request_id4, {}, {'test': 'payload4'})
 
-        self.assertTrue('test_send_queue_full was full' in error_context.exception.args[0])
+        assert 'test_send_queue_full was full' in error_context.value.args[0]
 
         response = core.receive_message('test_send_queue_full')
-        self.assertEqual(request_id1, response[0])
-        self.assertEqual('payload1', response[2]['test'])
+        assert response[0] == request_id1
+        assert response[2]['test'] == 'payload1'
 
         core.send_message('test_send_queue_full', request_id4, {}, {'test': 'payload4'})
 
-        with self.assertRaises(MessageSendError) as error_context:
+        with pytest.raises(MessageSendError) as error_context:
             core.send_message('test_send_queue_full', request_id5, {}, {'test': 'payload5'})
 
-        self.assertTrue('test_send_queue_full was full' in error_context.exception.args[0])
+        assert 'test_send_queue_full was full' in error_context.value.args[0]
 
         response = core.receive_message('test_send_queue_full')
-        self.assertEqual(request_id2, response[0])
-        self.assertEqual('payload2', response[2]['test'])
+        assert response[0] == request_id2
+        assert response[2]['test'] == 'payload2'
 
         core.send_message('test_send_queue_full', request_id5, {}, {'test': 'payload5'})
 
         response = core.receive_message('test_send_queue_full')
-        self.assertEqual(request_id3, response[0])
-        self.assertEqual('payload3', response[2]['test'])
+        assert response[0] == request_id3
+        assert response[2]['test'] == 'payload3'
 
         response = core.receive_message('test_send_queue_full')
-        self.assertEqual(request_id4, response[0])
-        self.assertEqual('payload4', response[2]['test'])
+        assert response[0] == request_id4
+        assert response[2]['test'] == 'payload4'
 
         response = core.receive_message('test_send_queue_full')
-        self.assertEqual(request_id5, response[0])
-        self.assertEqual('payload5', response[2]['test'])
+        assert response[0] == request_id5
+        assert response[2]['test'] == 'payload5'
 
     def test_receive_timeout_default(self):
-        core = self._get_core(receive_timeout_in_seconds=1)
+        core = self._get_server_core(receive_timeout_in_seconds=1)
 
         start = timeit.default_timer()
-        with self.assertRaises(MessageReceiveTimeout) as error_context:
+        with pytest.raises(MessageReceiveTimeout) as error_context:
             core.receive_message('test_receive_timeout')
         elapsed = timeit.default_timer() - start
 
-        self.assertTrue('received' in error_context.exception.args[0])
-        self.assertTrue(0.9 < elapsed < 1.1)
+        assert 'received' in error_context.value.args[0]
+        assert 0.9 < elapsed < 1.1
 
     def test_receive_timeout_override(self):
-        core = self._get_core()
+        core = self._get_server_core()
 
         start = timeit.default_timer()
-        with self.assertRaises(MessageReceiveTimeout) as error_context:
+        with pytest.raises(MessageReceiveTimeout) as error_context:
             core.receive_message('test_receive_timeout', receive_timeout_in_seconds=1)
         elapsed = timeit.default_timer() - start
 
-        self.assertTrue('received' in error_context.exception.args[0])
-        self.assertTrue(0.9 < elapsed < 1.1)
+        assert 'received' in error_context.value.args[0]
+        assert 0.9 < elapsed < 1.1
 
     def test_expired_message(self):
-        core = self._get_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+        core = self._get_server_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
 
         with freezegun.freeze_time(ignore=['mockredis.client', 'mockredis.clock', 'timeit']) as frozen_time:
             core.send_message('test_expired_message', 42, {}, {'test': 'payload'})
@@ -324,12 +492,12 @@ class TestRedisTransportCore(unittest.TestCase):
             frozen_time.tick(datetime.timedelta(seconds=11))
 
             start = timeit.default_timer()
-            with self.assertRaises(MessageReceiveTimeout) as error_context:
+            with pytest.raises(MessageReceiveTimeout) as error_context:
                 core.receive_message('test_expired_message')
             elapsed = timeit.default_timer() - start
 
-            self.assertTrue(0 < elapsed < 0.1)  # This shouldn't actually take 3 seconds, it should be instant
-            self.assertTrue('expired' in error_context.exception.args[0])
+            assert 0 < elapsed < 0.1  # This shouldn't actually take 3 seconds, it should be instant
+            assert 'expired' in error_context.value.args[0]
 
             frozen_time.tick(datetime.timedelta(seconds=1))
 
@@ -342,12 +510,12 @@ class TestRedisTransportCore(unittest.TestCase):
             response = core.receive_message('test_expired_message')
             elapsed = timeit.default_timer() - start
 
-            self.assertTrue(0 < elapsed < 0.1)
-            self.assertEqual(request_id, response[0])
+            assert 0 < elapsed < 0.1
+            assert response[0] == request_id
 
     @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
     def test_content_type_default(self, mock_standard):
-        core = self._get_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+        core = self._get_server_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
 
         mock_standard.return_value.get_connection.return_value.blpop.return_value = [
             True,
@@ -356,10 +524,13 @@ class TestRedisTransportCore(unittest.TestCase):
 
         request_id, meta, body = core.receive_message('test_content_type_default')
 
-        self.assertEqual(15, request_id)
-        self.assertIn('serializer', meta)
-        self.assertEqual(1, len(meta))
-        self.assertEqual({'foo': 'bar'}, body)
+        assert request_id == 15
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert len(meta) == 2
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_1
+        assert isinstance(meta['serializer'], MsgpackSerializer)
+        assert body == {'foo': 'bar'}
 
         mock_standard.return_value.get_connection.return_value.blpop.assert_called_once_with(
             ['pysoa:test_content_type_default'],
@@ -370,96 +541,683 @@ class TestRedisTransportCore(unittest.TestCase):
 
         call_kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0][1]
 
-        self.assertEqual('pysoa:test_content_type_default:reply', call_kwargs['queue_key'])
-        self.assertEqual(core.message_expiry_in_seconds, call_kwargs['expiry'])
-        self.assertEqual(core.queue_capacity, call_kwargs['capacity'])
-        self.assertEqual(mock_standard.return_value.get_connection.return_value, call_kwargs['connection'])
+        assert call_kwargs['queue_key'] == 'pysoa:test_content_type_default:reply'
+        assert call_kwargs['expiry'] == core.message_expiry_in_seconds
+        assert call_kwargs['capacity'] == core.queue_capacity
+        assert call_kwargs['connection'] == mock_standard.return_value.get_connection.return_value
 
-        self.assertTrue(call_kwargs['message'].startswith(b'content-type:application/msgpack;'))
+        assert not call_kwargs['message'].startswith(b'pysoa-redis/')
+        assert not call_kwargs['message'].startswith(b'content-type')
 
-        message = MsgpackSerializer().blob_to_dict(call_kwargs['message'][len(b'content-type:application/msgpack;'):])
-        self.assertEqual(15, message['request_id'])
-        self.assertTrue(message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds)
-        self.assertTrue({'yep': 'nope'}, message['body'])
+        message = MsgpackSerializer().blob_to_dict(call_kwargs['message'])
+        assert message['request_id'] == 15
+        assert message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds
+        assert message['body'] == {'yep': 'nope'}
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_content_type_default_with_version(self, mock_standard):
+        core = self._get_server_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        mock_standard.return_value.get_connection.return_value.blpop.return_value = [
+            True,
+            (
+                b'pysoa-redis/3//' +
+                MsgpackSerializer().dict_to_blob({'request_id': 16, 'meta': {}, 'body': {'foo': 'bar'}})
+            ),
+        ]
+
+        request_id, meta, body = core.receive_message('test_content_type_default_with_version')
+
+        assert request_id == 16
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert len(meta) == 2
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_3
+        assert isinstance(meta['serializer'], MsgpackSerializer)
+        assert body == {'foo': 'bar'}
+
+        mock_standard.return_value.get_connection.return_value.blpop.assert_called_once_with(
+            ['pysoa:test_content_type_default_with_version'],
+            timeout=core.receive_timeout_in_seconds,
+        )
+
+        core.send_message('test_content_type_default_with_version:reply', 16, meta, {'yep': 'nope'})
+
+        call_kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0][1]
+
+        assert call_kwargs['queue_key'] == 'pysoa:test_content_type_default_with_version:reply'
+        assert call_kwargs['expiry'] == core.message_expiry_in_seconds
+        assert call_kwargs['capacity'] == core.queue_capacity
+        assert call_kwargs['connection'] == mock_standard.return_value.get_connection.return_value
+
+        assert call_kwargs['message'].startswith(b'pysoa-redis/3//content-type:application/msgpack;')
+
+        message = MsgpackSerializer().blob_to_dict(
+            call_kwargs['message'][len(b'pysoa-redis/3//content-type:application/msgpack;'):],
+        )
+        assert message['request_id'] == 16
+        assert message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds
+        assert message['body'] == {'yep': 'nope'}
 
     @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
     def test_content_type_explicit_msgpack(self, mock_standard):
-        core = self._get_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+        core = self._get_server_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
 
         mock_standard.return_value.get_connection.return_value.blpop.return_value = [
             True,
             (
                 b'content-type:application/msgpack;' +
-                MsgpackSerializer().dict_to_blob({'request_id': 15, 'meta': {}, 'body': {'foo': 'bar'}})
+                MsgpackSerializer().dict_to_blob({'request_id': 71, 'meta': {}, 'body': {'baz': 'qux'}})
             ),
         ]
 
-        request_id, meta, body = core.receive_message('test_content_type_default')
+        request_id, meta, body = core.receive_message('test_content_type_explicit_msgpack')
 
-        self.assertEqual(15, request_id)
-        self.assertIn('serializer', meta)
-        self.assertEqual(1, len(meta))
-        self.assertIsInstance(meta['serializer'], MsgpackSerializer)
-        self.assertEqual({'foo': 'bar'}, body)
+        assert request_id == 71
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert len(meta) == 2
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_2
+        assert isinstance(meta['serializer'], MsgpackSerializer)
+        assert body == {'baz': 'qux'}
 
         mock_standard.return_value.get_connection.return_value.blpop.assert_called_once_with(
-            ['pysoa:test_content_type_default'],
+            ['pysoa:test_content_type_explicit_msgpack'],
             timeout=core.receive_timeout_in_seconds,
         )
 
-        core.send_message('test_content_type_default:reply', 15, meta, {'yep': 'nope'})
+        core.send_message('test_content_type_explicit_msgpack:reply', 71, meta, {'nope': 'yep'})
 
         call_kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0][1]
 
-        self.assertEqual('pysoa:test_content_type_default:reply', call_kwargs['queue_key'])
-        self.assertEqual(core.message_expiry_in_seconds, call_kwargs['expiry'])
-        self.assertEqual(core.queue_capacity, call_kwargs['capacity'])
-        self.assertEqual(mock_standard.return_value.get_connection.return_value, call_kwargs['connection'])
+        assert call_kwargs['queue_key'] == 'pysoa:test_content_type_explicit_msgpack:reply'
+        assert call_kwargs['expiry'] == core.message_expiry_in_seconds
+        assert call_kwargs['capacity'] == core.queue_capacity
+        assert call_kwargs['connection'] == mock_standard.return_value.get_connection.return_value
 
-        self.assertTrue(call_kwargs['message'].startswith(b'content-type:application/msgpack;'))
+        assert call_kwargs['message'].startswith(b'content-type:application/msgpack;')
 
         message = MsgpackSerializer().blob_to_dict(call_kwargs['message'][len(b'content-type:application/msgpack;'):])
-        self.assertEqual(15, message['request_id'])
-        self.assertTrue(message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds)
-        self.assertTrue({'yep': 'nope'}, message['body'])
+        assert message['request_id'] == 71
+        assert message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds
+        assert message['body'] == {'nope': 'yep'}
 
     @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
-    def test_content_type_explicit_json(self, mock_standard):
-        core = self._get_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+    def test_content_type_explicit_msgpack_with_version(self, mock_standard):
+        core = self._get_server_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
 
         mock_standard.return_value.get_connection.return_value.blpop.return_value = [
             True,
             (
-                b'content-type : application/json ;' +
-                JSONSerializer().dict_to_blob({'request_id': 15, 'meta': {}, 'body': {'foo': 'bar'}})
+                    b'pysoa-redis/3//content-type:application/msgpack;' +
+                    MsgpackSerializer().dict_to_blob({'request_id': 72, 'meta': {}, 'body': {'baz': 'qux'}})
             ),
         ]
 
-        request_id, meta, body = core.receive_message('test_content_type_default')
+        request_id, meta, body = core.receive_message('test_content_type_explicit_msgpack_with_version')
 
-        self.assertEqual(15, request_id)
-        self.assertIn('serializer', meta)
-        self.assertEqual(1, len(meta))
-        self.assertIsInstance(meta['serializer'], JSONSerializer)
-        self.assertEqual({'foo': 'bar'}, body)
+        assert request_id == 72
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert len(meta) == 2
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_3
+        assert isinstance(meta['serializer'], MsgpackSerializer)
+        assert body == {'baz': 'qux'}
 
         mock_standard.return_value.get_connection.return_value.blpop.assert_called_once_with(
-            ['pysoa:test_content_type_default'],
+            ['pysoa:test_content_type_explicit_msgpack_with_version'],
             timeout=core.receive_timeout_in_seconds,
         )
 
-        core.send_message('test_content_type_default:reply', 15, meta, {'yep': 'nope'})
+        core.send_message('test_content_type_explicit_msgpack_with_version:reply', 72, meta, {'nope': 'yep'})
 
         call_kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0][1]
 
-        self.assertEqual('pysoa:test_content_type_default:reply', call_kwargs['queue_key'])
-        self.assertEqual(core.message_expiry_in_seconds, call_kwargs['expiry'])
-        self.assertEqual(core.queue_capacity, call_kwargs['capacity'])
-        self.assertEqual(mock_standard.return_value.get_connection.return_value, call_kwargs['connection'])
+        assert call_kwargs['queue_key'] == 'pysoa:test_content_type_explicit_msgpack_with_version:reply'
+        assert call_kwargs['expiry'] == core.message_expiry_in_seconds
+        assert call_kwargs['capacity'] == core.queue_capacity
+        assert call_kwargs['connection'] == mock_standard.return_value.get_connection.return_value
 
-        self.assertTrue(call_kwargs['message'].startswith(b'content-type:application/json;'))
+        assert call_kwargs['message'].startswith(b'pysoa-redis/3//content-type:application/msgpack;')
+
+        message = MsgpackSerializer().blob_to_dict(
+            call_kwargs['message'][len(b'pysoa-redis/3//content-type:application/msgpack;'):],
+        )
+        assert message['request_id'] == 72
+        assert message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds
+        assert message['body'] == {'nope': 'yep'}
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_content_type_explicit_json(self, mock_standard):
+        core = self._get_server_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        mock_standard.return_value.get_connection.return_value.blpop.return_value = [
+            True,
+            (
+                b'content-type : application/json ; ' +
+                JSONSerializer().dict_to_blob({'request_id': 43, 'meta': {}, 'body': {'foo': 'bar'}})
+            ),
+        ]
+
+        request_id, meta, body = core.receive_message('test_content_type_explicit_json')
+
+        assert request_id == 43
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert len(meta) == 2
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_2
+        assert isinstance(meta['serializer'], JSONSerializer)
+        assert body == {'foo': 'bar'}
+
+        mock_standard.return_value.get_connection.return_value.blpop.assert_called_once_with(
+            ['pysoa:test_content_type_explicit_json'],
+            timeout=core.receive_timeout_in_seconds,
+        )
+
+        core.send_message('test_content_type_explicit_json:reply', 43, meta, {'yep': 'nope'})
+
+        call_kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0][1]
+
+        assert call_kwargs['queue_key'] == 'pysoa:test_content_type_explicit_json:reply'
+        assert call_kwargs['expiry'] == core.message_expiry_in_seconds
+        assert call_kwargs['capacity'] == core.queue_capacity
+        assert call_kwargs['connection'] == mock_standard.return_value.get_connection.return_value
+
+        assert call_kwargs['message'].startswith(b'content-type:application/json;')
 
         message = JSONSerializer().blob_to_dict(call_kwargs['message'][len(b'content-type:application/json;'):])
-        self.assertEqual(15, message['request_id'])
-        self.assertTrue(message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds)
-        self.assertTrue({'yep': 'nope'}, message['body'])
+        assert message['request_id'] == 43
+        assert message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds
+        assert message['body'] == {'yep': 'nope'}
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_content_type_explicit_json_with_version(self, mock_standard):
+        core = self._get_server_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        mock_standard.return_value.get_connection.return_value.blpop.return_value = [
+            True,
+            (
+                    b'pysoa-redis/3//content-type : application/json ; ' +
+                    JSONSerializer().dict_to_blob({'request_id': 44, 'meta': {}, 'body': {'foo': 'bar'}})
+            ),
+        ]
+
+        request_id, meta, body = core.receive_message('test_content_type_explicit_json_with_version')
+
+        assert request_id == 44
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert len(meta) == 2
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_3
+        assert isinstance(meta['serializer'], JSONSerializer)
+        assert body == {'foo': 'bar'}
+
+        mock_standard.return_value.get_connection.return_value.blpop.assert_called_once_with(
+            ['pysoa:test_content_type_explicit_json_with_version'],
+            timeout=core.receive_timeout_in_seconds,
+        )
+
+        core.send_message('test_content_type_explicit_json_with_version:reply', 44, meta, {'yep': 'nope'})
+
+        call_kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0][1]
+
+        assert call_kwargs['queue_key'] == 'pysoa:test_content_type_explicit_json_with_version:reply'
+        assert call_kwargs['expiry'] == core.message_expiry_in_seconds
+        assert call_kwargs['capacity'] == core.queue_capacity
+        assert call_kwargs['connection'] == mock_standard.return_value.get_connection.return_value
+
+        assert call_kwargs['message'].startswith(b'pysoa-redis/3//content-type:application/json;')
+
+        message = JSONSerializer().blob_to_dict(
+            call_kwargs['message'][len(b'pysoa-redis/3//content-type:application/json;'):],
+        )
+        assert message['request_id'] == 44
+        assert message['meta']['__expiry__'] <= time.time() + core.message_expiry_in_seconds
+        assert message['body'] == {'yep': 'nope'}
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_receive_chunking_prohibited_on_server(self, mock_standard):
+        core = self._get_server_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        message = {'request_id': 79, 'meta': {'yes': 'no'}, 'body': {'baz': 'qux'}}
+        message['body'].update({'key-{}'.format(i): 'value-{}'.format(i) for i in range(200)})
+
+        serialized = MsgpackSerializer().dict_to_blob(message)
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:1;' + serialized[0:1000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:2;' + serialized[1000:2000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:3;' + serialized[2000:3000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:4;' + serialized[3000:])],
+        ]
+
+        with pytest.raises(InvalidMessageError) as error_context:
+            core.receive_message('test_receive_chunking_prohibited_on_server')
+
+        assert 'Unsupported chunked request' in error_context.value.args[0]
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_receive_chunking_successful_on_client(self, mock_standard):
+        core = self._get_client_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        message = {'request_id': 79, 'meta': {'yes': 'no'}, 'body': {'baz': 'qux'}}
+        message['body'].update({'key-{}'.format(i): 'value-{}'.format(i) for i in range(200)})
+
+        serialized = MsgpackSerializer().dict_to_blob(message)
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:1;' + serialized[0:1000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:2;' + serialized[1000:2000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:3;' + serialized[2000:3000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:4;' + serialized[3000:])],
+        ]
+
+        request_id, meta, body = core.receive_message('test_receive_chunking_successful_on_client')
+
+        assert request_id == 79
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert meta['yes'] == 'no'
+        assert len(meta) == 3
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_3
+        assert isinstance(meta['serializer'], MsgpackSerializer)
+        assert body == message['body']
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_receive_chunking_successful_on_client_with_msgpack_content_type(self, mock_standard):
+        core = self._get_client_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        message = {'request_id': 80, 'meta': {'no': 'yes'}, 'body': {'foo': 'bar'}}
+        message['body'].update({'key-{}'.format(i): 'value-{}'.format(i) for i in range(200)})
+
+        serialized = MsgpackSerializer().dict_to_blob(message)
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (b'pysoa-redis/3//chunk-count:4;content-type:application/msgpack;chunk-id:1;' + serialized[0:1000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:2;' + serialized[1000:2000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:3;' + serialized[2000:3000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:4;' + serialized[3000:])],
+        ]
+
+        request_id, meta, body = core.receive_message(
+            'test_receive_chunking_successful_on_client_with_msgpack_content_type',
+        )
+
+        assert request_id == 80
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert meta['no'] == 'yes'
+        assert len(meta) == 3
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_3
+        assert isinstance(meta['serializer'], MsgpackSerializer)
+        assert body == message['body']
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_receive_chunking_successful_on_client_with_json_content_type(self, mock_standard):
+        core = self._get_client_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        message = {'request_id': 83, 'meta': {'no': 'yes'}, 'body': {'baz': 'qux'}}
+        message['body'].update({'key-{}'.format(i): 'value-{}'.format(i) for i in range(200)})
+
+        serialized = JSONSerializer().dict_to_blob(message)
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:1;content-type:application/json;' + serialized[0:1000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:2;' + serialized[1000:2000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:3;' + serialized[2000:3000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:4;' + serialized[3000:])],
+        ]
+
+        request_id, meta, body = core.receive_message(
+            'test_receive_chunking_successful_on_client_with_json_content_type',
+        )
+
+        assert request_id == 83
+        assert 'serializer' in meta
+        assert 'protocol_version' in meta
+        assert meta['no'] == 'yes'
+        assert len(meta) == 3
+        assert meta['protocol_version'] == ProtocolVersion.VERSION_3
+        assert isinstance(meta['serializer'], JSONSerializer)
+        assert body == message['body']
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_receive_chunking_fails_on_client_missing_header(self, mock_standard):
+        core = self._get_client_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        message = {'request_id': 79, 'meta': {'yes': 'no'}, 'body': {'baz': 'qux'}}
+        message['body'].update({'key-{}'.format(i): 'value-{}'.format(i) for i in range(200)})
+
+        serialized = MsgpackSerializer().dict_to_blob(message)
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (b'pysoa-redis/3//chunk-count:4;' + serialized[0:1000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:2;' + serialized[1000:2000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:3;' + serialized[2000:3000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:4;' + serialized[3000:])],
+        ]
+
+        with pytest.raises(InvalidMessageError) as error_context:
+            core.receive_message('test_receive_chunking_fails_on_client_missing_header')
+
+        assert 'missing chunk ID' in error_context.value.args[0]
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_receive_chunking_fails_on_client_subsequent_chunk_missing_headers(self, mock_standard):
+        core = self._get_client_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        message = {'request_id': 79, 'meta': {'yes': 'no'}, 'body': {'baz': 'qux'}}
+        message['body'].update({'key-{}'.format(i): 'value-{}'.format(i) for i in range(200)})
+
+        serialized = MsgpackSerializer().dict_to_blob(message)
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:1;' + serialized[0:1000])],
+            [True, (b'pysoa-redis/3//chunk-id:2;' + serialized[1000:2000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:3;' + serialized[2000:3000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:4;' + serialized[3000:])],
+        ]
+
+        with pytest.raises(InvalidMessageError) as error_context:
+            core.receive_message('test_receive_chunking_fails_on_client_subsequent_chunk_missing_headers')
+
+        assert 'missing chunk headers' in error_context.value.args[0]
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_receive_chunking_fails_on_client_subsequent_chunk_count_differs(self, mock_standard):
+        core = self._get_client_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        message = {'request_id': 79, 'meta': {'yes': 'no'}, 'body': {'baz': 'qux'}}
+        message['body'].update({'key-{}'.format(i): 'value-{}'.format(i) for i in range(200)})
+
+        serialized = MsgpackSerializer().dict_to_blob(message)
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:1;' + serialized[0:1000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:2;' + serialized[1000:2000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:3;' + serialized[2000:3000])],
+            [True, (b'pysoa-redis/3//chunk-count:5;chunk-id:4;' + serialized[3000:])],
+        ]
+
+        with pytest.raises(InvalidMessageError) as error_context:
+            core.receive_message('test_receive_chunking_fails_on_client_subsequent_chunk_count_differs')
+
+        assert 'different chunk count' in error_context.value.args[0]
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_receive_chunking_fails_on_client_subsequent_chunk_id_is_unexpected(self, mock_standard):
+        core = self._get_client_core(receive_timeout_in_seconds=3, message_expiry_in_seconds=10)
+
+        message = {'request_id': 79, 'meta': {'yes': 'no'}, 'body': {'baz': 'qux'}}
+        message['body'].update({'key-{}'.format(i): 'value-{}'.format(i) for i in range(200)})
+
+        serialized = MsgpackSerializer().dict_to_blob(message)
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:1;' + serialized[0:1000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:2;' + serialized[1000:2000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:4;' + serialized[2000:3000])],
+            [True, (b'pysoa-redis/3//chunk-count:4;chunk-id:5;' + serialized[3000:])],
+        ]
+
+        with pytest.raises(InvalidMessageError) as error_context:
+            core.receive_message('test_receive_chunking_fails_on_client_subsequent_chunk_count_differs')
+
+        assert 'incorrect chunk ID' in error_context.value.args[0]
+
+    @pytest.mark.parametrize(
+        ('version', ),
+        (
+            (ProtocolVersion.VERSION_1, ),
+            (ProtocolVersion.VERSION_2, ),
+            (None, ),
+        ),
+    )
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_send_chunking_fails_if_client_does_not_support(self, mock_standard, version):
+        core = self._get_server_core(
+            chunk_messages_larger_than_bytes=102400,
+            maximum_message_size_in_bytes=102400 * 6,
+        )
+
+        meta = {'protocol_version': version} if version else {}
+        body = {'test': ['payload%i' % i for i in range(10000, 30000)]}  # 2.5 chunks needed
+
+        with pytest.raises(MessageTooLarge) as error_context:
+            core.send_message('test_send_chunking_fails_if_client_does_not_support', 103, meta, body)
+
+        assert 'client does not support chunking' in error_context.value.args[0]
+
+        assert not mock_standard.return_value.send_message_to_queue.called
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_send_chunking_works_three_chunks(self, mock_standard):
+        core = self._get_server_core(
+            chunk_messages_larger_than_bytes=102400,
+            maximum_message_size_in_bytes=102400 * 6,
+        )
+
+        meta = {'protocol_version': ProtocolVersion.VERSION_3}
+        body = {'test': ['payload%i' % i for i in range(10000, 30000)]}  # 2.5 chunks needed
+
+        core.send_message('test_send_chunking_works_three_chunks', 103, meta, body)
+
+        assert mock_standard.return_value.send_message_to_queue.call_count == 3
+
+        starts_with = b'pysoa-redis/3//content-type:application/msgpack;chunk-count:3;chunk-id:'
+        starts_with_length = len(starts_with) + 2
+
+        payload = b''
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0]
+        assert kwargs['message'].startswith(starts_with + b'1;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[1]
+        assert kwargs['message'].startswith(starts_with + b'2;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[2]
+        assert kwargs['message'].startswith(starts_with + b'3;')
+        payload += kwargs['message'][starts_with_length:]
+
+        deserialized = MsgpackSerializer().blob_to_dict(payload)
+        assert deserialized['request_id'] == 103
+        assert '__expiry__' in deserialized['meta']
+        assert len(deserialized['meta']) == 1
+        assert deserialized['body'] == body
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_send_chunking_works_four_chunks(self, mock_standard):
+        core = self._get_server_core(
+            chunk_messages_larger_than_bytes=125000,
+            maximum_message_size_in_bytes=125000 * 6,
+        )
+
+        meta = {'protocol_version': ProtocolVersion.VERSION_3, 'serializer': JSONSerializer()}
+        body = {'test': ['payload%i' % i for i in range(10000, 40000)]}  # 3.8 chunks needed
+
+        core.send_message('test_send_chunking_works_four_chunks', 115, meta, body)
+
+        assert mock_standard.return_value.send_message_to_queue.call_count == 4
+
+        starts_with = b'pysoa-redis/3//content-type:application/json;chunk-count:4;chunk-id:'
+        starts_with_length = len(starts_with) + 2
+
+        payload = b''
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0]
+        assert kwargs['message'].startswith(starts_with + b'1;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[1]
+        assert kwargs['message'].startswith(starts_with + b'2;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[2]
+        assert kwargs['message'].startswith(starts_with + b'3;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[3]
+        assert kwargs['message'].startswith(starts_with + b'4;')
+        payload += kwargs['message'][starts_with_length:]
+
+        deserialized = JSONSerializer().blob_to_dict(payload)
+        assert deserialized['request_id'] == 115
+        assert '__expiry__' in deserialized['meta']
+        assert len(deserialized['meta']) == 1
+        assert deserialized['body'] == body
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_send_chunking_works_five_chunks(self, mock_standard):
+        core = self._get_server_core(
+            chunk_messages_larger_than_bytes=111111,
+            maximum_message_size_in_bytes=111111 * 6,
+        )
+
+        meta = {'protocol_version': ProtocolVersion.VERSION_3}
+        body = {'test': ['payload%i' % i for i in range(10000, 51000)]}  # 4.1 chunks needed
+
+        core.send_message('test_send_chunking_works_five_chunks', 122, meta, body)
+
+        assert mock_standard.return_value.send_message_to_queue.call_count == 5
+
+        starts_with = b'pysoa-redis/3//content-type:application/msgpack;chunk-count:5;chunk-id:'
+        starts_with_length = len(starts_with) + 2
+
+        payload = b''
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[0]
+        assert kwargs['message'].startswith(starts_with + b'1;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[1]
+        assert kwargs['message'].startswith(starts_with + b'2;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[2]
+        assert kwargs['message'].startswith(starts_with + b'3;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[3]
+        assert kwargs['message'].startswith(starts_with + b'4;')
+        payload += kwargs['message'][starts_with_length:]
+
+        _, kwargs = mock_standard.return_value.send_message_to_queue.call_args_list[4]
+        assert kwargs['message'].startswith(starts_with + b'5;')
+        payload += kwargs['message'][starts_with_length:]
+
+        deserialized = MsgpackSerializer().blob_to_dict(payload)
+        assert deserialized['request_id'] == 122
+        assert '__expiry__' in deserialized['meta']
+        assert len(deserialized['meta']) == 1
+        assert deserialized['body'] == body
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_send_chunking_can_still_hit_too_large_error(self, mock_standard):
+        core = self._get_server_core(
+            chunk_messages_larger_than_bytes=111111,
+            maximum_message_size_in_bytes=111111 * 6,
+        )
+
+        meta = {}
+        body = {'test': ['payload%i' % i for i in range(10000, 75000)]}  # > 111111 * 6
+
+        with pytest.raises(MessageTooLarge) as error_context:
+            core.send_message('test_send_chunking_can_still_hit_too_large_error', 115, meta, body)
+
+        assert 'exceeds maximum message size' in error_context.value.args[0]
+
+        assert not mock_standard.return_value.send_message_to_queue.called
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_send_chunking_works_round_trip_three_chunks(self, mock_standard):
+        server_core = self._get_server_core(
+            chunk_messages_larger_than_bytes=102400,
+            maximum_message_size_in_bytes=102400 * 6,
+        )
+        client_core = self._get_client_core()
+
+        meta = {'protocol_version': ProtocolVersion.VERSION_3}
+        body = {'test': ['payload%i' % i for i in range(10000, 30000)]}  # 2.5 chunks needed
+
+        server_core.send_message('test_send_chunking_works_round_trip_three_chunks', 103, meta, body)
+
+        assert mock_standard.return_value.send_message_to_queue.call_count == 3
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[0][1]['message'])],
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[1][1]['message'])],
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[2][1]['message'])],
+        ]
+
+        request_id, _, received_body = client_core.receive_message(
+            'test_send_chunking_works_round_trip_three_chunks',
+        )
+
+        assert request_id == 103
+        assert received_body == body
+
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_send_chunking_works_round_trip_five_chunks(self, mock_standard):
+        server_core = self._get_server_core(
+            chunk_messages_larger_than_bytes=102400,
+            maximum_message_size_in_bytes=102400 * 6,
+        )
+        client_core = self._get_client_core()
+
+        meta = {'protocol_version': ProtocolVersion.VERSION_3}
+        body = {'test': ['payload%i' % i for i in range(10000, 48000)]}  # 4.1 chunks needed
+
+        server_core.send_message('test_send_chunking_works_round_trip_five_chunks', 103, meta, body)
+
+        assert mock_standard.return_value.send_message_to_queue.call_count == 5
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[0][1]['message'])],
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[1][1]['message'])],
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[2][1]['message'])],
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[3][1]['message'])],
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[4][1]['message'])],
+        ]
+
+        request_id, _, received_body = client_core.receive_message(
+            'test_send_chunking_works_round_trip_five_chunks',
+        )
+
+        assert request_id == 103
+        assert received_body == body
+
+    @pytest.mark.parametrize(
+        ('version', ),
+        (
+            (ProtocolVersion.VERSION_1, ),
+            (ProtocolVersion.VERSION_2, ),
+            (ProtocolVersion.VERSION_3, ),
+            (None, ),
+        ),
+    )
+    @mock.patch('pysoa.common.transport.redis_gateway.core.StandardRedisClient')
+    def test_client_protocol_version_configuration(self, mock_standard, version):
+        server_core = self._get_server_core()
+        if version:
+            client_core = self._get_client_core(protocol_version=version)
+        else:
+            client_core = self._get_client_core()
+
+        body = {'foo': 'bar', 'baz': 'qux', 'hello': 'world', 'goodbye': 'friends'}
+
+        client_core.send_message('test_client_protocol_version_configuration', 91, {}, body)
+
+        assert mock_standard.return_value.send_message_to_queue.call_count == 1
+
+        mock_standard.return_value.get_connection.return_value.blpop.side_effect = [
+            [True, (mock_standard.return_value.send_message_to_queue.call_args_list[0][1]['message'])],
+        ]
+
+        request_id, meta, received_body = server_core.receive_message('test_client_protocol_version_configuration')
+
+        assert request_id == 91
+        assert 'protocol_version' in meta
+        assert meta['protocol_version'] == version if version else ProtocolVersion.VERSION_2  # 2 is the default
+        assert received_body == body

--- a/tests/unit/common/transport/redis_gateway/test_server.py
+++ b/tests/unit/common/transport/redis_gateway/test_server.py
@@ -3,17 +3,16 @@ from __future__ import (
     unicode_literals,
 )
 
+import random
 import unittest
-import uuid
 
 from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.exceptions import InvalidMessageError
-from pysoa.common.transport.redis_gateway.constants import DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER
 from pysoa.common.transport.redis_gateway.server import RedisServerTransport
 from pysoa.test.compatibility import mock
 
 
-@mock.patch('pysoa.common.transport.redis_gateway.server.RedisTransportCore')
+@mock.patch('pysoa.common.transport.redis_gateway.server.RedisTransportServerCore')
 class TestServerTransport(unittest.TestCase):
     @staticmethod
     def _get_transport(service='my_service', **kwargs):
@@ -27,8 +26,6 @@ class TestServerTransport(unittest.TestCase):
             hello='world',
             goodbye='earth',
             metrics=transport.metrics,
-            metrics_prefix='server',
-            maximum_message_size_in_bytes=DEFAULT_MAXIMUM_MESSAGE_BYTES_SERVER,
         )
 
         mock_core.reset_mock()
@@ -40,14 +37,13 @@ class TestServerTransport(unittest.TestCase):
             hello='world',
             goodbye='earth',
             metrics=transport.metrics,
-            metrics_prefix='server',
             maximum_message_size_in_bytes=79,
         )
 
     def test_receive_request_message(self, mock_core):
         transport = self._get_transport()
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         meta = {'app': 'ppa'}
         message = {'test': 'payload'}
 
@@ -60,7 +56,7 @@ class TestServerTransport(unittest.TestCase):
     def test_receive_request_message_another_service(self, mock_core):
         transport = self._get_transport('geo')
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         message = {'another': 'message'}
 
         mock_core.return_value.receive_message.return_value = request_id, {}, message
@@ -72,7 +68,7 @@ class TestServerTransport(unittest.TestCase):
     def test_send_response_message_no_reply_to(self, mock_core):
         transport = self._get_transport()
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         meta = {'app': 'ppa'}
         message = {'test': 'payload'}
 
@@ -84,7 +80,7 @@ class TestServerTransport(unittest.TestCase):
     def test_send_response_message(self, mock_core):
         transport = self._get_transport()
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         meta = {'app': 'ppa', 'reply_to': 'my_reply_to_queue'}
         message = {'test': 'payload'}
 
@@ -100,7 +96,7 @@ class TestServerTransport(unittest.TestCase):
     def test_send_response_message_another_service(self, mock_core):
         transport = self._get_transport()
 
-        request_id = uuid.uuid4().hex
+        request_id = random.randint(1, 1000)
         meta = {'reply_to': 'service.tag.123498afe09b9128cd92348a8c7bde31!'}
         message = {'another': 'message'}
 


### PR DESCRIPTION
This implements #190 and part of #195.

- Part of the 1.0.0 milestone includes adding Python Typing support throughout the library. That was not the goal of this commit, but doing so in part of the library made it easier to correctly implement these changes, so this commit includes extensive added Python Typing support.
- Add a new Protocol Version concept to the PySOA Redis transport protocol.
- Although Protocol Version was previously undocumented, it was still an implicit concept, where without-content-type was Version 1 and with-content-type was Version 2. Now that it is a formal concept, the default Protocol Version has changed from Version 1 to Version 2, with a client-side configuration option to override the default with Version 1, 2, or 3.
- Add server response chunking to the PySOA Redis Transport Protocol version 3. Client requests can never support chunking, due to the nature of the way the protocol works at its foundation. Only server responses can support chunking.
- Add a bunch of unit tests to verify the chunking implementation.
- Add more functional tests to verify the chunking behavior, and found and fixed some bugs as a result.
- Update documentation.
- Make auto-doc-generation work in Python 3 (only).
- Re-run auto-doc-generation.