### PR TITLE
[MINOR] Use Conformity's Settings and deprecate PySOA's Settings

### DIFF
--- a/docs/update_reference_docs.py
+++ b/docs/update_reference_docs.py
@@ -12,9 +12,8 @@ import sys
 
 import attr
 from conformity import fields
+from conformity.settings import Settings
 import six
-
-from pysoa.common.settings import Settings
 
 
 if sys.version_info < (3, 5):
@@ -417,10 +416,8 @@ def _pretty_introspect(value, depth=1, nullable=''):
         documentation += 'flexible ``dict``{}: {}\n'.format(nullable, description)
         documentation += '\n{}keys\n{}{}\n'.format(first, second, _pretty_introspect(value.key_type, depth + 1))
         documentation += '\n{}values\n{}{}\n'.format(first, second, _pretty_introspect(value.value_type, depth + 1))
-    elif isinstance(value, fields.List):
-        noun = 'list'
-        if isinstance(value, fields.Set):
-            noun = 'set'
+    elif isinstance(value, (fields.List, fields.Sequence, fields.Set)):
+        noun = value.introspect_type
         documentation += '``{}``{}: {}\n'.format(noun, nullable, description)
         documentation += '\n{}values\n{}{}'.format(first, second, _pretty_introspect(value.contents, depth + 1))
     elif isinstance(value, fields.Nullable):

--- a/pysoa/client/expander.py
+++ b/pysoa/client/expander.py
@@ -4,9 +4,11 @@ from __future__ import (
 )
 
 from conformity import fields
+from conformity.settings import (  # noqa: F401 TODO Python 3
+    Settings,
+    SettingsSchema,
+)
 import six
-
-from pysoa.common.settings import Settings
 
 
 class ExpansionSettings(Settings):
@@ -93,7 +95,7 @@ class ExpansionSettings(Settings):
             description='The definition of all types that may contain identifiers that can be expanded into objects '
                         'using the `type_routes` configurations',
         ),
-    }
+    }  # type: SettingsSchema
 
 
 class TypeNode(object):

--- a/pysoa/client/settings.py
+++ b/pysoa/client/settings.py
@@ -3,9 +3,14 @@ from __future__ import (
     unicode_literals,
 )
 
+from typing import cast
 import warnings
 
 from conformity import fields
+from conformity.settings import (  # noqa: F401 TODO Python 3
+    SettingsData,
+    SettingsSchema,
+)
 
 from pysoa.client.middleware import ClientMiddleware
 from pysoa.common.settings import SOASettings
@@ -34,51 +39,54 @@ class ClientSettings(SOASettings):
                         'will remain in place until 2018-06-15 to give a safe period for people to remove it from '
                         'settings, but its value will always be ignored.',
         ),
