### PR TITLE
[PATCH] Try importing from typing before typing_extensions

### DIFF
--- a/pysoa/test/plan/__init__.py
+++ b/pysoa/test/plan/__init__.py
@@ -22,7 +22,6 @@ from typing import (
 
 import attr
 import six
-from typing_extensions import Literal
 
 from pysoa.common.types import Body
 from pysoa.test.compatibility import mock
@@ -46,6 +45,11 @@ from pysoa.test.plan.parser import ServiceTestPlanFixtureParser
 from pysoa.test.server import PyTestServerTestCase
 from pysoa.test.stub_service import stub_action
 
+
+try:
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
 
 try:
     from typing import Protocol

--- a/pysoa/test/server.py
+++ b/pysoa/test/server.py
@@ -42,7 +42,6 @@ from _pytest.recwarn import WarningsChecker
 from conformity.settings import SettingsData
 import pytest
 import six
-from typing_extensions import Literal
 
 from pysoa.client.client import Client
 from pysoa.common.errors import Error
@@ -59,9 +58,14 @@ from pysoa.test.assertions import (
 
 
 try:
-    from typing import NoReturn
+    from typing import Literal  # type: ignore
 except ImportError:
-    from typing_extensions import NoReturn
+    from typing_extensions import Literal  # type: ignore
+
+try:
+    from typing import NoReturn  # type: ignore
+except ImportError:
+    from typing_extensions import NoReturn  # type: ignore
 
 
 __all__ = (

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -32,7 +32,6 @@ from conformity.settings import SettingsData
 from pymetrics.recorders.base import MetricsRecorder
 from pymetrics.recorders.noop import noop_metrics
 import six
-from typing_extensions import Literal
 
 from pysoa.client.client import (
     Client,
@@ -62,6 +61,12 @@ from pysoa.server.types import (
     EnrichedActionRequest,
 )
 from pysoa.test.compatibility import mock
+
+
+try:
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
 
 
 __all__ = (


### PR DESCRIPTION
Before we import from `typing_extensions`, we should always first try to import from `typing`.