### PR TITLE
[PATCH] Improve error messages and use correct msgpack dependency

### DIFF
--- a/pysoa/common/serializer/json_serializer.py
+++ b/pysoa/common/serializer/json_serializer.py
@@ -41,12 +41,18 @@ class JSONSerializer(BaseSerializer):
         try:
             return json.dumps(data_dict).encode('utf-8')
         except TypeError as e:
-            raise InvalidField(*e.args)
+            raise InvalidField(
+                "Can't serialize message due to {}: {}".format(str(type(e).__name__), str(e)),
+                *e.args
+            )
 
     def blob_to_dict(self, blob):  # type: (six.binary_type) -> Dict
         try:
             if six.PY3 and isinstance(blob, six.binary_type):
                 return json.loads(blob.decode('utf-8'))
             return json.loads(blob)
-        except (ValueError, UnicodeDecodeError) as e:
-            raise InvalidMessage(*e.args)
+        except (ValueError, TypeError) as e:
+            raise InvalidMessage(
+                "Can't deserialize message due to {}: {}".format(str(type(e).__name__), str(e)),
+                *e.args
+            )

--- a/pysoa/common/serializer/msgpack_serializer.py
+++ b/pysoa/common/serializer/msgpack_serializer.py
@@ -96,13 +96,19 @@ class MsgpackSerializer(BaseSerializer):
         try:
             return msgpack.packb(data_dict, default=self._default, use_bin_type=True)
         except TypeError as e:
-            raise InvalidField(*e.args)
+            raise InvalidField(
+                "Can't serialize message due to {}: {}".format(str(type(e).__name__), str(e)),
+                *e.args
+            )
 
     def blob_to_dict(self, blob):  # type: (six.binary_type) -> Dict
         try:
             return msgpack.unpackb(blob, raw=False, ext_hook=self._ext_hook)
-        except (TypeError, msgpack.UnpackValueError, msgpack.ExtraData) as e:
-            raise InvalidMessage(*e.args)
+        except (ValueError, TypeError, msgpack.UnpackValueError, msgpack.ExtraData) as e:
+            raise InvalidMessage(
+                "Can't deserialize message due to {}: {}".format(str(type(e).__name__), str(e)),
+                *e.args
+            )
 
     def _default(self, obj):  # type: (Any) -> msgpack.ExtType
         """

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     'conformity~=1.26',
     'currint>=1.6,<3',
     'enum34;python_version<"3.4"',
-    'msgpack-python~=0.5,>=0.5.2',
+    'msgpack~=0.6,>=0.6.2',
     'pymetrics~=1.0',
     'pytz>=2019.1',
     'redis~=2.10',


### PR DESCRIPTION
- `msgpack-python` is a deprecated PyPi dependency. The library has been renamed to `msgpack`, and changing this is the only way to get the latest bug fixes. There are no breaking changes between these libraries (same module name, just a different paackage name).
- The serializers were masking the underlying error type and message when errors were encountered. This fixes that.