### PR TITLE
[PATCH] Remove noqa comments now that Flake8 3.7.8 is out

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,9 +4,9 @@ from __future__ import (
 )
 
 import sys
-from typing import List  # noqa: F401 TODO Python 3
+from typing import List
 
-import six  # noqa: F401 TODO Python 3
+import six
 
 
 # Skip event loop tests for Python versions less than 3.5

--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -7,7 +7,7 @@ import collections
 import random
 import sys
 from types import TracebackType
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     AbstractSet,
     Any,
     Callable,
@@ -29,11 +29,11 @@ from typing import (  # noqa: F401 TODO Python 3
 import uuid
 
 import attr
-from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
+from conformity.settings import SettingsData
 import six
 
 from pysoa.version import __version_info__
-from pysoa.client.expander import (  # noqa: F401 TODO Python 3
+from pysoa.client.expander import (
     ExpansionConverter,
     ExpansionNode,
     Expansions,
@@ -41,17 +41,17 @@ from pysoa.client.expander import (  # noqa: F401 TODO Python 3
     TypeExpansions,
     TypeRoutes,
 )
-from pysoa.client.middleware import (  # noqa: F401 TODO Python 3
+from pysoa.client.middleware import (
     ClientMiddleware,
     ClientRequestMiddlewareTask,
     ClientResponseMiddlewareTask,
 )
 from pysoa.client.settings import ClientSettings
-from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+from pysoa.common.metrics import (
     MetricsRecorder,
     TimerResolution,
 )
-from pysoa.common.transport.base import ClientTransport  # noqa: F401 TODO Python 3
+from pysoa.common.transport.base import ClientTransport
 from pysoa.common.transport.exceptions import (
     ConnectionError,
     InvalidMessageError,
@@ -61,7 +61,7 @@ from pysoa.common.transport.exceptions import (
     MessageSendTimeout,
     MessageTooLarge,
 )
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
     Body,

--- a/pysoa/client/expander.py
+++ b/pysoa/client/expander.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     List,
@@ -13,7 +13,7 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 
 from conformity import fields
-from conformity.settings import (  # noqa: F401 TODO Python 3
+from conformity.settings import (
     Settings,
     SettingsSchema,
 )

--- a/pysoa/client/middleware.py
+++ b/pysoa/client/middleware.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Callable,
     Dict,
@@ -12,9 +12,9 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 
 from conformity import fields
-import six  # noqa: F401 TODO Python 3
+import six
 
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     JobRequest,
     JobResponse,
 )

--- a/pysoa/client/settings.py
+++ b/pysoa/client/settings.py
@@ -6,7 +6,7 @@ from __future__ import (
 import warnings
 
 from conformity import fields
-from conformity.settings import (  # noqa: F401 TODO Python 3
+from conformity.settings import (
     SettingsData,
     SettingsSchema,
 )

--- a/pysoa/common/compatibility.py
+++ b/pysoa/common/compatibility.py
@@ -5,7 +5,7 @@ from __future__ import (
 
 import sys
 import threading
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Generic,
     Optional,
@@ -13,7 +13,7 @@ from typing import (  # noqa: F401 TODO Python 3
     cast,
 )
 
-import six  # noqa: F401 TODO Python 3
+import six
 
 
 try:

--- a/pysoa/common/logging.py
+++ b/pysoa/common/logging.py
@@ -6,7 +6,7 @@ from __future__ import (
 import logging
 import logging.handlers
 import socket
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Iterable,
@@ -23,7 +23,7 @@ from typing import (  # noqa: F401 TODO Python 3
 import six
 
 from pysoa.common.compatibility import ContextVar
-from pysoa.common.types import Context  # noqa: F401 TODO Python 3
+from pysoa.common.types import Context
 
 
 __all__ = (

--- a/pysoa/common/metrics.py
+++ b/pysoa/common/metrics.py
@@ -5,7 +5,7 @@ from __future__ import (
 
 import abc
 import enum
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Optional,
     Union,

--- a/pysoa/common/serializer/base.py
+++ b/pysoa/common/serializer/base.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import abc
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Dict,
     FrozenSet,
     Type,

--- a/pysoa/common/serializer/json_serializer.py
+++ b/pysoa/common/serializer/json_serializer.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import json
-from typing import Dict  # noqa: F401 TODO Python 3
+from typing import Dict
 
 from conformity import fields
 import six

--- a/pysoa/common/serializer/msgpack_serializer.py
+++ b/pysoa/common/serializer/msgpack_serializer.py
@@ -8,7 +8,7 @@ from __future__ import (
 import datetime
 import decimal
 import struct
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
 )

--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -6,7 +6,7 @@ from __future__ import (
 import warnings
 
 from conformity import fields
-from conformity.settings import (  # noqa: F401 TODO Python 3
+from conformity.settings import (
     Settings as ConformitySettings,
     SettingsData,
     SettingsSchema,

--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -19,7 +19,7 @@ from __future__ import (
 
 import abc
 import threading
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     NamedTuple,

--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 from collections import deque
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Deque,
     Dict,
@@ -18,7 +18,7 @@ from typing import (  # noqa: F401 TODO Python 3
 from conformity import fields
 import six
 
-from pysoa.common.metrics import MetricsRecorder  # noqa: F401 TODO Python 3
+from pysoa.common.metrics import MetricsRecorder
 from pysoa.common.transport.base import (
     ClientTransport,
     ReceivedMessage,

--- a/pysoa/common/transport/redis_gateway/backend/base.py
+++ b/pysoa/common/transport/redis_gateway/backend/base.py
@@ -7,18 +7,18 @@ import abc
 import binascii
 import itertools
 import random
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Callable,
     List,
     Optional,
 )
 
-import redis  # noqa: F401 TODO Python 3
-import redis.client  # noqa: F401 TODO Python 3
+import redis
+import redis.client
 import six
 
-from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+from pysoa.common.metrics import (
     Counter,
     NoOpMetricsRecorder,
 )

--- a/pysoa/common/transport/redis_gateway/backend/sentinel.py
+++ b/pysoa/common/transport/redis_gateway/backend/sentinel.py
@@ -6,7 +6,7 @@ from __future__ import (
 import itertools
 import random
 import time
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Iterable,

--- a/pysoa/common/transport/redis_gateway/backend/standard.py
+++ b/pysoa/common/transport/redis_gateway/backend/standard.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Iterable,

--- a/pysoa/common/transport/redis_gateway/client.py
+++ b/pysoa/common/transport/redis_gateway/client.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Optional,
@@ -11,9 +11,9 @@ from typing import (  # noqa: F401 TODO Python 3
 import uuid
 
 from conformity import fields
-import six  # noqa: F401 TODO Python 3
+import six
 
-from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+from pysoa.common.metrics import (
     MetricsRecorder,
     TimerResolution,
 )

--- a/pysoa/common/transport/redis_gateway/constants.py
+++ b/pysoa/common/transport/redis_gateway/constants.py
@@ -5,9 +5,9 @@ from __future__ import (
 
 import enum
 import re
-from typing import Tuple  # noqa: F401 TODO Python 3
+from typing import Tuple
 
-import six  # noqa: F401 TODO Python 3
+import six
 
 
 __all__ = (

--- a/pysoa/common/transport/redis_gateway/core.py
+++ b/pysoa/common/transport/redis_gateway/core.py
@@ -11,7 +11,7 @@ import math
 import random
 import re
 import time
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     FrozenSet,
@@ -28,7 +28,7 @@ import redis
 import six
 
 from pysoa.common.logging import RecursivelyCensoredDictWrapper
-from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+from pysoa.common.metrics import (
     Counter,
     Histogram,
     MetricsRecorder,
@@ -46,7 +46,7 @@ from pysoa.common.transport.exceptions import (
     MessageSendError,
     MessageTooLarge,
 )
-from pysoa.common.transport.redis_gateway.backend.base import (  # noqa: F401 TODO Python 3
+from pysoa.common.transport.redis_gateway.backend.base import (
     BaseRedisClient,
     CannotGetConnectionError,
 )

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -3,19 +3,19 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
 )
 
 from conformity import fields
-import six  # noqa: F401 TODO Python 3
+import six
 
-from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+from pysoa.common.metrics import (
     MetricsRecorder,
     TimerResolution,
 )
-from pysoa.common.transport.base import (  # noqa: F401 TODO Python 3
+from pysoa.common.transport.base import (
     ReceivedMessage,
     ServerTransport,
 )

--- a/pysoa/common/transport/redis_gateway/utils.py
+++ b/pysoa/common/transport/redis_gateway/utils.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-import six  # noqa: F401 TODO Python 3
+import six
 
 
 def make_redis_queue_name(service_name):  # type: (six.text_type) -> six.text_type

--- a/pysoa/common/types.py
+++ b/pysoa/common/types.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Iterable,

--- a/pysoa/server/action/base.py
+++ b/pysoa/server/action/base.py
@@ -4,14 +4,14 @@ from __future__ import (
 )
 
 import abc
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Optional,
     Union,
 )
 
-from conformity import fields  # noqa: F401 TODO Python 3
+from conformity import fields
 import six
 
 from pysoa.common.types import (
@@ -22,8 +22,8 @@ from pysoa.server.errors import (
     ActionError,
     ResponseValidationError,
 )
-from pysoa.server.settings import ServerSettings  # noqa: F401 TODO Python 3
-from pysoa.server.types import (  # noqa: F401 TODO Python 3
+from pysoa.server.settings import ServerSettings
+from pysoa.server.types import (
     ActionInterface,
     EnrichedActionRequest,
 )

--- a/pysoa/server/action/introspection.py
+++ b/pysoa/server/action/introspection.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import re
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Generator,
@@ -26,7 +26,7 @@ from pysoa.server.action.switched import SwitchedAction
 from pysoa.server.errors import ActionError
 from pysoa.server.internal.types import get_switch
 from pysoa.server.server import Server
-from pysoa.server.types import (  # noqa: F401 TODO Python 3
+from pysoa.server.types import (
     ActionType,
     EnrichedActionRequest,
 )

--- a/pysoa/server/action/status.py
+++ b/pysoa/server/action/status.py
@@ -6,7 +6,7 @@ from __future__ import (
 import abc
 import platform
 import sys
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Callable,
     Dict,
@@ -25,9 +25,9 @@ import six
 
 import pysoa
 from pysoa.server.action import Action
-from pysoa.server.server import Server  # noqa: F401 TODO Python 3
-from pysoa.server.settings import ServerSettings  # noqa: F401 TODO Python 3
-from pysoa.server.types import EnrichedActionRequest  # noqa: F401 TODO Python 3
+from pysoa.server.server import Server
+from pysoa.server.settings import ServerSettings
+from pysoa.server.types import EnrichedActionRequest
 
 
 __all__ = (

--- a/pysoa/server/action/switched.py
+++ b/pysoa/server/action/switched.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import abc
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Optional,
     Sequence,
@@ -15,13 +15,13 @@ from typing import (  # noqa: F401 TODO Python 3
 
 import six
 
-from pysoa.common.types import ActionResponse  # noqa: F401 TODO Python 3
-from pysoa.server.internal.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import ActionResponse
+from pysoa.server.internal.types import (
     SupportsIntValue,
     is_switch,
 )
-from pysoa.server.settings import ServerSettings  # noqa: F401 TODO Python 3
-from pysoa.server.types import (  # noqa: F401 TODO Python 3
+from pysoa.server.settings import ServerSettings
+from pysoa.server.types import (
     ActionType,
     EnrichedActionRequest,
 )

--- a/pysoa/server/autoreload.py
+++ b/pysoa/server/autoreload.py
@@ -58,8 +58,8 @@ import subprocess
 import sys
 import threading
 import time
-from types import ModuleType  # noqa: F401 TODO Python 3
-from typing import (  # noqa: F401 TODO Python 3
+from types import ModuleType
+from typing import (
     Dict,
     List,
     Optional,

--- a/pysoa/server/django/cache.py
+++ b/pysoa/server/django/cache.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import Any  # noqa: F401 TODO Python 3
+from typing import Any
 
 from django.core.cache.backends.locmem import LocMemCache
 from django.core.cache.backends.memcached import (

--- a/pysoa/server/errors.py
+++ b/pysoa/server/errors.py
@@ -3,17 +3,17 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Generator,
     Iterable,
     List,
     Optional,
 )
 
-from conformity.error import Error as ConformityError  # noqa: F401 TODO Python 3
-import six  # noqa: F401 TODO Python 3
+from conformity.error import Error as ConformityError
+import six
 
-from pysoa.common.types import Error  # noqa: F401 TODO Python 3
+from pysoa.common.types import Error
 
 
 def _replace_error_if_necessary(errors, is_caller_error):

--- a/pysoa/server/internal/event_loop.py
+++ b/pysoa/server/internal/event_loop.py
@@ -14,7 +14,7 @@ from typing import (
 from conformity import fields
 
 from pysoa.common.compatibility import set_running_loop
-from pysoa.server.coroutine import (  # noqa: F401 TODO Python 3
+from pysoa.server.coroutine import (
     Coroutine,
     CoroutineMiddleware,
 )

--- a/pysoa/server/internal/types.py
+++ b/pysoa/server/internal/types.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Iterable,
     Optional,

--- a/pysoa/server/middleware.py
+++ b/pysoa/server/middleware.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
@@ -11,9 +11,9 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 
 from conformity import fields
-import six  # noqa: F401 TODO Python 3
+import six
 
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     ActionResponse,
     JobResponse,
 )
@@ -21,7 +21,7 @@ from pysoa.common.types import (  # noqa: F401 TODO Python 3
 
 if TYPE_CHECKING:
     # To prevent circular imports
-    from pysoa.server.types import EnrichedActionRequest  # noqa: F401 TODO Python 3
+    from pysoa.server.types import EnrichedActionRequest
 
 
 __all__ = (

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -15,8 +15,8 @@ import sys
 import threading
 import time
 import traceback
-from types import FrameType  # noqa: F401 TODO Python 3
-from typing import (  # noqa: F401 TODO Python 3
+from types import FrameType
+from typing import (
     Any,
     Callable,
     Dict,
@@ -44,19 +44,19 @@ from pysoa.common.logging import (
     PySOALogContextFilter,
     RecursivelyCensoredDictWrapper,
 )
-from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+from pysoa.common.metrics import (
     MetricsRecorder,
     Timer,
     TimerResolution,
 )
 from pysoa.common.serializer.exceptions import InvalidField
-from pysoa.common.transport.base import ServerTransport  # noqa: F401 TODO Python 3
+from pysoa.common.transport.base import ServerTransport
 from pysoa.common.transport.exceptions import (
     MessageReceiveError,
     MessageReceiveTimeout,
     MessageTooLarge,
 )
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     ActionResponse,
     Context,
     Error,
@@ -68,10 +68,10 @@ from pysoa.server.errors import (
     JobError,
 )
 from pysoa.server.internal.types import RequestSwitchSet
-from pysoa.server.middleware import ServerMiddleware  # noqa: F401 TODO Python 3
+from pysoa.server.middleware import ServerMiddleware
 from pysoa.server.schemas import JobRequestSchema
 from pysoa.server.settings import ServerSettings
-from pysoa.server.types import (  # noqa: F401 TODO Python 3
+from pysoa.server.types import (
     ActionType,
     EnrichedActionRequest,
 )

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
 )
@@ -14,11 +14,11 @@ from conformity.fields.logging import (
     PYTHON_LOGGING_CONFIG_SCHEMA,
     PythonLogLevel,
 )
-from conformity.settings import (  # noqa: F401 TODO Python 3
+from conformity.settings import (
     SettingsData,
     SettingsSchema,
 )
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.common.logging import SyslogHandler
 from pysoa.common.settings import SOASettings

--- a/pysoa/server/standalone.py
+++ b/pysoa/server/standalone.py
@@ -13,7 +13,7 @@ import signal
 import sys
 import threading
 import time
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Callable,
     Deque,
@@ -23,9 +23,9 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 
 import attr
-import six  # noqa: F401 TODO Python 3
+import six
 
-from pysoa.server.server import Server  # noqa: F401 TODO Python 3
+from pysoa.server.server import Server
 import pysoa.utils
 
 

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import abc
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Callable,
     Dict,
@@ -16,14 +16,14 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 
 import attr
-import six  # noqa: F401 TODO Python 3
+import six
 
-from pysoa.client.client import Client  # noqa: F401 TODO Python 3
+from pysoa.client.client import Client
 from pysoa.common.constants import (
     ERROR_CODE_SERVER_ERROR,
     ERROR_CODE_UNKNOWN,
 )
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
     Context,
@@ -31,7 +31,7 @@ from pysoa.common.types import (  # noqa: F401 TODO Python 3
     Error,
 )
 from pysoa.server.errors import ActionError
-from pysoa.server.internal.types import (  # noqa: F401 TODO Python 3
+from pysoa.server.internal.types import (
     RequestSwitchSet,
     SupportsIntValue,
 )

--- a/pysoa/test/assertions.py
+++ b/pysoa/test/assertions.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import contextlib
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Iterable,
@@ -21,7 +21,7 @@ import pytest
 import six
 
 from pysoa.client.client import Client
-from pysoa.common.types import Error  # noqa: F401 TODO Python 3
+from pysoa.common.types import Error
 
 
 __all__ = (

--- a/pysoa/test/factories.py
+++ b/pysoa/test/factories.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import importlib
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Optional,
@@ -12,12 +12,12 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 
 import factory
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.server.action import Action
 from pysoa.server.server import Server
 from pysoa.server.settings import ServerSettings
-from pysoa.server.types import EnrichedActionRequest  # noqa: F401 TODO Python 3
+from pysoa.server.types import EnrichedActionRequest
 
 
 class ServerSettingsFactory(factory.Factory):

--- a/pysoa/test/plan/__init__.py
+++ b/pysoa/test/plan/__init__.py
@@ -8,8 +8,8 @@ import os
 import re
 import sys
 import traceback
-from types import TracebackType  # noqa: F401 TODO Python 3
-from typing import (  # noqa: F401 TODO Python 3
+from types import TracebackType
+from typing import (
     Any,
     Dict,
     Generator,
@@ -24,15 +24,15 @@ from typing_extensions import Literal
 import attr
 import six
 
-from pysoa.common.types import Body  # noqa: F401 TODO Python 3
-from pysoa.test.compatibility import mock  # noqa: F401 TODO Python 3
+from pysoa.common.types import Body
+from pysoa.test.compatibility import mock
 from pysoa.test.plan import grammar
 from pysoa.test.plan.errors import (
     DirectiveError,
     FixtureLoadError,
     StatusError,
 )
-from pysoa.test.plan.grammar.directive import (  # noqa: F401 TODO Python 3
+from pysoa.test.plan.grammar.directive import (
     ActionCase,
     ActionResults,
     Directive,

--- a/pysoa/test/plan/grammar/assertions.py
+++ b/pysoa/test/plan/grammar/assertions.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import pprint
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     AbstractSet,
     Any,
     Dict,

--- a/pysoa/test/plan/grammar/data_types.py
+++ b/pysoa/test/plan/grammar/data_types.py
@@ -7,7 +7,7 @@ import base64
 import datetime
 import decimal
 import re
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     List,
@@ -17,7 +17,7 @@ from typing import (  # noqa: F401 TODO Python 3
     cast,
 )
 
-from pyparsing import (  # noqa: F401 TODO Python 3
+from pyparsing import (
     ParseResults,
     oneOf,
 )

--- a/pysoa/test/plan/grammar/directive.py
+++ b/pysoa/test/plan/grammar/directive.py
@@ -45,7 +45,7 @@ from __future__ import (
 
 import abc
 import sys
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     List,
@@ -55,7 +55,7 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 
 import pkg_resources
-from pyparsing import (  # noqa: F401 TODO Python 3
+from pyparsing import (
     Literal,
     Optional,
     ParserElement,
@@ -67,7 +67,7 @@ from pyparsing import (  # noqa: F401 TODO Python 3
 )
 import six
 
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     ActionResponse,
     JobResponse,
 )

--- a/pysoa/test/plan/grammar/tools.py
+++ b/pysoa/test/plan/grammar/tools.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import re
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     AbstractSet,
     Any,
     Dict,
@@ -16,7 +16,7 @@ from typing import (  # noqa: F401 TODO Python 3
     Union,
 )
 
-from pyparsing import (  # noqa: F401 TODO Python 3
+from pyparsing import (
     And,
     Literal,
     MatchFirst,

--- a/pysoa/test/plan/parser.py
+++ b/pysoa/test/plan/parser.py
@@ -7,7 +7,7 @@ import codecs
 import copy
 import functools
 import os
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     List,
@@ -15,7 +15,7 @@ from typing import (  # noqa: F401 TODO Python 3
     Type,
 )
 
-from pyparsing import (  # noqa: F401 TODO Python 3
+from pyparsing import (
     LineEnd,
     LineStart,
     MatchFirst,
@@ -29,14 +29,14 @@ from pyparsing import (  # noqa: F401 TODO Python 3
     line as get_parse_line,
     lineno as get_parse_line_number,
 )
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.test.plan.errors import (
     FixtureLoadError,
     FixtureSyntaxError,
 )
 from pysoa.test.plan.grammar.data_types import DataTypeConversionError
-from pysoa.test.plan.grammar.directive import (  # noqa: F401 TODO Python 3
+from pysoa.test.plan.grammar.directive import (
     Directive,
     TestCase,
     TestFixture,

--- a/pysoa/test/plugins/pytest/fixtures.py
+++ b/pysoa/test/plugins/pytest/fixtures.py
@@ -5,7 +5,7 @@ from __future__ import (
 
 import importlib
 import os
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Callable,
     Dict,
@@ -16,17 +16,17 @@ from typing import (  # noqa: F401 TODO Python 3
     cast,
 )
 
-from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
+from conformity.settings import SettingsData
 import pytest
 import six
 
 from pysoa.client.client import Client
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     ActionResponse,
     Body,
 )
 from pysoa.server.errors import ActionError
-from pysoa.server.server import Server  # noqa: F401 TODO Python 3
+from pysoa.server.server import Server
 from pysoa.test.compatibility import mock
 from pysoa.test.stub_service import (
     Errors,

--- a/pysoa/test/server.py
+++ b/pysoa/test/server.py
@@ -5,7 +5,7 @@ from __future__ import (
 
 import importlib
 import os
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Iterable,
@@ -17,11 +17,11 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 import unittest
 
-from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
-import six  # noqa: F401 TODO Python 3
+from conformity.settings import SettingsData
+import six
 
 from pysoa.client.client import Client
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     ActionResponse,
     Body,
     Error,

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -9,7 +9,7 @@ from collections import (
 )
 from functools import wraps
 import re
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Callable,
     Dict,
@@ -27,7 +27,7 @@ from typing import (  # noqa: F401 TODO Python 3
 from typing_extensions import Literal
 
 from conformity import fields
-from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
+from conformity.settings import SettingsData
 import six
 
 from pysoa.client.client import (
@@ -35,7 +35,7 @@ from pysoa.client.client import (
     ServiceHandler,
 )
 from pysoa.client.settings import ClientSettings
-from pysoa.common.metrics import (  # noqa: F401 TODO Python 3
+from pysoa.common.metrics import (
     MetricsRecorder,
     NoOpMetricsRecorder,
 )
@@ -44,7 +44,7 @@ from pysoa.common.transport.exceptions import (
     MessageReceiveTimeout,
 )
 from pysoa.common.transport.local import LocalClientTransport
-from pysoa.common.types import (  # noqa: F401 TODO Python 3
+from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
     Body,
@@ -57,7 +57,7 @@ from pysoa.server.errors import (
     JobError,
 )
 from pysoa.server.server import Server
-from pysoa.server.types import (  # noqa: F401 TODO Python 3
+from pysoa.server.types import (
     ActionType,
     EnrichedActionRequest,
 )

--- a/pysoa/utils.py
+++ b/pysoa/utils.py
@@ -6,7 +6,7 @@ from __future__ import (
 
 import ctypes
 import sys
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     FrozenSet,

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -4,9 +4,9 @@ from __future__ import (
 )
 
 import subprocess
-from typing import List  # noqa: F401 TODO Python 3
+from typing import List
 
-import six  # noqa: F401 TODO Python 3
+import six
 
 
 COMPOSE_FILE = 'tests/functional/docker/docker-compose.yaml'

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -4,9 +4,9 @@ from __future__ import (
 )
 
 import copy
-from typing import Dict  # noqa: F401 TODO Python 3
+from typing import Dict
 
-from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
+from conformity.settings import SettingsData
 import pytest
 
 from pysoa.client.client import Client

--- a/tests/integration/test/plan/test_001_fixtures_work.py
+++ b/tests/integration/test/plan/test_001_fixtures_work.py
@@ -7,12 +7,12 @@ import datetime
 import os
 import random
 import sys
-from typing import List  # noqa: F401 TODO Python 3
+from typing import List
 import unittest
 import uuid
 
 from conformity import fields
-from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
+from conformity.settings import SettingsData
 import pytest
 import six
 

--- a/tests/integration/test_send_receive.py
+++ b/tests/integration/test_send_receive.py
@@ -6,7 +6,7 @@ from __future__ import (
 import sys
 import traceback
 import types
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     List,
@@ -15,7 +15,7 @@ from unittest import TestCase
 
 from conformity import fields
 import pytest
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.client.client import Client
 from pysoa.client.middleware import ClientMiddleware

--- a/tests/unit/common/test_compatibility_threading.py
+++ b/tests/unit/common/test_compatibility_threading.py
@@ -6,7 +6,7 @@ from __future__ import (
 import contextlib
 import threading
 import time
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Dict,
     Optional,
 )

--- a/tests/unit/common/test_logging.py
+++ b/tests/unit/common/test_logging.py
@@ -12,7 +12,7 @@ from logging import (
 import logging.handlers
 import socket
 import threading
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Optional,

--- a/tests/unit/common/transport/redis_gateway/backend/test_sentinel.py
+++ b/tests/unit/common/transport/redis_gateway/backend/test_sentinel.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
 )
@@ -11,7 +11,7 @@ import unittest
 
 import msgpack
 import redis.sentinel
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.common.transport.redis_gateway.backend.base import CannotGetConnectionError
 from pysoa.common.transport.redis_gateway.backend.sentinel import SentinelRedisClient

--- a/tests/unit/common/transport/redis_gateway/test_client.py
+++ b/tests/unit/common/transport/redis_gateway/test_client.py
@@ -5,13 +5,13 @@ from __future__ import (
 
 import random
 import re
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
 )
 import unittest
 
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.base import get_hex_thread_id

--- a/tests/unit/common/transport/redis_gateway/test_core.py
+++ b/tests/unit/common/transport/redis_gateway/test_core.py
@@ -6,7 +6,7 @@ from __future__ import (
 import datetime
 import time
 import timeit
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
 )
@@ -14,7 +14,7 @@ from typing import (  # noqa: F401 TODO Python 3
 import attr
 import freezegun
 import pytest
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.common.serializer.json_serializer import JSONSerializer
 from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer

--- a/tests/unit/common/transport/redis_gateway/test_threading.py
+++ b/tests/unit/common/transport/redis_gateway/test_threading.py
@@ -5,13 +5,13 @@ from __future__ import (
 
 import threading
 import time
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Dict,
     List,
 )
 import unittest
 
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.common.metrics import NoOpMetricsRecorder
 from pysoa.common.transport.exceptions import MessageReceiveTimeout

--- a/tests/unit/server/action/test_switched.py
+++ b/tests/unit/server/action/test_switched.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Callable,
     Optional,
     SupportsInt,

--- a/tests/unit/server/test_autoreloader.py
+++ b/tests/unit/server/test_autoreloader.py
@@ -11,7 +11,7 @@ import signal
 import sys
 import tempfile
 import time
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Dict,
     Optional,
 )

--- a/tests/unit/server/test_server/test_handle_next_request.py
+++ b/tests/unit/server/test_server/test_handle_next_request.py
@@ -3,15 +3,15 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import Mapping  # noqa: F401 TODO Python 3
+from typing import Mapping
 from unittest import TestCase
 
 from conformity import fields
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.common.transport.base import ServerTransport
 from pysoa.server.server import Server
-from pysoa.server.types import ActionType  # noqa: F401 TODO Python 3
+from pysoa.server.types import ActionType
 from pysoa.test import factories
 
 

--- a/tests/unit/server/test_standalone.py
+++ b/tests/unit/server/test_standalone.py
@@ -8,8 +8,8 @@ import os
 import signal
 import sys
 import time
-from types import ModuleType  # noqa: F401 TODO Python 3
-from typing import Optional  # noqa: F401 TODO Python 3
+from types import ModuleType
+from typing import Optional
 import unittest
 
 import freezegun

--- a/tests/unit/test/plan/grammar/test_tools.py
+++ b/tests/unit/test/plan/grammar/test_tools.py
@@ -3,13 +3,13 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
 )
 import unittest
 
-import six  # noqa: F401 TODO Python 3
+import six
 
 from pysoa.test.plan.errors import StatusError
 from pysoa.test.plan.grammar.tools import (

--- a/tests/unit/test/plan/test_plan_execution_errors.py
+++ b/tests/unit/test/plan/test_plan_execution_errors.py
@@ -4,7 +4,7 @@ from __future__ import (
 )
 
 import os
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Dict,
     List,
     Optional,
@@ -13,9 +13,9 @@ from typing import (  # noqa: F401 TODO Python 3
 )
 import unittest
 
-import six  # noqa: F401 TODO Python 3
+import six
 
-from pysoa.common.types import ActionResponse  # noqa: F401 TODO Python 3
+from pysoa.common.types import ActionResponse
 from pysoa.test.compatibility import mock
 from pysoa.test.plan import ServicePlanTestCase
 from pysoa.test.plan.errors import (

--- a/tests/unit/test/test_stub_service.py
+++ b/tests/unit/test/test_stub_service.py
@@ -8,7 +8,7 @@ import random
 from unittest import TestCase
 
 import attr
-from conformity.settings import SettingsData  # noqa: F401 TODO Python 3
+from conformity.settings import SettingsData
 import six
 
 from pysoa.client.client import Client

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,7 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from typing import (  # noqa: F401 TODO Python 3
+from typing import (
     Any,
     Dict,
     Hashable,


### PR DESCRIPTION
Flake8 recently fixed the bug causing F401 errors for unused imports when those imports were used only for type annotation comments in Python 2. This means we can get rid of over 100 `# noqa: F401` comments. Hooray!