-    }
+    }  # type: SettingsSchema
+
     defaults = {
         'transport': {
             'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
         },
         'transport_cache_time_in_seconds': 0,
-    }
+    }  # type: SettingsData
 
 
-ClientSettings.schema['transport'].initiate_cache_for(
+cast(fields.ClassConfigurationSchema, ClientSettings.schema['transport']).initiate_cache_for(
     'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
 )
-ClientSettings.schema['transport'].initiate_cache_for(
+cast(fields.ClassConfigurationSchema, ClientSettings.schema['transport']).initiate_cache_for(
     'pysoa.common.transport.local:LocalClientTransport',
 )
 
 
 class RedisClientSettings(ClientSettings):
+    schema = {
+        'transport': fields.ClassConfigurationSchema(base_class=RedisClientTransport),
+    }  # type: SettingsSchema
+
     defaults = {
         'transport': {
             'path': 'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
         }
-    }
-    schema = {
-        'transport': fields.ClassConfigurationSchema(base_class=RedisClientTransport),
-    }
+    }  # type: SettingsData
 
 
-RedisClientSettings.schema['transport'].initiate_cache_for(
+cast(fields.ClassConfigurationSchema, RedisClientSettings.schema['transport']).initiate_cache_for(
     'pysoa.common.transport.redis_gateway.client:RedisClientTransport',
 )
 
 
 class LocalClientSettings(ClientSettings):
+    schema = {
+        'transport': fields.ClassConfigurationSchema(base_class=LocalClientTransport),
+    }  # type: SettingsSchema
+
     defaults = {
         'transport': {
             'path': 'pysoa.common.transport.local:LocalClientTransport',
         }
-    }
-    schema = {
-        'transport': fields.ClassConfigurationSchema(base_class=LocalClientTransport),
-    }
+    }  # type: SettingsData
 
 
-LocalClientSettings.schema['transport'].initiate_cache_for(
+cast(fields.ClassConfigurationSchema, LocalClientSettings.schema['transport']).initiate_cache_for(
     'pysoa.common.transport.local:LocalClientTransport',
 )
 

--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -3,123 +3,31 @@ from __future__ import (
     unicode_literals,
 )
 
-import copy
-import itertools
-from typing import (  # noqa: F401 TODO Python 3
-    Any,
-    Dict,
-)
+import warnings
 
 from conformity import fields
-from conformity.error import ValidationError
-from conformity.validator import validate
-import six
+from conformity.settings import (  # noqa: F401 TODO Python 3
+    Settings as ConformitySettings,
+    SettingsData,
+    SettingsSchema,
+)
 
 from pysoa.common.metrics import MetricsSchema
 
 
-class _SettingsMetaclass(type):
+class Settings(ConformitySettings):
     """
-    Metaclass that gathers fields defined on settings objects into a single
-    variable to access them.
+    Deprecated. Use `conformity.settings.Settings`, instead.
     """
-
-    def __new__(mcs, name, bases, body):
-        # Don't allow multiple inheritance as it mucks up schema collecting
-        if len(bases) != 1:
-            raise TypeError('You cannot use multiple inheritance with Settings')
-        # Make the new class
-        cls = super(_SettingsMetaclass, mcs).__new__(mcs, name, bases, body)
-        # Merge the schema and defaults objects with their parents
-        if bases[0] is not object:
-            cls.schema = dict(itertools.chain(bases[0].schema.items(), cls.schema.items()))
-            cls.defaults = dict(itertools.chain(bases[0].defaults.items(), cls.defaults.items()))
-        return cls
-
-
-@six.add_metaclass(_SettingsMetaclass)
-class Settings(object):
-    """
-    Represents settings that can be passed to either a Client or a Server, and
-    then trickle down into lower levels, passed explicitly each time (no globals)
-
-    The base classes are designed to be inherited from and have their schema
-    extended, first into a Client and Server variant, and then into
-    implementation-specific variants to match subclasses of Client and Server.
-
-    Subclasses may define defaults as a dictionary. Defaults defined on a subclass
-    will be merged with the defaults of its parent, but only to a depth of 1. For
-    example:
-
-        class BaseSettings(Settings):
-            defaults = {
-                'foo': 1,
-                'bar': {'baz': 2},
-            }
-
-        class MySettings(BaseSettings):
-            defaults = {
-                'bar': {'baz': 3}
-            }
-
-    The class MySettings will have the defaults {'foo': 1, 'bar': {'baz': 3}}. This
-    provides a measure of convenience while discouraging deep inheritance structures.
-
-    To use Settings, instantiate the class with the raw settings value, and then
-    access the items using dict syntax - e.g. settings_instance['transport']. The class
-    will merge any passed values into its defaults.
-    """
-
-    schema = {}  # type: Dict[six.text_type, fields.Base]
-    defaults = {}  # type: Dict[six.text_type, Any]
-
-    class ImproperlyConfigured(Exception):
-        """Raised when a configuration validation fails."""
-        pass
-
     def __init__(self, data):
-        self._data = {}
-        self.set(data)
-
-    def _merge_dicts(self, data, defaults):
-        for key, value in data.items():
-            if key in defaults and isinstance(value, dict) and isinstance(defaults[key], dict):
-                self._merge_dicts(value, defaults[key])
-            else:
-                defaults[key] = value
-
-    def set(self, data):
-        """
-        Sets the value of this settings object in its entirety.
-        """
-        settings = copy.deepcopy(self.defaults)
-        data = copy.deepcopy(data)
-        self._merge_dicts(data, settings)
-        # Make sure all values were populated
-        unpopulated_keys = set(self.schema.keys()) - set(settings.keys())
-        if unpopulated_keys:
-            raise self.ImproperlyConfigured(
-                'No value provided for required setting(s): {}'.format(', '.join(unpopulated_keys))
-            )
-        unconsumed_keys = set(settings.keys()) - set(self.schema.keys())
-        if unconsumed_keys:
-            raise self.ImproperlyConfigured('Unknown setting(s): {}'.format(', '.join(unconsumed_keys)))
-        for key, value in settings.items():
-            # Validate the value
-            try:
-                validate(self.schema[key], value, "setting '{}'".format(key))
-            except ValidationError as e:
-                raise self.ImproperlyConfigured(*e.args)
-            self._data[key] = value
-
-    def __getitem__(self, key):
-        return self._data[key]
-
-    def __contains__(self, key):
-        return key in self._data
+        warnings.warn(
+            'pysoa.common.settings.Settings is deprecated. Use conformity.settings.ConformitySettings, instead.',
+            DeprecationWarning,
+        )
+        super(Settings, self).__init__(data)
 
 
-class SOASettings(Settings):
+class SOASettings(ConformitySettings):
     """
     Settings shared between client and server.
     """
@@ -131,9 +39,9 @@ class SOASettings(Settings):
             description='The list of all middleware objects that should be applied to this server or client',
         ),
         'metrics': MetricsSchema(),
-    }  # type: Dict[six.text_type, fields.Base]
+    }  # type: SettingsSchema
 
     defaults = {
         'middleware': [],
         'metrics': {'path': 'pysoa.common.metrics:NoOpMetricsRecorder'},
-    }  # type: Dict[six.text_type, Any]
+    }  # type: SettingsData

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -11,6 +11,7 @@ from functools import wraps
 import re
 
 from conformity import fields
