### PR TITLE
[PATCH] Skip Django database connection cleanup in unit tests

### DIFF
--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -241,6 +241,8 @@ class Server(object):
         self._heartbeat_file_last_update = 0.0
         self._forked_process_id = forked_process_id
 
+        self._skip_django_database_cleanup = False
+
     def handle_next_request(self):  # type: () -> None
         """
         Retrieves the next request from the transport, or returns if it times out (no request has been made), and then
@@ -763,7 +765,7 @@ class Server(object):
         """
 
     def _close_old_django_connections(self):  # type: () -> None
-        if self.use_django:
+        if self.use_django and not self._skip_django_database_cleanup:
             if not getattr(django_settings, 'DATABASES'):
                 # No database connections are configured, so we have nothing to do
                 return

--- a/pysoa/test/server.py
+++ b/pysoa/test/server.py
@@ -45,6 +45,7 @@ import six
 
 from pysoa.client.client import Client
 from pysoa.common.errors import Error
+from pysoa.common.transport.local import LocalClientTransport
 from pysoa.common.types import (
     ActionResponse,
     Body,
@@ -138,6 +139,11 @@ class BaseServerTestCase(object):
                 },
             },
         )
+        # noinspection PyProtectedMember
+        cast(
+            LocalClientTransport,
+            self.client._get_handler(self.service_name).transport,
+        ).server._skip_django_database_cleanup = True
 
     def call_action(self, action, body=None, service_name=None, **kwargs):
         # type: (six.text_type, Body, Optional[six.text_type], **Any) -> ActionResponse

--- a/tests/functional/test_very_large_responses.py
+++ b/tests/functional/test_very_large_responses.py
@@ -3,9 +3,9 @@ from __future__ import (
     unicode_literals,
 )
 
-from pysoa.client.client import Client
 import pytest
 
+from pysoa.client.client import Client
 from pysoa.common.constants import ERROR_CODE_RESPONSE_TOO_LARGE
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,14 +47,14 @@ commands = flake8
 
 [testenv:coverage]
 skip_install = true
-deps = coverage
+deps = coverage~=4.5
 commands =
     coverage combine
     coverage report
 
 [testenv:py27-coverage]
 skip_install = true
-deps = coverage
+deps = coverage~=4.5
 commands =
     coverage combine
     coverage report --omit=pysoa/server/coroutine.py,pysoa/server/internal/event_loop.py


### PR DESCRIPTION
This should prevent the following error:

```
RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
```