### PR TITLE
[MINOR] Refactor PySOA errors for easier and more concise usage

### DIFF
--- a/pysoa/client/client.py
+++ b/pysoa/client/client.py
@@ -34,6 +34,12 @@ from pymetrics.instruments import TimerResolution
 from pymetrics.recorders.base import MetricsRecorder
 import six
 
+from pysoa.client.errors import (
+    CallActionError,
+    CallJobError,
+    ImproperlyConfigured,
+    InvalidExpansionKey,
+)
 from pysoa.client.expander import (
     ExpansionConverter,
     ExpansionNode,
@@ -48,15 +54,11 @@ from pysoa.client.middleware import (
     ClientResponseMiddlewareTask,
 )
 from pysoa.client.settings import ClientSettings
+from pysoa.common.errors import Error
 from pysoa.common.transport.base import ClientTransport
-from pysoa.common.transport.exceptions import (
-    ConnectionError,
-    InvalidMessageError,
-    MessageReceiveError,
+from pysoa.common.transport.errors import (
     MessageReceiveTimeout,
-    MessageSendError,
-    MessageSendTimeout,
-    MessageTooLarge,
+    PySOATransportError,
 )
 from pysoa.common.types import (
     ActionRequest,
@@ -64,7 +66,6 @@ from pysoa.common.types import (
     Body,
     Context,
     Control,
-    Error,
     JobRequest,
     JobResponse,
     UnicodeKeysDict,
@@ -142,8 +143,7 @@ class ServiceHandler(object):
 
         :return: The request ID
 
-        :raises: :class:`ConnectionError`, :class:`InvalidField`, :class:`MessageSendError`,
-                 :class:`MessageSendTimeout`, :class:`MessageTooLarge`
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`
         """
         request_id = self.request_counter
         self.request_counter += 1
@@ -181,8 +181,7 @@ class ServiceHandler(object):
 
         :return: A generator that yields a two-tuple of request ID, job response
 
-        :raises: :class:`ConnectionError`, :class:`MessageReceiveError`, :class:`MessageReceiveTimeout`,
-                 :class:`InvalidMessage`, :class:`StopIteration`
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`, :class:`StopIteration`
         """
 
         wrapper = self._make_middleware_stack(
@@ -262,6 +261,9 @@ class FutureSOAResponse(Generic[_FR]):
                         seconds) will be used.
 
         :return: The response
+
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
+                 :class:`CallActionError`, :class:`CallJobError`
         """
         if self._raise:
             if six.PY2:
@@ -378,51 +380,20 @@ class Client(object):
 
     # Exceptions
 
-    class ImproperlyConfigured(Exception):
-        """
-        Raised when this client is improperly configured to call the specified service.
-        """
+    ImproperlyConfigured = ImproperlyConfigured
+    """Convenience alias for :class:`pysoa.client.errors.ImproperlyConfigured`"""
 
-    class InvalidExpansionKey(Exception):
-        """
-        Raised when this client is improperly configured to perform the specified expansion.
-        """
+    InvalidExpansionKey = InvalidExpansionKey
+    """Convenience alias for :class:`pysoa.client.errors.InvalidExpansionKey`"""
 
-    class JobError(Exception):
-        """
-        Raised by `Client.call_***` methods when a job response contains one or more job errors. Stores a list of
-        :class:`Error` objects and has a string representation cleanly displaying the errors.
-        """
+    JobError = CallJobError
+    """Convenience alias for :class:`pysoa.client.errors.CallJobError`"""
 
-        def __init__(self, errors=None):  # type: (Optional[List[Error]]) -> None
-            """
-            :param errors: The list of all errors in this job, available as an `errors` property on the exception
-                           instance.
-            """
-            self.errors = errors or []  # type: List[Error]
+    CallJobError = CallJobError
+    """Convenience alias for :class:`pysoa.client.errors.CallJobError`"""
 
-        def __repr__(self):
-            return self.__str__()
-
-        def __str__(self):
-            errors_string = '\n'.join([str(e) for e in self.errors])
-            return 'Error executing job:\n{}'.format(errors_string)
-
-    class CallActionError(Exception):
-        """
-        Raised by `Client.call_***` methods when a job response contains one or more action errors. Stores a list of
-        :class:`ActionResponse` objects and has a string representation cleanly displaying the actions' errors.
-        """
-        def __init__(self, actions=None):  # type: (Optional[List[ActionResponse]]) -> None
-            """
-            :param actions: The list of all actions that have errors (not actions without errors), available as an
-                            `actions` property on the exception instance.
-            """
-            self.actions = actions or []  # type: List[ActionResponse]
-
-        def __str__(self):
-            errors_string = '\n'.join(['{a.action}: {a.errors}'.format(a=a) for a in self.actions])
-            return 'Error calling action(s):\n{}'.format(errors_string)
+    CallActionError = CallActionError
+    """Convenience alias for :class:`pysoa.client.errors.CallActionError`"""
 
     # Blocking methods that send a request and wait until a response is available
 
@@ -468,9 +439,8 @@ class Client(object):
 
         :return: The action response.
 
-        :raises: :class:`ConnectionError`, :class:`InvalidField`, :class:`MessageSendError`,
-                 :class:`MessageSendTimeout`, :class:`MessageTooLarge`, :class:`MessageReceiveError`,
-                 :class:`MessageReceiveTimeout`, :class:`InvalidMessage`, :class:`JobError`, :class:`CallActionError`
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
+                 :class:`CallActionError`, :class:`CallJobError`
         """
         return self.call_action_future(
             service_name=service_name,
@@ -530,9 +500,8 @@ class Client(object):
 
         :return: The job response.
 
-        :raises: :class:`ConnectionError`, :class:`InvalidField`, :class:`MessageSendError`,
-                 :class:`MessageSendTimeout`, :class:`MessageTooLarge`, :class:`MessageReceiveError`,
-                 :class:`MessageReceiveTimeout`, :class:`InvalidMessage`, :class:`JobError`, :class:`CallActionError`
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
+                 :class:`CallActionError`, :class:`CallJobError`
         """
         return self.call_actions_future(
             service_name=service_name,
@@ -582,14 +551,13 @@ class Client(object):
         :param raise_action_errors: Whether to raise a :class:`CallActionError` if any action responses contain errors
                                     (defaults to `True`).
         :param catch_transport_errors: Whether to catch transport errors and return them instead of letting them
-                                       propagate. By default (`False`), the errors :class:`ConnectionError`,
-                                       :class:`InvalidMessageError`, :class:`MessageReceiveError`,
-                                       :class:`MessageReceiveTimeout`, :class:`MessageSendError`,
-                                       :class:`MessageSendTimeout`, and :class:`MessageTooLarge`, when raised by the
-                                       transport, cause the entire process to terminate, potentially losing responses.
-                                       If this argument is set to `True`, those errors are, instead, caught, and they
-                                       are returned in place of their corresponding responses in the returned list of
-                                       job responses.
+                                       propagate. By default (`False`), all raised
+                                       :class:`pysoa.common.transport.errors.PySOATransportError` exceptions cause the
+                                       entire process to terminate, potentially losing responses. If this argument is
+                                       set to `True`, those errors are, instead, caught, and they are returned in place
+                                       of their corresponding responses in the returned list of job responses. You
+                                       should not do this in most cases, but it is helpful if you really need to get
+                                       the successful responses even if there are errors getting other responses.
         :param timeout: If provided, this will override the default transport timeout values to; requests will expire
                         after this number of seconds plus some buffer defined by the transport, and the client will not
                         block waiting for a response for longer than this amount of time.
@@ -600,9 +568,8 @@ class Client(object):
 
         :return: A generator of action responses
 
-        :raises: :class:`ConnectionError`, :class:`InvalidField`, :class:`MessageSendError`,
-                 :class:`MessageSendTimeout`, :class:`MessageTooLarge`, :class:`MessageReceiveError`,
-                 :class:`MessageReceiveTimeout`, :class:`InvalidMessage`, :class:`JobError`, :class:`CallActionError`
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
+                 :class:`CallActionError`, :class:`CallJobError`
         """
         return self.call_actions_parallel_future(
             service_name=service_name,
@@ -652,14 +619,13 @@ class Client(object):
         :param raise_action_errors: Whether to raise a :class:`CallActionError` if any action responses contain errors
                                     (defaults to `True`).
         :param catch_transport_errors: Whether to catch transport errors and return them instead of letting them
-                                       propagate. By default (`False`), the errors :class:`ConnectionError`,
-                                       :class:`InvalidMessageError`, :class:`MessageReceiveError`,
-                                       :class:`MessageReceiveTimeout`, :class:`MessageSendError`,
-                                       :class:`MessageSendTimeout`, and :class:`MessageTooLarge`, when raised by the
-                                       transport, cause the entire process to terminate, potentially losing responses.
-                                       If this argument is set to `True`, those errors are, instead, caught, and they
-                                       are returned in place of their corresponding responses in the returned list of
-                                       job responses.
+                                       propagate. By default (`False`), all raised
+                                       :class:`pysoa.common.transport.errors.PySOATransportError` exceptions cause the
+                                       entire process to terminate, potentially losing responses. If this argument is
+                                       set to `True`, those errors are, instead, caught, and they are returned in place
+                                       of their corresponding responses in the returned list of job responses. You
+                                       should not do this in most cases, but it is helpful if you really need to get
+                                       the successful responses even if there are errors getting other responses.
         :param timeout: If provided, this will override the default transport timeout values to; requests will expire
                         after this number of seconds plus some buffer defined by the transport, and the client will not
                         block waiting for a response for longer than this amount of time.
@@ -672,9 +638,8 @@ class Client(object):
 
         :return: The job response
 
-        :raises: :class:`ConnectionError`, :class:`InvalidField`, :class:`MessageSendError`,
-                 :class:`MessageSendTimeout`, :class:`MessageTooLarge`, :class:`MessageReceiveError`,
-                 :class:`MessageReceiveTimeout`, :class:`InvalidMessage`, :class:`JobError`, :class:`CallActionError`
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
+                 :class:`CallActionError`, :class:`CallJobError`
         """
         return self.call_jobs_parallel_future(
             jobs=jobs,
@@ -715,6 +680,8 @@ class Client(object):
         the future is used.
 
         :return: A future from which the action response can later be retrieved
+
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
         """
         action_request = ActionRequest(
             action=action,
@@ -766,6 +733,8 @@ class Client(object):
         the future is used.
 
         :return: A future from which the job response can later be retrieved
+
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
         """
         expected_request_id = self.send_request(
             service_name=service_name,
@@ -853,6 +822,8 @@ class Client(object):
         of `Exception` instead of individual :class:`ActionResponse`s. Be sure to check for that if used in this manner.
 
         :return: A generator of action responses that blocks waiting on responses once you begin iteration
+
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
         """
         job_responses = self.call_jobs_parallel_future(
             jobs=({'service_name': service_name, 'actions': [action]} for action in actions),
@@ -906,6 +877,8 @@ class Client(object):
         others may be raised when the future is used.
 
         :return: A future from which the list of job responses can later be retrieved
+
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`,
         """
         error_key = 0
         transport_errors = {}  # type: Dict[Tuple[six.text_type, int], Exception]
@@ -925,7 +898,7 @@ class Client(object):
                     message_expiry_in_seconds=timeout if timeout else None,
                 )
                 service_request_ids.setdefault(job['service_name'], set()).add(sent_request_id)
-            except (ConnectionError, InvalidMessageError, MessageSendError, MessageSendTimeout, MessageTooLarge) as e:
+            except PySOATransportError as e:
                 if not catch_transport_errors:
                     raise
                 sent_request_id = error_key = error_key - 1
@@ -949,7 +922,7 @@ class Client(object):
                         if catch_transport_errors:
                             # We don't need the set to be reduced unless we're catching errors
                             request_ids.remove(request_id)
-                except (ConnectionError, InvalidMessageError, MessageReceiveError, MessageReceiveTimeout) as e:
+                except PySOATransportError as e:
                     if not catch_transport_errors:
                         raise
                     for request_id in request_ids:
@@ -1038,8 +1011,7 @@ class Client(object):
 
         :return: The request ID
 
-        :raises: :class:`ConnectionError`, :class:`InvalidField`, :class:`MessageSendError`,
-                 :class:`MessageSendTimeout`, :class:`MessageTooLarge`
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`
         """
 
         control_extra = control_extra.copy() if control_extra else {}
@@ -1072,8 +1044,7 @@ class Client(object):
 
         :return: A generator that yields a two-tuple of request ID, job response
 
-        :raises: :class:`ConnectionError`, :class:`MessageReceiveError`, :class:`MessageReceiveTimeout`,
-                 :class:`InvalidMessage`
+        :raises: :class:`pysoa.common.transport.errors.PySOATransportError`
         """
 
         handler = self._get_handler(service_name)

--- a/pysoa/client/errors.py
+++ b/pysoa/client/errors.py
@@ -1,0 +1,72 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+from typing import (
+    List,
+    Optional,
+)
+
+from pysoa.common.errors import (
+    Error,
+    PySOAError,
+)
+from pysoa.common.types import ActionResponse
+
+
+class PySOAClientError(PySOAError):
+    """
+    Base exception for all client-side errors other than transport errors.
+    """
+
+
+class ImproperlyConfigured(PySOAClientError):
+    """
+    Raised when this client is improperly configured to call the specified service.
+    """
+
+
+class InvalidExpansionKey(PySOAClientError):
+    """
+    Raised when this client is improperly configured to perform the specified expansion.
+    """
+
+
+class CallJobError(PySOAClientError):
+    """
+    Raised by `Client.call_***` methods when a job response contains one or more job errors. Stores a list of
+    :class:`Error` objects and has a string representation cleanly displaying the errors.
+    """
+
+    def __init__(self, errors=None):  # type: (Optional[List[Error]]) -> None
+        """
+        :param errors: The list of all errors in this job, available as an `errors` property on the exception
+                       instance.
+        """
+        self.errors = errors or []  # type: List[Error]
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        errors_string = '\n'.join([str(e) for e in self.errors])
+        return 'Error executing job:\n{}'.format(errors_string)
+
+
+class CallActionError(PySOAClientError):
+    """
+    Raised by `Client.call_***` methods when a job response contains one or more action errors. Stores a list of
+    :class:`ActionResponse` objects and has a string representation cleanly displaying the actions' errors.
+    """
+
+    def __init__(self, actions=None):  # type: (Optional[List[ActionResponse]]) -> None
+        """
+        :param actions: The list of all actions that have errors (not actions without errors), available as an
+                        `actions` property on the exception instance.
+        """
+        self.actions = actions or []  # type: List[ActionResponse]
+
+    def __str__(self):
+        errors_string = '\n'.join(['{a.action}: {a.errors}'.format(a=a) for a in self.actions])
+        return 'Error calling action(s):\n{}'.format(errors_string)

--- a/pysoa/client/expander.py
+++ b/pysoa/client/expander.py
@@ -23,6 +23,7 @@ import six
 __all__ = (
     'ExpansionConverter',
     'ExpansionNode',
+    'Expansions',
     'ExpansionSettings',
     'TypeExpansions',
     'TypeNode',

--- a/pysoa/client/settings.py
+++ b/pysoa/client/settings.py
@@ -65,7 +65,7 @@ class RedisClientSettings(ClientSettings):
     def __init__(self, *args, **kwargs):
         super(RedisClientSettings, self).__init__(*args, **kwargs)
 
-        warnings.warn('RedisClientSettings is deprecated; use ClientSettings instead', DeprecationWarning)
+        warnings.warn('RedisClientSettings is deprecated; use ClientSettings instead', DeprecationWarning, stacklevel=2)
 
 
 class LocalClientSettings(ClientSettings):
@@ -82,7 +82,7 @@ class LocalClientSettings(ClientSettings):
     def __init__(self, *args, **kwargs):
         super(LocalClientSettings, self).__init__(*args, **kwargs)
 
-        warnings.warn('LocalClientSettings is deprecated; use ClientSettings instead', DeprecationWarning)
+        warnings.warn('LocalClientSettings is deprecated; use ClientSettings instead', DeprecationWarning, stacklevel=2)
 
 
 class PolymorphicClientSettings(ClientSettings):
@@ -93,4 +93,8 @@ class PolymorphicClientSettings(ClientSettings):
     def __init__(self, *args, **kwargs):
         super(PolymorphicClientSettings, self).__init__(*args, **kwargs)
 
-        warnings.warn('PolymorphicClientSettings is deprecated; use ClientSettings instead', DeprecationWarning)
+        warnings.warn(
+            'PolymorphicClientSettings is deprecated; use ClientSettings instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )

--- a/pysoa/common/errors.py
+++ b/pysoa/common/errors.py
@@ -1,0 +1,57 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+
+import attr
+import six
+
+
+__all__ = (
+    'Error',
+    'PySOAError',
+)
+
+
+@attr.s(frozen=True)
+class Error(object):
+    """
+    Represents an error that occurred, in the format transmitted over the transport between client and service.
+
+    :param code: The machine-readable error code.
+    :param message: The human-readable error message.
+    :param field: If the error is the result of validation of a job attribute or action request field, this contains
+                  the name of that attribute or field. It will be `None` otherwise.
+    :param traceback: If the error is the result of an exception with valuable traceback information, this contains
+                      that traceback. It will be `None` otherwise.
+    :param variables: If there are any variables pertinent to this error, this dictionary will contain the names and
+                      values of those variables. It will be `None` otherwise. New in version 0.9.0.
+    :param denied_permissions: If this error is the result of insufficient privileges to perform the requested
+                               operation, this attribute will be a list containing the necessary permissions that
+                               were denied, if the service supports reporting this information.  It will be `None`
+                               otherwise. New in version 0.44.0.
+    :param is_caller_error: Indicates whether this error is the result of the caller doing something wrong (`True`),
+                            such as an invalid job request or an action request body that fails to validate, or the
+                            result of a server or service problem or bug (`False`). New in version 0.70.0.
+    """
+
+    code = attr.ib()  # type: six.text_type
+    message = attr.ib()  # type: six.text_type
+    field = attr.ib(default=None)  # type: Optional[six.text_type]
+    traceback = attr.ib(default=None)  # type: Optional[six.text_type]
+    variables = attr.ib(default=None)  # type: Dict[six.text_type, Any]
+    denied_permissions = attr.ib(default=None)  # type: Optional[List[six.text_type]]
+    is_caller_error = attr.ib(default=False, metadata={'added_in_version': (0, 70, 0)})  # type: bool
+
+
+class PySOAError(Exception):
+    """
+    Base exception for all PySOA errors.
+    """

--- a/pysoa/common/serializer/errors.py
+++ b/pysoa/common/serializer/errors.py
@@ -1,0 +1,31 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+from pysoa.common.errors import PySOAError
+
+
+__all__ = (
+    'InvalidField',
+    'InvalidMessage',
+    'SerializationError',
+)
+
+
+class SerializationError(PySOAError):
+    """
+    Base exceptions for all exceptions related to serialization and deserialization.
+    """
+
+
+class InvalidMessage(SerializationError):
+    """
+    Raised when a serialized message is incapable of being deserialized.
+    """
+
+
+class InvalidField(SerializationError):
+    """
+    Raised when a field in a message is not serializable.
+    """

--- a/pysoa/common/serializer/exceptions.py
+++ b/pysoa/common/serializer/exceptions.py
@@ -3,16 +3,15 @@ from __future__ import (
     unicode_literals,
 )
 
+import warnings
 
-__all__ = (
-    'InvalidField',
-    'InvalidMessage',
+from pysoa.common.serializer.errors import (  # noqa: F401
+    InvalidField,
+    InvalidMessage,
 )
 
 
-class InvalidMessage(Exception):
-    pass
-
-
-class InvalidField(Exception):
-    pass
+warnings.warn(
+    '`pysoa.common.serializer.exceptions` is deprecated. Import from `pysoa.common.serializer.errors`, instead.',
+    DeprecationWarning,
+)

--- a/pysoa/common/serializer/json_serializer.py
+++ b/pysoa/common/serializer/json_serializer.py
@@ -10,7 +10,7 @@ from conformity import fields
 import six
 
 from pysoa.common.serializer.base import Serializer as BaseSerializer
-from pysoa.common.serializer.exceptions import (
+from pysoa.common.serializer.errors import (
     InvalidField,
     InvalidMessage,
 )

--- a/pysoa/common/serializer/msgpack_serializer.py
+++ b/pysoa/common/serializer/msgpack_serializer.py
@@ -20,7 +20,7 @@ import pytz
 import six
 
 from pysoa.common.serializer.base import Serializer as BaseSerializer
-from pysoa.common.serializer.exceptions import (
+from pysoa.common.serializer.errors import (
     InvalidField,
     InvalidMessage,
 )

--- a/pysoa/common/settings.py
+++ b/pysoa/common/settings.py
@@ -22,6 +22,7 @@ class Settings(ConformitySettings):
         warnings.warn(
             'pysoa.common.settings.Settings is deprecated. Use conformity.settings.ConformitySettings, instead.',
             DeprecationWarning,
+            stacklevel=2,
         )
         super(Settings, self).__init__(data)
 

--- a/pysoa/common/transport/errors.py
+++ b/pysoa/common/transport/errors.py
@@ -1,0 +1,93 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+from typing import Any
+
+from pysoa.common.errors import PySOAError
+
+
+__all__ = (
+    'ConnectionError',
+    'InvalidMessageError',
+    'MessageReceiveError',
+    'MessageReceiveTimeout',
+    'MessageSendError',
+    'MessageSendTimeout',
+    'MessageTooLarge',
+    'PySOATransportError',
+    'TransientPySOATransportError',
+)
+
+
+class PySOATransportError(PySOAError):
+    """
+    Base exception for all transport-related PySOA errors.
+    """
+
+
+class MessageTooLarge(PySOATransportError):
+    """
+    Raised when a message is too large to be sent by the configured transport. This indicates a client- or server-side
+    (wherever it was raised) programming error that must be resolved.
+    """
+    def __init__(self, message_size_in_bytes, *args):  # type: (int, *Any) -> None
+        self.message_size_in_bytes = message_size_in_bytes
+        super(MessageTooLarge, self).__init__(*args)
+
+
+class InvalidMessageError(PySOATransportError):
+    """
+    Raised when the transport cannot send a message because there is some problem with its contents or the way it is
+    structured. This is unrelated to serialization and indicates a client- or server-side (wherever it was raised)
+    programming error that must be resolved.
+    """
+
+
+class TransientPySOATransportError(PySOATransportError):
+    """
+    Base exception for transport errors that are typically transient (a failure to send or receive an error) and
+    cannot (usually) be resolved my changes to the client- or server-side code.
+    """
+
+
+class MessageReceiveTimeout(TransientPySOATransportError):
+    """
+    Raised when the transport reaches the timeout waiting to receive a message. On the server side, this is used for
+    application control flow: When the server does not receive a message within the specified time, it performs idle
+    cleanup operations and then asks the transport for a message again, in a loop, indefinitely. On the client side,
+    this means the server did not respond within the specified timeout, and can be the result of several things:
+
+    * The client timeout was set too low for the given action or actions called.
+    * The server action code is poorly performant and is taking too long to respond.
+    * The server is overloaded and is receiving requests faster than it can process them.
+    * The server is currently down.
+    """
+
+
+class MessageSendTimeout(TransientPySOATransportError):
+    """
+    Raised when the transport encounters a timeout while attempting to send a message. The meaning of such an error
+    can vary wildly depending on the configured transport. See the transport documentation for more information.
+    """
+
+
+class MessageReceiveError(TransientPySOATransportError):
+    """
+    Raised when an error occurs while the transport is attempting to receive a message. The meaning of such an error
+    can vary wildly depending on the configured transport. See the transport documentation for more information.
+    """
+
+
+class MessageSendError(TransientPySOATransportError):
+    """
+    Raised when an error occurs while the transport is attempting to send a message. The meaning of such an error
+    can vary wildly depending on the configured transport. See the transport documentation for more information.
+    """
+
+
+class ConnectionError(TransientPySOATransportError):
+    """
+    Raised when the transport cannot obtain the necessary connection to send or receive a message.
+    """

--- a/pysoa/common/transport/exceptions.py
+++ b/pysoa/common/transport/exceptions.py
@@ -3,58 +3,20 @@ from __future__ import (
     unicode_literals,
 )
 
+import warnings
 
-__all__ = (
-    'ConnectionError',
-    'InvalidMessageError',
-    'MessageReceiveError',
-    'MessageReceiveTimeout',
-    'MessageSendError',
-    'MessageSendTimeout',
-    'MessageTooLarge',
+from pysoa.common.transport.errors import (  # noqa: F401
+    ConnectionError,
+    InvalidMessageError,
+    MessageReceiveError,
+    MessageReceiveTimeout,
+    MessageSendError,
+    MessageSendTimeout,
+    MessageTooLarge,
 )
 
 
-class MessageTooLarge(Exception):
-    """
-    Raised when a message is too large to be send by the configured transport.
-    """
-    def __init__(self, message_size_in_bytes, *args):
-        self.message_size_in_bytes = message_size_in_bytes
-        super(MessageTooLarge, self).__init__(*args)
-
-
-class MessageReceiveTimeout(Exception):
-    """
-    Raised when the transport reaches the timeout waiting to receive a message.
-    """
-
-
-class MessageSendTimeout(Exception):
-    """
-    Raised when the transport encounters a timeout while attempting to send a message.
-    """
-
-
-class MessageReceiveError(Exception):
-    """
-    Raised when an error occurs while the transport is attempting to receive a message.
-    """
-
-
-class MessageSendError(Exception):
-    """
-    Raised when an error occurs while the transport is attempting to send a message.
-    """
-
-
-class ConnectionError(Exception):
-    """
-    Raised when the transport cannot obtain the necessary connection to send or receive a message.
-    """
-
-
-class InvalidMessageError(Exception):
-    """
-    Raised when the transport cannot serialize or deserialize the message because it is not valid in some way.
-    """
+warnings.warn(
+    '`pysoa.common.transport.exceptions` is deprecated. Import from `pysoa.common.transport.errors`, instead.',
+    DeprecationWarning,
+)

--- a/pysoa/common/transport/redis_gateway/client.py
+++ b/pysoa/common/transport/redis_gateway/client.py
@@ -20,7 +20,7 @@ from pysoa.common.transport.base import (
     ReceivedMessage,
     get_hex_thread_id,
 )
-from pysoa.common.transport.exceptions import MessageReceiveTimeout
+from pysoa.common.transport.errors import MessageReceiveTimeout
 from pysoa.common.transport.redis_gateway.backend.base import BaseRedisClient
 from pysoa.common.transport.redis_gateway.constants import ProtocolVersion
 from pysoa.common.transport.redis_gateway.core import RedisTransportClientCore

--- a/pysoa/common/transport/redis_gateway/core.py
+++ b/pysoa/common/transport/redis_gateway/core.py
@@ -39,7 +39,7 @@ from pysoa.common.logging import RecursivelyCensoredDictWrapper
 from pysoa.common.serializer.base import Serializer
 from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer
 from pysoa.common.transport.base import ReceivedMessage
-from pysoa.common.transport.exceptions import (
+from pysoa.common.transport.errors import (
     InvalidMessageError,
     MessageReceiveError,
     MessageReceiveTimeout,

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -17,7 +17,7 @@ from pysoa.common.transport.base import (
     ReceivedMessage,
     ServerTransport,
 )
-from pysoa.common.transport.exceptions import (
+from pysoa.common.transport.errors import (
     InvalidMessageError,
     MessageReceiveTimeout,
 )

--- a/pysoa/common/types.py
+++ b/pysoa/common/types.py
@@ -17,6 +17,8 @@ from typing import (
 import attr
 import six
 
+from pysoa.common.errors import Error
+
 
 __all__ = (
     'ActionRequest',
@@ -26,7 +28,6 @@ __all__ = (
     'Control',
     'JobRequest',
     'JobResponse',
-    'Error',
     'UnicodeKeysDict',
 )
 
@@ -57,37 +58,6 @@ Context = Dict[six.text_type, Any]
 
 Control = Dict[six.text_type, Any]
 """A type used for annotating attributes and arguments that represent job request control headers."""
-
-
-@attr.s(frozen=True)
-class Error(object):
-    """
-    Represents an error that occurred, in the format transmitted over the transport between client and service.
-
-    :param code: The machine-readable error code.
-    :param message: The human-readable error message.
-    :param field: If the error is the result of validation of a job attribute or action request field, this contains
-                  the name of that attribute or field. It will be `None` otherwise.
-    :param traceback: If the error is the result of an exception with valuable traceback information, this contains
-                      that traceback. It will be `None` otherwise.
-    :param variables: If there are any variables pertinent to this error, this dictionary will contain the names and
-                      values of those variables. It will be `None` otherwise. New in version 0.9.0.
-    :param denied_permissions: If this error is the result of insufficient privileges to perform the requested
-                               operation, this attribute will be a list containing the necessary permissions that
-                               were denied, if the service supports reporting this information.  It will be `None`
-                               otherwise. New in version 0.44.0.
-    :param is_caller_error: Indicates whether this error is the result of the caller doing something wrong (`True`),
-                            such as an invalid job request or an action request body that fails to validate, or the
-                            result of a server or service problem or bug (`False`). New in version 0.70.0.
-    """
-
-    code = attr.ib()  # type: six.text_type
-    message = attr.ib()  # type: six.text_type
-    field = attr.ib(default=None)  # type: Optional[six.text_type]
-    traceback = attr.ib(default=None)  # type: Optional[six.text_type]
-    variables = attr.ib(default=None)  # type: Dict[six.text_type, Any]
-    denied_permissions = attr.ib(default=None)  # type: Optional[List[six.text_type]]
-    is_caller_error = attr.ib(default=False, metadata={'added_in_version': (0, 70, 0)})  # type: bool
 
 
 def _convert_errors(errors):

--- a/pysoa/server/action/base.py
+++ b/pysoa/server/action/base.py
@@ -14,10 +14,8 @@ from typing import (
 from conformity import fields
 import six
 
-from pysoa.common.types import (
-    ActionResponse,
-    Error,
-)
+from pysoa.common.errors import Error
+from pysoa.common.types import ActionResponse
 from pysoa.server.errors import (
     ActionError,
     ResponseValidationError,
@@ -116,7 +114,7 @@ class Action(ActionInterface):
                 for error in (self.request_schema.errors(action_request.body) or [])
             ]
             if errors:
-                raise ActionError(errors=errors, is_caller_error=None)
+                raise ActionError(errors=errors, set_is_caller_error_to=None)
         # Run any custom validation
         self.validate(action_request)
         # Run the body of the action

--- a/pysoa/server/action/introspection.py
+++ b/pysoa/server/action/introspection.py
@@ -19,7 +19,7 @@ from conformity import fields
 import six
 
 from pysoa.common.constants import ERROR_CODE_INVALID
-from pysoa.common.types import Error
+from pysoa.common.errors import Error
 from pysoa.server.action.base import Action
 from pysoa.server.action.status import BaseStatusAction
 from pysoa.server.action.switched import SwitchedAction
@@ -163,7 +163,7 @@ class IntrospectionAction(Action):
                     field='action_name',
                     is_caller_error=True,
                 )],
-                is_caller_error=None,
+                set_is_caller_error_to=None,
             )
 
         if action_name in self.server.action_class_map:

--- a/pysoa/server/errors.py
+++ b/pysoa/server/errors.py
@@ -4,26 +4,30 @@ from __future__ import (
 )
 
 from typing import (
-    Generator,
     Iterable,
     List,
     Optional,
 )
+import warnings
 
 from conformity.error import Error as ConformityError
 import six
 
-from pysoa.common.types import Error
+from pysoa.common.errors import (
+    Error,
+    PySOAError,
+)
 
 
-def _replace_error_if_necessary(errors, is_caller_error):
-    # type: (Iterable[Error], bool) -> Generator[Error, None, None]
+def _replace_errors_if_necessary(errors, is_caller_error):
+    # type: (Iterable[Error], bool) -> List[Error]
+    new_errors = []
     for e in errors:
         if e.is_caller_error == is_caller_error:
-            yield e
+            new_errors.append(e)
         else:
             # Error is immutable, so return a new one
-            yield Error(
+            new_errors.append(Error(
                 code=e.code,
                 message=e.message,
                 field=e.field,
@@ -31,43 +35,108 @@ def _replace_error_if_necessary(errors, is_caller_error):
                 variables=e.variables,
                 denied_permissions=e.denied_permissions,
                 is_caller_error=is_caller_error,
-            )
+            ))
+    return new_errors
 
 
-class JobError(Exception):
-    def __init__(self, errors, is_caller_error=False):  # type: (List[Error], Optional[bool]) -> None
+class PySOAServerError(PySOAError):
+    """
+    Base exception for all server-side errors other than transport errors.
+    """
+
+
+class JobError(PySOAServerError):
+    """
+    Raised by middleware or the server class as a flow control mechanism for returning a
+    :class:`pysoa.common.types.JobResponse` with at least one :class:`Error` in it.
+    """
+
+    def __init__(self, errors, set_is_caller_error_to=False, **kwargs):
+        # type: (List[Error], Optional[bool], **Optional[bool]) -> None
         """
         Constructs a new job error.
 
         :param errors: The list of :class:`Error` objects associated with this job error.
-        :param is_caller_error: If non-`None`, all of the `Error` objects in `errors` will have their `is_caller_error`
-                                attribute set to this value. Defaults to `False`, so you should set this to `None`, if
-                                you do not desire the input errors to be modified.
+        :param set_is_caller_error_to: If non-`None`, all of the `Error` objects in `errors` will have their
+                                       `is_caller_error` attribute set to this value. Defaults to `False`, so you
+                                       should set this to `None` if you do not desire the input errors to be modified.
         """
-        self.errors = errors if is_caller_error is None else list(_replace_error_if_necessary(errors, is_caller_error))
-        self.is_caller_error = is_caller_error
+        if 'is_caller_error' in kwargs:
+            warnings.warn(
+                '`JobError` argument `is_caller_error` is deprecated. Please use `set_is_caller_error_to`, instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            set_is_caller_error_to = kwargs.pop('is_caller_error')
+        if kwargs:
+            raise TypeError("TypeError: __init__() got an unexpected keyword argument '{}'".format(
+                next(iter(kwargs.keys())),
+            ))
+
+        self.errors = (
+            errors if set_is_caller_error_to is None else _replace_errors_if_necessary(errors, set_is_caller_error_to)
+        )
+        self._set_is_caller_error_to = set_is_caller_error_to
+
+    @property
+    def is_caller_error(self):
+        warnings.warn(
+            '`JobError` attribute `is_caller_error` is deprecated with no replacement.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._set_is_caller_error_to
 
 
-class ActionError(Exception):
-    def __init__(self, errors, is_caller_error=True):  # type: (List[Error], Optional[bool]) -> None
+class ActionError(PySOAServerError):
+    """
+    Raised by action code, middleware, or the server class as a flow control mechanism for returning an
+    :class:`pysoa.common.types.ActionResponse` with at least one :class:`Error` in it.
+    """
+
+    def __init__(self, errors, set_is_caller_error_to=True, **kwargs):
+        # type: (List[Error], Optional[bool], **Optional[bool]) -> None
         """
         Constructs a new action error.
 
         :param errors: The list of :class:`Error` objects associated with this action error.
-        :param is_caller_error: If non-`None`, all of the `Error` objects in `errors` will have their `is_caller_error`
-                                attribute set to this value. Defaults to `True`, so you should set this to `None`, if
-                                you do not desire the input errors to be modified.
+        :param set_is_caller_error_to: If non-`None`, all of the `Error` objects in `errors` will have their
+                                       `is_caller_error` attribute set to this value. Defaults to `True`, so you should
+                                       set this to `None` if you do not desire the input errors to be modified.
         """
-        self.errors = errors if is_caller_error is None else list(_replace_error_if_necessary(errors, is_caller_error))
-        self.is_caller_error = is_caller_error
+        if 'is_caller_error' in kwargs:
+            warnings.warn(
+                '`ActionError` argument `is_caller_error` is deprecated. Please use `set_is_caller_error_to`, instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            set_is_caller_error_to = kwargs.pop('is_caller_error')
+        if kwargs:
+            raise TypeError("TypeError: __init__() got an unexpected keyword argument '{}'".format(
+                next(iter(kwargs.keys())),
+            ))
+
+        self.errors = (
+            errors if set_is_caller_error_to is None else _replace_errors_if_necessary(errors, set_is_caller_error_to)
+        )
+        self._set_is_caller_error_to = set_is_caller_error_to
+
+    @property
+    def is_caller_error(self):
+        warnings.warn(
+            '`ActionError` attribute `is_caller_error` is deprecated with no replacement.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._set_is_caller_error_to
 
 
-class ResponseValidationError(Exception):
+class ResponseValidationError(PySOAServerError):
     """
-    Raised by an Action when the response fails to validate. Not meant to
-    be caught and handled by the server other than going into the error logging
-    infrastructure.
+    Raised by an action when the response fails to validate against the defined response schema for that action.
+    Indicates a server-side programming error that must be corrected.
     """
+
     def __init__(self, action, errors):  # type: (six.text_type, List[ConformityError]) -> None
         self.action = action
         self.errors = errors

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -45,13 +45,14 @@ from pysoa.common.constants import (
     ERROR_CODE_SERVER_ERROR,
     ERROR_CODE_UNKNOWN,
 )
+from pysoa.common.errors import Error
 from pysoa.common.logging import (
     PySOALogContextFilter,
     RecursivelyCensoredDictWrapper,
 )
-from pysoa.common.serializer.exceptions import InvalidField
+from pysoa.common.serializer.errors import InvalidField
 from pysoa.common.transport.base import ServerTransport
-from pysoa.common.transport.exceptions import (
+from pysoa.common.transport.errors import (
     MessageReceiveError,
     MessageReceiveTimeout,
     MessageTooLarge,
@@ -59,7 +60,6 @@ from pysoa.common.transport.exceptions import (
 from pysoa.common.types import (
     ActionResponse,
     Context,
-    Error,
     JobResponse,
     UnicodeKeysDict,
 )
@@ -379,7 +379,7 @@ class Server(object):
                 for error in (JobRequestSchema.errors(job_request) or [])
             ]
             if validation_errors:
-                raise JobError(errors=validation_errors, is_caller_error=None)
+                raise JobError(errors=validation_errors, set_is_caller_error_to=None)
 
             # Add the client object in case a middleware or action wishes to use it
             job_request['client'] = self.make_client(job_request['context'])

--- a/pysoa/server/settings.py
+++ b/pysoa/server/settings.py
@@ -42,6 +42,7 @@ def log_level_schema(*args, **kwargs):
         '`pysoa.server.settings.log_level_schema` is deprecated. '
         'Use `conformity.fields.logging.PythonLogLevel`, instead.',
         DeprecationWarning,
+        stacklevel=2,
     )
     return PythonLogLevel(*args, **kwargs)
 
@@ -195,7 +196,7 @@ class RedisServerSettings(ServerSettings):
     def __init__(self, *args, **kwargs):
         super(RedisServerSettings, self).__init__(*args, **kwargs)
 
-        warnings.warn('RedisServerSettings is deprecated; use ServerSettings instead', DeprecationWarning)
+        warnings.warn('RedisServerSettings is deprecated; use ServerSettings instead', DeprecationWarning, stacklevel=2)
 
 
 class LocalServerSettings(ServerSettings):
@@ -212,7 +213,7 @@ class LocalServerSettings(ServerSettings):
     def __init__(self, *args, **kwargs):
         super(LocalServerSettings, self).__init__(*args, **kwargs)
 
-        warnings.warn('LocalServerSettings is deprecated; use ServerSettings instead', DeprecationWarning)
+        warnings.warn('LocalServerSettings is deprecated; use ServerSettings instead', DeprecationWarning, stacklevel=2)
 
 
 class PolymorphicServerSettings(ServerSettings):
@@ -223,4 +224,8 @@ class PolymorphicServerSettings(ServerSettings):
     def __init__(self, *args, **kwargs):
         super(PolymorphicServerSettings, self).__init__(*args, **kwargs)
 
-        warnings.warn('PolymorphicServerSettings is deprecated; use ServerSettings instead', DeprecationWarning)
+        warnings.warn(
+            'PolymorphicServerSettings is deprecated; use ServerSettings instead',
+            DeprecationWarning,
+            stacklevel=2,
+        )

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -23,12 +23,12 @@ from pysoa.common.constants import (
     ERROR_CODE_SERVER_ERROR,
     ERROR_CODE_UNKNOWN,
 )
+from pysoa.common.errors import Error
 from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
     Context,
     Control,
-    Error,
 )
 from pysoa.server.errors import ActionError
 from pysoa.server.internal.types import (
@@ -135,7 +135,7 @@ class EnrichedActionRequest(ActionRequest):
                 is_caller_error=False,
             )]
             if raise_action_errors:
-                raise ActionError(errors, is_caller_error=None)
+                raise ActionError(errors, set_is_caller_error_to=None)
             return ActionResponse(action=action, errors=errors)
 
         if action not in server.action_class_map:
@@ -147,7 +147,7 @@ class EnrichedActionRequest(ActionRequest):
                 is_caller_error=False,
             )]
             if raise_action_errors:
-                raise ActionError(errors, is_caller_error=None)
+                raise ActionError(errors, set_is_caller_error_to=None)
             return ActionResponse(action=action, errors=errors)
 
         action_type = server.action_class_map[action]  # type: ActionType
@@ -173,7 +173,7 @@ class EnrichedActionRequest(ActionRequest):
             return ActionResponse(action=action, errors=e.errors)
 
         if raise_action_errors and response.errors:
-            raise ActionError(response.errors, is_caller_error=is_caller_error)
+            raise ActionError(response.errors, set_is_caller_error_to=is_caller_error)
 
         return response
 

--- a/pysoa/test/assertions.py
+++ b/pysoa/test/assertions.py
@@ -21,7 +21,7 @@ import pytest
 import six
 
 from pysoa.client.client import Client
-from pysoa.common.types import Error
+from pysoa.common.errors import Error
 
 
 __all__ = (

--- a/pysoa/test/plan/grammar/directives/expects_errors.py
+++ b/pysoa/test/plan/grammar/directives/expects_errors.py
@@ -15,7 +15,7 @@ from pyparsing import (
 )
 import six
 
-from pysoa.common.types import Error
+from pysoa.common.errors import Error
 from pysoa.test.plan.grammar.assertions import (
     assert_actual_list_not_subset,
     assert_expected_list_subset_of_actual,

--- a/pysoa/test/plan/grammar/directives/stub_action.py
+++ b/pysoa/test/plan/grammar/directives/stub_action.py
@@ -18,7 +18,7 @@ from pyparsing import (
 )
 import six
 
-from pysoa.common.types import Error
+from pysoa.common.errors import Error
 from pysoa.test.compatibility import mock as unittest_mock
 from pysoa.test.plan.errors import FixtureSyntaxError
 from pysoa.test.plan.grammar.data_types import (

--- a/pysoa/test/server.py
+++ b/pysoa/test/server.py
@@ -21,10 +21,10 @@ from conformity.settings import SettingsData
 import six
 
 from pysoa.client.client import Client
+from pysoa.common.errors import Error
 from pysoa.common.types import (
     ActionResponse,
     Body,
-    Error,
 )
 from pysoa.server.server import Server
 from pysoa.test.assertions import (

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -37,7 +37,8 @@ from pysoa.client.client import (
     ServiceHandler,
 )
 from pysoa.client.settings import ClientSettings
-from pysoa.common.transport.exceptions import (
+from pysoa.common.errors import Error
+from pysoa.common.transport.errors import (
     MessageReceiveError,
     MessageReceiveTimeout,
 )
@@ -46,7 +47,6 @@ from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
     Body,
-    Error,
     JobResponse,
 )
 from pysoa.server.action import Action

--- a/tests/functional/test_forking_and_reloading.py
+++ b/tests/functional/test_forking_and_reloading.py
@@ -8,7 +8,7 @@ import time
 import pytest
 
 from pysoa.common.constants import ERROR_CODE_ACTION_TIMEOUT
-from pysoa.common.transport.exceptions import MessageReceiveTimeout
+from pysoa.common.transport.errors import MessageReceiveTimeout
 
 from tests.functional import (
     get_container_logs,

--- a/tests/integration/test/plan/test_001_fixtures_work.py
+++ b/tests/integration/test/plan/test_001_fixtures_work.py
@@ -16,7 +16,7 @@ from conformity.settings import SettingsData
 import pytest
 import six
 
-from pysoa.common.types import Error
+from pysoa.common.errors import Error
 from pysoa.server.action.base import Action
 from pysoa.server.errors import (
     ActionError,

--- a/tests/integration/test_send_receive.py
+++ b/tests/integration/test_send_receive.py
@@ -23,15 +23,15 @@ from pysoa.common.constants import (
     ERROR_CODE_INVALID,
     ERROR_CODE_SERVER_ERROR,
 )
+from pysoa.common.errors import Error
 from pysoa.common.transport.base import ClientTransport
-from pysoa.common.transport.exceptions import (
+from pysoa.common.transport.errors import (
     MessageReceiveError,
     MessageSendError,
 )
 from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
-    Error,
     JobResponse,
 )
 from pysoa.server.errors import JobError

--- a/tests/unit/common/test_serializers.py
+++ b/tests/unit/common/test_serializers.py
@@ -14,7 +14,7 @@ from pysoa.common.serializer import (
     JSONSerializer,
     MsgpackSerializer,
 )
-from pysoa.common.serializer.exceptions import (
+from pysoa.common.serializer.errors import (
     InvalidField,
     InvalidMessage,
 )

--- a/tests/unit/common/transport/redis_gateway/test_core.py
+++ b/tests/unit/common/transport/redis_gateway/test_core.py
@@ -18,7 +18,7 @@ import six
 
 from pysoa.common.serializer.json_serializer import JSONSerializer
 from pysoa.common.serializer.msgpack_serializer import MsgpackSerializer
-from pysoa.common.transport.exceptions import (
+from pysoa.common.transport.errors import (
     InvalidMessageError,
     MessageReceiveError,
     MessageReceiveTimeout,

--- a/tests/unit/common/transport/redis_gateway/test_server.py
+++ b/tests/unit/common/transport/redis_gateway/test_server.py
@@ -8,7 +8,7 @@ import unittest
 
 from pymetrics.recorders.noop import noop_metrics
 
-from pysoa.common.transport.exceptions import InvalidMessageError
+from pysoa.common.transport.errors import InvalidMessageError
 from pysoa.common.transport.redis_gateway.server import RedisServerTransport
 from pysoa.test.compatibility import mock
 

--- a/tests/unit/common/transport/redis_gateway/test_threading.py
+++ b/tests/unit/common/transport/redis_gateway/test_threading.py
@@ -14,7 +14,7 @@ import unittest
 from pymetrics.recorders.noop import noop_metrics
 import six
 
-from pysoa.common.transport.exceptions import MessageReceiveTimeout
+from pysoa.common.transport.errors import MessageReceiveTimeout
 from pysoa.common.transport.redis_gateway.client import RedisClientTransport
 from pysoa.common.transport.redis_gateway.constants import REDIS_BACKEND_TYPE_STANDARD
 from pysoa.common.transport.redis_gateway.server import RedisServerTransport

--- a/tests/unit/server/action/test_status.py
+++ b/tests/unit/server/action/test_status.py
@@ -13,10 +13,10 @@ import six
 
 import pysoa
 from pysoa.client.client import Client
-from pysoa.common.transport.exceptions import MessageReceiveTimeout
+from pysoa.common.errors import Error
+from pysoa.common.transport.errors import MessageReceiveTimeout
 from pysoa.common.types import (
     ActionResponse,
-    Error,
     JobResponse,
 )
 from pysoa.server.action.status import (

--- a/tests/unit/server/action/test_switched.py
+++ b/tests/unit/server/action/test_switched.py
@@ -13,10 +13,8 @@ import unittest
 
 from conformity import fields
 
-from pysoa.common.types import (
-    ActionResponse,
-    Error,
-)
+from pysoa.common.errors import Error
+from pysoa.common.types import ActionResponse
 from pysoa.server.action.base import Action
 from pysoa.server.action.switched import SwitchedAction
 from pysoa.server.errors import ActionError

--- a/tests/unit/server/test_server/test_process_job.py
+++ b/tests/unit/server/test_server/test_process_job.py
@@ -6,7 +6,7 @@ from __future__ import (
 from unittest import TestCase
 
 from pysoa.common.constants import ERROR_CODE_INVALID
-from pysoa.common.types import Error
+from pysoa.common.errors import Error
 from pysoa.server.errors import ActionError
 from pysoa.server.middleware import ServerMiddleware
 from pysoa.server.server import Server

--- a/tests/unit/server/test_types.py
+++ b/tests/unit/server/test_types.py
@@ -8,10 +8,8 @@ import logging
 import attr
 import pytest
 
-from pysoa.common.types import (
-    ActionResponse,
-    Error,
-)
+from pysoa.common.errors import Error
+from pysoa.common.types import ActionResponse
 from pysoa.server.errors import ActionError
 from pysoa.server.types import EnrichedActionRequest
 from pysoa.test.compatibility import mock

--- a/tests/unit/test/plan/grammar/test_assertions.py
+++ b/tests/unit/test/plan/grammar/test_assertions.py
@@ -5,7 +5,7 @@ from __future__ import (
 
 import unittest
 
-from pysoa.common.types import Error
+from pysoa.common.errors import Error
 from pysoa.test.plan.grammar import assertions
 from pysoa.test.plan.grammar.data_types import AnyValue
 

--- a/tests/unit/test/test_assertions.py
+++ b/tests/unit/test/test_assertions.py
@@ -6,10 +6,8 @@ from __future__ import (
 import pytest
 
 from pysoa.client.client import Client
-from pysoa.common.types import (
-    ActionResponse,
-    Error,
-)
+from pysoa.common.errors import Error
+from pysoa.common.types import ActionResponse
 from pysoa.test.assertions import (
     raises_call_action_error,
     raises_error_codes,

--- a/tests/unit/test/test_stub_service.py
+++ b/tests/unit/test/test_stub_service.py
@@ -16,10 +16,10 @@ from pysoa.common.constants import (
     ERROR_CODE_INVALID,
     ERROR_CODE_NOT_AUTHORIZED,
 )
+from pysoa.common.errors import Error
 from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
-    Error,
     JobResponse,
     UnicodeKeysDict,
 )


### PR DESCRIPTION
- Create a common base class for all PySOA errors, `PySOAError`, and ensure all publicly-exposed exceptions inherit from that.
- Create common base classes `PySOAClientError`, `PySOAServerError`, `PySOATransportError`, `TransientPySOATransportError`, and `SerializationError` for more concise (less verbose) catching of related errors.
- The library had a mixture of `errors` modules and `exceptions` modules; standardize on `errors` and deprecated the `exceptions` modules.
- `is_caller_error` is brand new and already the `is_caller_error` arguments to `ActionError` and `JobError` are confusing users in relation to the `is_caller_error` attribute for `Error`. This deprecates the `is_caller_error` arguments to `ActionError` and `JobError` and replaces them with `set_is_caller_error_to` to better indicate that the argument sets `is_caller_error` on the `Error`.
- Add `stacklevel` to most deprecation warnings to provide better indication of where deprecated things are being used.

All of these changes are completely backwards compatible, but the bits that have been deprecated will be removed in PySOA 1.0.0.