+from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
 import six
 
 from pysoa.client.client import (
@@ -84,7 +85,7 @@ class StubClientSettings(ClientSettings):
         'transport': {
             'path': 'pysoa.test.stub_service:StubClientTransport'
         }
-    }
+    }  # type: SettingsData
 
 
 class StubClient(Client):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def readme():
 
 base_requirements = [
     'attrs>=17.4,<20',
-    'conformity~=1.25',
+    'conformity~=1.26',
     'currint>=1.6,<3',
     'enum34;python_version<"3.4"',
     'msgpack-python~=0.5,>=0.5.2',

--- a/tests/unit/common/test_settings.py
+++ b/tests/unit/common/test_settings.py
@@ -5,7 +5,7 @@ from __future__ import (
 
 import unittest
 
-from conformity import fields
+from conformity.settings import Settings
 import pytest
 
 from pysoa.client.client import Client
@@ -15,186 +15,13 @@ from pysoa.common.serializer import (
     JSONSerializer,
     MsgpackSerializer,
 )
-from pysoa.common.settings import (
-    Settings,
-    SOASettings,
-)
+from pysoa.common.settings import SOASettings
 from pysoa.common.transport.redis_gateway.client import RedisClientTransport
 from pysoa.common.transport.redis_gateway.constants import REDIS_BACKEND_TYPE_STANDARD
 from pysoa.common.transport.redis_gateway.core import RedisTransportCore
 from pysoa.common.transport.redis_gateway.server import RedisServerTransport
 from pysoa.server.server import Server
 from pysoa.server.settings import ServerSettings
-
-
-class SettingsWithSimpleSchema(Settings):
-    schema = {
-        'required_property': fields.Integer(),
-        'property_with_default': fields.Integer(),
-    }
-
-    defaults = {
-        'property_with_default': 0,
-    }
-
-
-class SettingsWithDefaults(Settings):
-    schema = {
-        'complex_property': fields.Dictionary({
-            'string_property': fields.UnicodeString(),
-            'int_property': fields.Integer(),
-            'kwargs': fields.Dictionary({
-                'foo': fields.Integer(),
-                'bar': fields.UnicodeString(),
-            }),
-        }),
-        'simple_property': fields.Integer(),
-    }
-
-    defaults = {
-        'simple_property': 0,
-        'complex_property': {
-            'string_property': 'default_string',
-            'kwargs': {
-                'foo': 1,
-            },
-        },
-    }
-
-
-class TestSettings(object):
-    """Tests for settings class inheritance and initialization behavior."""
-
-    def test_top_level_schema_keys_required(self):
-        """All keys in the top level of the schema are required."""
-        with pytest.raises(Settings.ImproperlyConfigured):
-            SettingsWithSimpleSchema({})
-
-        settings = SettingsWithSimpleSchema({
-            'required_property': 0,
-        })
-        assert settings['required_property'] == 0
-
-    def test_extra_top_level_key_fail(self):
-        """Any keys not in the top level of the schema cause validation to fail."""
-        with pytest.raises(Settings.ImproperlyConfigured):
-            SettingsWithSimpleSchema({
-                'other_property': 'foo',
-            })
-
-    def test_incorrect_nested_value_fails(self):
-        """Values with incorrect types cause validation to fail."""
-        with pytest.raises(Settings.ImproperlyConfigured):
-            SettingsWithDefaults({})
-
-        with pytest.raises(Settings.ImproperlyConfigured):
-            SettingsWithDefaults({
-                'complex_property': {'kwargs': {'foo': 'asdf'}},
-            })
-
-    def test_data_fields_merge_with_defaults(self):
-        """Passed data is merged with the class defaults."""
-        settings = SettingsWithDefaults({
-            'simple_property': 1,
-            'complex_property': {
-                'int_property': 2,
-                'kwargs': {
-                    'bar': 'four',
-                },
-            },
-        })
-        assert settings['simple_property'] == 1
-        assert settings['complex_property']['string_property'] == 'default_string'
-        assert settings['complex_property']['kwargs']['foo'] == 1
-        assert settings['complex_property']['kwargs']['bar'] == 'four'
-
-    def test_top_level_defaults_inherited(self):
-        """Defaults at the top level of the defaults dict are inherited."""
-        class MySettings(SettingsWithSimpleSchema):
-            defaults = {
-                'required_property': 1,
-            }
-
-        assert MySettings.defaults['property_with_default'] == 0
-        assert MySettings({})['required_property'] == 1
-
-    def test_top_level_schema_inherited(self):
-        """Schema items at the top level of the schema dict are inherited."""
-        class MySettings(SettingsWithSimpleSchema):
-            schema = {
-                'another_property': fields.Integer(),
-            }
-
-        assert MySettings.schema['another_property']
-        with pytest.raises(Settings.ImproperlyConfigured):
-            MySettings({'required_property': 1})
-        assert MySettings({
-            'required_property': 1,
-            'another_property': 2,
-        })['another_property'] == 2
-
-    def test_nested_defaults_not_inherited(self):
-        """Defaults nested deeper than the top level of the default dict are not inherited."""
-        class MySettings(SettingsWithDefaults):
-            defaults = {
-                'complex_property': {
-                    'int_property': 0,
-                }
-            }
-        with pytest.raises(Settings.ImproperlyConfigured):
-            # If nested defaults were inherited, only kwargs would be required
-            MySettings({
-                'complex_property': {
-                    'kwargs': {
-                        'foo': 1,
-                        'bar': 'four',
-                    },
-                },
-            })
-
-    def test_nested_schema_not_inherited(self):
-        """Schema items deeper than the top level of the schema dict are not inherited."""
-        class MySettings(SettingsWithDefaults):
-            schema = {
-                'complex_property': fields.Dictionary({
-                    'another_property': fields.Integer(),
-                }),
-            }
-
-        with pytest.raises(Settings.ImproperlyConfigured):
-            # If nested schema items were inherited, keys from the parent class would
-            # not cause validation to fail.
-            MySettings({
-                'simple_property': 1,
-                'complex_property': {
-                    'int_property': 2,
-                    'kwargs': {
-                        'bar': 'four',
-                    },
-                    'another_property': 1,
-                },
-            })
-
-        with pytest.raises(Settings.ImproperlyConfigured):
-            # This happens because the inherited defaults no longer match the new schema.
-            MySettings({
-                'simple_property': 1,
-                'complex_property': {
-                    'another_property': 1,
-                }
-            })
-
-        # If we override the defaults to match the schema, it works
-        class MyCorrectSetting(MySettings):
-            defaults = {
-                'complex_property': {
-                    'another_property': 1,
-                },
-            }
-
-        settings = MyCorrectSetting({})
-        assert settings['complex_property']['another_property'] == 1
-        assert settings['simple_property'] == 0
 
 
 class TestSOASettings(unittest.TestCase):
@@ -310,10 +137,10 @@ class TestSOASettings(unittest.TestCase):
             },
         }
 
