### PR TITLE
[PATCH] Fix tests broken by releasing 0.70.0

### DIFF
--- a/pysoa/common/metrics.py
+++ b/pysoa/common/metrics.py
@@ -10,6 +10,7 @@ from typing import (  # noqa: F401 TODO Python 3
     Optional,
     Union,
 )
+from typing_extensions import Literal
 
 from conformity import fields
 import six
@@ -77,7 +78,7 @@ class Timer(Histogram):
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):  # type: (Any, Any, Any) -> bool
+    def __exit__(self, exc_type, exc_value, traceback):  # type: (Any, Any, Any) -> Literal[False]
         """
         Stops the timer at the end of the context manager. All parameters are ignored. Always returns ``False``.
 

--- a/pysoa/server/internal/types.py
+++ b/pysoa/server/internal/types.py
@@ -9,6 +9,7 @@ from typing import (  # noqa: F401 TODO Python 3
     Optional,
     SupportsInt,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -66,9 +67,9 @@ class SwitchSet(frozenset):
     """
 
     def __new__(
-        cls,
+        cls,  # type: Type[_S]
         switches=None,  # type: Optional[Iterable[Union[SupportsInt, SupportsIntValue]]]
-    ):  # type: (...) -> Type[SwitchSet]
+    ):  # type: (...) -> _S
         """
         Create a new uninitialized `SwitchSet` instance.
 
@@ -89,6 +90,9 @@ class SwitchSet(frozenset):
         :return: A boolean indicating whether the switch is active (in the set)
         """
         return super(SwitchSet, self).__contains__(get_switch(switch))  # type: ignore
+
+
+_S = TypeVar('_S', bound=SwitchSet)
 
 
 class RequestSwitchSet(SwitchSet):

--- a/pysoa/test/plan/__init__.py
+++ b/pysoa/test/plan/__init__.py
@@ -19,6 +19,7 @@ from typing import (  # noqa: F401 TODO Python 3
     Type,
     Union,
 )
+from typing_extensions import Literal
 
 import attr
 import six
@@ -766,7 +767,7 @@ class ServicePlanTestCase(ServerTestCase):
             return None
 
         def __exit__(self, exc_type=None, exc_value=None, traceback=None):
-            # type: (Any, Any, Any) -> bool
+            # type: (Any, Any, Any) -> Literal[False]
             if self._stub_action_context:
                 return self._stub_action_context.__exit__(exc_type, exc_value, traceback)
             return False

--- a/pysoa/test/plan/grammar/directives/expects_errors.py
+++ b/pysoa/test/plan/grammar/directives/expects_errors.py
@@ -130,12 +130,12 @@ class ActionExpectsErrorsDirective(ActionDirective):
         # noinspection PyTypeChecker
         errors.append(Error(  # type: ignore
             code=parse_results.error_code,
-            message=getattr(parse_results, 'error_message', None) or AnyValue('str'),
-            field=getattr(parse_results, 'field_name', None) or AnyValue('str', permit_none=True),
-            traceback=AnyValue('str', permit_none=True),
-            variables=AnyValue('dict', permit_none=True),
-            denied_permissions=AnyValue('list', permit_none=True),
-            is_caller_error=AnyValue('bool'),
+            message=getattr(parse_results, 'error_message', None) or AnyValue('str'),  # type: ignore
+            field=getattr(parse_results, 'field_name', None) or AnyValue('str', permit_none=True),  # type: ignore
+            traceback=AnyValue('str', permit_none=True),  # type: ignore
+            variables=AnyValue('dict', permit_none=True),  # type: ignore
+            denied_permissions=AnyValue('list', permit_none=True),  # type: ignore
+            is_caller_error=AnyValue('bool'),  # type: ignore
         ))
 
     def assert_test_case_action_results(

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -24,6 +24,7 @@ from typing import (  # noqa: F401 TODO Python 3
     Union,
     cast,
 )
+from typing_extensions import Literal
 
 from conformity import fields
 from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
@@ -609,7 +610,7 @@ class stub_action(object):
         self.enabled = True
         return self._current_mock_action
 
-    def __exit__(self, exc_type=None, exc_value=None, traceback=None):  # type: (Any, Any, Any) -> bool
+    def __exit__(self, exc_type=None, exc_value=None, traceback=None):  # type: (Any, Any, Any) -> Literal[False]
         if not self.enabled:
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ tests_require = [
     'freezegun~=0.3',
     'lunatic-python-universal~=2.1',
     'mockredispy~=2.9',
-    'mypy;python_version>"3.4"',
+    'mypy~=0.730;python_version>"3.4"',
     'pytest-runner',
 ] + test_plan_requirements
 

--- a/tests/integration/test_send_receive.py
+++ b/tests/integration/test_send_receive.py
@@ -338,7 +338,7 @@ class TestClientSendReceive(TestCase):
                 'body': {},
             },
         ]  # type: List[Dict[six.text_type, Any]]
-        error_expected = Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo')
+        error_expected = Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo', is_caller_error=True)
         self.client_settings[SERVICE_NAME]['transport']['kwargs']['action_map']['action_2'] = {
             'errors': [error_expected],
         }
@@ -493,7 +493,7 @@ class TestClientParallelSendReceive(TestCase):
         self.assertEqual({'cat': 'dog'}, action_responses[0].body)
         self.assertEqual({}, action_responses[1].body)
         self.assertEqual(
-            [Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo')],
+            [Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo', is_caller_error=True)],
             action_responses[1].errors,
         )
         self.assertEqual({'selected': True, 'count': 7}, action_responses[2].body)
@@ -565,7 +565,7 @@ class TestClientParallelSendReceive(TestCase):
             )
 
         self.assertEqual(
-            [Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo')],
+            [Error(code=ERROR_CODE_INVALID, message='Invalid input', field='foo', is_caller_error=True)],
             error_context.exception.actions[0].errors,
         )
 

--- a/tests/unit/test/test_stub_service.py
+++ b/tests/unit/test/test_stub_service.py
@@ -840,6 +840,7 @@ class TestStubAction(ServerTestCase):
                 code='UNKNOWN',
                 message='The action "does_not_exist" was not found on this server.',
                 field='action',
+                is_caller_error=True,
             )],
             job_responses[3].actions[0].errors
         )

--- a/tox.ini
+++ b/tox.ini
@@ -40,12 +40,12 @@ commands =
 
 [testenv:py27-flake8]
 skip_install = true
-deps = flake8
+deps = flake8~=3.7,>=3.7.8
 commands = flake8
 
 [testenv:py37-flake8]
 skip_install = true
-deps = flake8
+deps = flake8~=3.7,>=3.7.8
 commands = flake8
 
 [testenv:coverage]


### PR DESCRIPTION
Since we weren't transmitting `is_caller_error` between client and server unless the client reported that it was running version 0.70.0 or newer, certain tests that were passing before PySOA 0.70.0 was released started failing after it was released, because `is_caller_error` started getting transmitted in the correct situations. In a sense, this pass-before-fail-after behavior actually verified that our blacklisting of the attribute for older clients worked properly. This simple commit fixes those four breaking tests.