### PR TITLE
[PATCH] Fix import errors in Python 3.5.2/3.6.1 and fix Harakiri logging

### DIFF
--- a/pysoa/__init__.py
+++ b/pysoa/__init__.py
@@ -3,6 +3,8 @@ from __future__ import (
     unicode_literals,
 )
 
+import sys
+
 from pysoa.version import (
     __version__,
     __version_info__,
@@ -13,3 +15,11 @@ __all__ = (
     '__version__',
     '__version_info__',
 )
+
+
+if (3, 5) <= sys.version_info < (3, 7):
+    # We have some typing patches that we might need to apply in Python 3.5 and 3.6. We won't need to apply them in
+    # 2.7 because the `typing` backport in PyPi already has the fixes, and we won't need to apply them in 3.7 because
+    # that version has the fixes.
+    # noinspection PyUnresolvedReferences
+    import pysoa.typing_patches  # noqa: F401

--- a/pysoa/typing_patches.py
+++ b/pysoa/typing_patches.py
@@ -1,0 +1,45 @@
+import collections
+import sys
+import typing
+
+
+if (3, 5) <= sys.version_info < (3, 5, 3):
+    CT_co = typing.TypeVar('CT_co', covariant=True, bound=type)
+
+    # noinspection PyCompatibility
+    class PatchedType(typing.Generic[CT_co], extra=type):  # noqa: E999
+        """
+        Python 3.5.0-3.5.2 contain a bug whereby Type is defined as follows:
+
+        Type(type, Generic[CT_co], extra=type):
+            < docs, no methods or anything else >
+
+        This was reported in https://github.com/python/typing/issues/266 and fixed in
+        https://github.com/python/typing/pull/267/files, but some Python in the wild is still 3.5.2 or less, so this
+        patch backports that fix to 3.5.0-3.5.2.
+        """
+
+    typing.Type = PatchedType
+
+
+if (3, 5) <= sys.version_info < (3, 5, 4) or (3, 6) <= sys.version_info < (3, 6, 1):
+    T = typing.TypeVar('T')
+
+    # noinspection PyCompatibility
+    class Deque(collections.deque, typing.MutableSequence[T], extra=collections.deque):  # noqa: E999
+        """
+        Python 3.5.4 and 3.6.1 added typing.Deque, but some Python in the wild is still 3.5.3 or less or 3.6.0, so this
+        patch backports Deque to 3.5.0-3.5.3 and 3.6.0. This code was copied from
+        https://github.com/python/cpython/blob/v3.5.4/Lib/typing.py#L1901-L1908 and
+        https://github.com/python/cpython/blob/v3.6.1/Lib/typing.py#L1871-L1878.
+        """
+
+        __slots__ = ()
+
+        # noinspection PyProtectedMember,PyUnresolvedReferences,PyArgumentList
+        def __new__(cls, *args, **kwargs):
+            if typing._geqv(cls, Deque):
+                return collections.deque(*args, **kwargs)
+            return collections.deque.__new__(cls, *args, **kwargs)
+
+    typing.Deque = Deque


### PR DESCRIPTION
- Fix the import errors in Python 3.5.2/3.6.1 due to missing stuff
- Fix Harakiri logging