-        with self.assertRaises(Settings.ImproperlyConfigured) as error_context:
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
             ServerSettings(settings_dict)
 
-        assert 'is not one of or a subclass of one of' in error_context.exception.args[0]
+        assert 'is not one of or a subclass of one of' in error_context.value.args[0]
 
     def test_client_settings_fails_with_server_transport(self):
         """The client settings fail to validate with server transport"""
@@ -327,11 +154,11 @@ class TestSOASettings(unittest.TestCase):
             },
         }
 
-        with self.assertRaises(Settings.ImproperlyConfigured) as error_context:
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
             ClientSettings(settings_dict)
 
-        assert 'is not one of or a subclass of one of' in error_context.exception.args[0]
-        assert 'RedisServerTransport' in error_context.exception.args[0]
+        assert 'is not one of or a subclass of one of' in error_context.value.args[0]
+        assert 'RedisServerTransport' in error_context.value.args[0]
 
     def test_client_settings_fails_with_invalid_path(self):
         """The client settings fail to validate with non-existent transport"""
@@ -345,11 +172,11 @@ class TestSOASettings(unittest.TestCase):
             },
         }
 
-        with self.assertRaises(Settings.ImproperlyConfigured) as error_context:
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
             ClientSettings(settings_dict)
 
-        assert 'has no attribute' in error_context.exception.args[0]
-        assert 'NonExistentTransport' in error_context.exception.args[0]
+        assert 'has no attribute' in error_context.value.args[0]
+        assert 'NonExistentTransport' in error_context.value.args[0]
 
     def test_server_settings_fails_with_invalid_serializer(self):
         """The server settings fail to validate with server middleware as serializer"""
