### PR TITLE
[PATCH] Add missing assertLogs, fix assertCountEqual, rename some tests

### DIFF
--- a/pysoa/test/plan/__init__.py
+++ b/pysoa/test/plan/__init__.py
@@ -761,4 +761,5 @@ class ServicePlanTestCase(PyTestServerTestCase):
             # type: (Any, Any, Any) -> Literal[False]
             if self._stub_action_context:
                 return self._stub_action_context.__exit__(exc_type, exc_value, traceback)
+            # noinspection PyTypeChecker
             return False

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -501,10 +501,10 @@ class stub_action(object):
             for i, action_request_obj in actions_to_send_to_mock.items():
                 mock_response = None
                 try:
-                    # noinspection PyCallingNonCallable
                     assert self._current_mock_action is not None, (
                         'Enabled stub_action with no current mock is in an inconsistent state'
                     )
+                    # noinspection PyCallingNonCallable
                     mock_response = self._current_mock_action(action_request_obj.body or {})
                     if isinstance(mock_response, JobResponse):
                         job_response.errors.extend(mock_response.errors)
@@ -616,6 +616,7 @@ class stub_action(object):
 
     def __exit__(self, exc_type=None, exc_value=None, traceback=None):  # type: (Any, Any, Any) -> Literal[False]
         if not self.enabled:
+            # noinspection PyTypeChecker
             return False
 
         # Unwrap Client.send_request and Client.get_all_responses to their previous versions (which might themselves be
@@ -623,6 +624,7 @@ class stub_action(object):
         Client.send_request = self._wrapped_client_send_request  # type: ignore
         Client.get_all_responses = self._wrapped_client_get_all_responses  # type: ignore
         self.enabled = False
+        # noinspection PyTypeChecker
         return False
 
     def __call__(self, func):  # type: (_CT) -> _CT

--- a/tests/unit/client/test_expander.py
+++ b/tests/unit/client/test_expander.py
@@ -12,7 +12,7 @@ from pysoa.client.expander import (
 )
 
 
-class TypeNodeTests(TestCase):
+class TestTypeNode(TestCase):
     def setUp(self):
         self.type_node = TypeNode(node_type='foo')
 
@@ -223,7 +223,7 @@ class TypeNodeTests(TestCase):
         self.assertEqual(set(type_node_dict['foo']), {'bar.qux', 'bar.baz'})
 
 
-class ExpansionNodeTests(TestCase):
+class TestExpansionNode(TestCase):
     def setUp(self):
         self.expansion_node = ExpansionNode(
             node_type='foo',
@@ -272,7 +272,7 @@ class ExpansionNodeTests(TestCase):
         )
 
 
-class ExpansionConverterTests(TestCase):
+class TestExpansionConverter(TestCase):
     def setUp(self):
         self.converter = ExpansionConverter(
             type_routes={

--- a/tests/unit/server/internal/test_event_loop.py
+++ b/tests/unit/server/internal/test_event_loop.py
@@ -32,9 +32,9 @@ from pysoa.test.compatibility import mock
 
 
 # noinspection PyCompatibility
-class AsyncEventLoopThreadTests(unittest.TestCase):
+class TestAsyncEventLoopThread(unittest.TestCase):
     def setUp(self):
-        super(AsyncEventLoopThreadTests, self).setUp()
+        super(TestAsyncEventLoopThread, self).setUp()
         self.thread = AsyncEventLoopThread([])
         self.thread.start()
 

--- a/tests/unit/server/test_server/test_configuration.py
+++ b/tests/unit/server/test_server/test_configuration.py
@@ -14,7 +14,7 @@ class BaseTestServiceServer(Server):
     service_name = 'test_service'
 
 
-class ServerInitializationTests(TestCase):
+class TestServerInitialization(TestCase):
 
     def setUp(self):
         self.settings = factories.ServerSettingsFactory()

--- a/tests/unit/server/test_server/test_handle_next_request.py
+++ b/tests/unit/server/test_server/test_handle_next_request.py
@@ -38,7 +38,7 @@ class SimplePassthroughServerTransport(ServerTransport):
         return self._response
 
 
-class ProcessNextRequestsTests(TestCase):
+class TestProcessNextRequests(TestCase):
     def test_emtpy_request_returns_job_response_error(self):
         """
         Test that server can handle an emtpy job missing top level elements without throwing exceptions

--- a/tests/unit/server/test_server/test_process_job.py
+++ b/tests/unit/server/test_server/test_process_job.py
@@ -57,7 +57,7 @@ class ProcessJobMiddleware(ServerMiddleware):
         return handler
 
 
-class ProcessJobTests(TestCase):
+class TestProcessJob(TestCase):
     """
     Main process_job test suite.
     """


### PR DESCRIPTION
- Add the `assertLogs` method that is missing from `PyTestServerTestCase` and causing test failures in services.
- Fix the `assertCountEqual` implementation in `PyTestServerTestCase` to resolve some test failures in services (and deprecate it, because we have to rely on private CPython methods to use it).
- Rename some tests to use a standard naming scheme.