### PR TITLE
[PATCH] Fix #239: stub_action side_effect now supports mix of types

### DIFF
--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -594,7 +594,8 @@ class stub_action(object):
             if self._stub_action_responses_to_merge[service_name]:
                 raise Exception('Something very bad happened, and there are still stubbed responses to merge!')
 
-            for request_id, response_or_e in six.iteritems(self._stub_action_responses_outstanding[service_name]):
+            for request_id in list(self._stub_action_responses_outstanding[service_name].keys()):
+                response_or_e = self._stub_action_responses_outstanding[service_name].pop(request_id)
                 if isinstance(response_or_e, Exception):
                     raise response_or_e
                 yield request_id, response_or_e

--- a/tests/unit/test/test_stub_service.py
+++ b/tests/unit/test/test_stub_service.py
@@ -24,6 +24,7 @@ from pysoa.common.constants import (
     ERROR_CODE_NOT_AUTHORIZED,
 )
 from pysoa.common.errors import Error
+from pysoa.common.transport.errors import MessageReceiveTimeout
 from pysoa.common.types import (
     ActionRequest,
     ActionResponse,
@@ -642,6 +643,23 @@ class TestStubAction(PyTestServerTestCase):
             mock.call({'input_attribute': True}),
             mock.call({'another_attribute': False}),
         ])
+
+    def test_stub_action_with_side_effect_mixed_exceptions_and_bodies_as_context_manager(self):
+        with stub_action('foo', 'bar', side_effect=[MessageReceiveTimeout('No message received'), {'good': 'yes'}]):
+            with pytest.raises(MessageReceiveTimeout):
+                self.client.call_action('foo', 'bar')
+
+            response = self.client.call_action('foo', 'bar')
+            assert response.body == {'good': 'yes'}
+
+    @stub_action('foo', 'bar')
+    def test_stub_action_with_side_effect_mixed_exceptions_and_bodies_as_decorator(self, stub_foo_bar):
+        stub_foo_bar.side_effect = [MessageReceiveTimeout('No message received'), {'good': 'yes'}]
+        with pytest.raises(MessageReceiveTimeout):
+            self.client.call_action('foo', 'bar')
+
+        response = self.client.call_action('foo', 'bar')
+        assert response.body == {'good': 'yes'}
 
     @stub_action('test_service', 'test_action_1')
     def test_two_stubs_same_service_split(self, stub_test_action_1):
@@ -1537,6 +1555,23 @@ class TestStubActionUnitTestCase(UnitTestServerTestCase):
             mock.call({'input_attribute': True}),
             mock.call({'another_attribute': False}),
         ])
+
+    def test_stub_action_with_side_effect_mixed_exceptions_and_bodies_as_context_manager(self):
+        with stub_action('foo', 'bar', side_effect=[MessageReceiveTimeout('No message received'), {'good': 'yes'}]):
+            with pytest.raises(MessageReceiveTimeout):
+                self.client.call_action('foo', 'bar')
+
+            response = self.client.call_action('foo', 'bar')
+            assert response.body == {'good': 'yes'}
+
+    @stub_action('foo', 'bar')
+    def test_stub_action_with_side_effect_mixed_exceptions_and_bodies_as_decorator(self, stub_foo_bar):
+        stub_foo_bar.side_effect = [MessageReceiveTimeout('No message received'), {'good': 'yes'}]
+        with pytest.raises(MessageReceiveTimeout):
+            self.client.call_action('foo', 'bar')
+
+        response = self.client.call_action('foo', 'bar')
+        assert response.body == {'good': 'yes'}
 
     @stub_action('test_service', 'test_action_1')
     def test_two_stubs_same_service_split(self, stub_test_action_1):


### PR DESCRIPTION
`stub_action` was not properly popping certain responses from the collection of outstanding responses when those responses were retrieved. As a result, if a `stub_action` call specified a `side_effect`, and one of those side effects was an exception, and other non-exception side effects followed the exception, the exception masked all future side effects. This is now fixed.