@@ -366,11 +193,11 @@ class TestSOASettings(unittest.TestCase):
             },
         }
 
-        with self.assertRaises(Settings.ImproperlyConfigured) as error_context:
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
             ServerSettings(settings_dict)
 
-        assert 'is not one of or a subclass of one of' in error_context.exception.args[0]
-        assert 'ServerMiddleware' in error_context.exception.args[0]
+        assert 'is not one of or a subclass of one of' in error_context.value.args[0]
+        assert 'ServerMiddleware' in error_context.value.args[0]
 
     def test_server_settings_fails_with_client_middleware(self):
         """The server settings fail to validate with client middleware"""
@@ -387,11 +214,11 @@ class TestSOASettings(unittest.TestCase):
             ],
         }
 
-        with self.assertRaises(Settings.ImproperlyConfigured) as error_context:
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
             ServerSettings(settings_dict)
 
-        assert 'is not one of or a subclass of one of' in error_context.exception.args[0]
-        assert 'ClientMiddleware' in error_context.exception.args[0]
+        assert 'is not one of or a subclass of one of' in error_context.value.args[0]
+        assert 'ClientMiddleware' in error_context.value.args[0]
 
         settings_dict['middleware'][0]['path'] = 'pysoa.server.middleware:ServerMiddleware'
 
@@ -412,11 +239,11 @@ class TestSOASettings(unittest.TestCase):
             ],
         }
 
-        with self.assertRaises(Settings.ImproperlyConfigured) as error_context:
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
             ClientSettings(settings_dict)
 
-        assert 'is not one of or a subclass of one of' in error_context.exception.args[0]
-        assert 'ServerMiddleware' in error_context.exception.args[0]
+        assert 'is not one of or a subclass of one of' in error_context.value.args[0]
+        assert 'ServerMiddleware' in error_context.value.args[0]
 
         settings_dict['middleware'][0]['path'] = 'pysoa.client.middleware:ClientMiddleware'
 


### PR DESCRIPTION
Use Conformity 1.26's new `Settings` and other features in order to remove a bunch of code from PySOA and deprecated PySOA's `Settings`.