### PR TITLE
[PATCH] Try to make Travis builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,39 +14,6 @@ install:
 matrix:
   include:
     - stage: build
-      name: "Unit Tests: Python 2.7 with Attrs 18 and 19"
-      python: "2.7"
-      script:
-        - tox -e py27-attrs18,py27-attrs19,py27-flake8,py27-coverage
-    - stage: build
-      name: "Unit Tests: Python 3.5 with and without PyInotify"
-      python: "3.5"
-      script:
-        - tox -e py35,py35-pyinotify,coverage
-    - stage: build
-      name: "Unit Tests: Python 3.6 with Currint 1.6 and 2.0"
-      python: "3.6"
-      script:
-        - tox -e py36-currint16,py36-currint20,coverage
-    - stage: build
-      name: "Unit Tests: Python 3.7 with Attrs 18 and 19"
-      python: "3.7"
-      script:
-        - tox -e py37-attrs18,py37-attrs19,py37-flake8,coverage
-      dist: xenial
-    - stage: build
-      name: "Unit Tests: Python 3.7 with PyTest 4.6 and 5.1"
-      python: "3.7"
-      script:
-        - tox -e py37-pytest46,py37-pytest51,py37-flake8,coverage,py37-mypy
-      dist: xenial
-    - stage: build
-      name: "Unit Tests: Python 3.8"
-      python: "3.8"
-      script:
-        - tox -e py38,coverage,py38-mypy
-      dist: xenial
-    - stage: build
       name: "Functional Tests"
       language: shell
       dist: xenial
@@ -64,8 +31,30 @@ matrix:
         - docker-compose --version
       script:
         - ./functional.sh verbose
+    - stage: build
+      name: "Unit Tests: Python 2.7 with Attrs 18 and 19"
+      python: "2.7"
+      script:
+        - tox -e py27-attrs18,py27-flake8,py27-coverage
+    - stage: build
+      name: "Unit Tests: Python 3.5 with and without PyInotify; Pytest 5.1 and 5.3"
+      python: "3.5"
+      script:
+        - tox -e py35,py35-pyinotify,py35-pytest51,py35-pytest53,coverage
+    - stage: build
+      name: "Unit Tests: Python 3.7 with Attrs 18 and 19; PyTest 4.6 and 5.3"
+      python: "3.7"
+      script:
+        - tox -e py37-attrs18,py37-pytest46,py37-flake8,coverage,py37-mypy
+      dist: xenial
+    - stage: build
+      name: "Unit Tests: Python 3.8 with Currint 1.6 and 2.0"
+      python: "3.8"
+      script:
+        - tox -e py38,py38-currint16,coverage,py38-mypy
+      dist: xenial
     - stage: deploy
-      python: "3.6"
+      python: "3.7"
       script: skip
       install:
         - pip install -U pip setuptools pyopenssl

--- a/functional.sh
+++ b/functional.sh
@@ -43,14 +43,16 @@ done
 
 set -x
 
-docker build --tag pysoa-test-mysql --file tests/functional/docker/Dockerfile-mysql .
-docker build --tag pysoa-test-service --file tests/functional/docker/Dockerfile-service .
-docker build --tag pysoa-test-service-echo --file tests/functional/services/echo/Dockerfile .
+docker build --tag pysoa-test-mysql --file tests/functional/docker/Dockerfile-mysql . &
+docker build --tag pysoa-test-service --file tests/functional/docker/Dockerfile-service . &
+wait
+docker build --tag pysoa-test-service-echo --file tests/functional/services/echo/Dockerfile . &
+docker build --tag pysoa-test-service-meta --file tests/functional/services/meta/Dockerfile . &
+docker build --tag pysoa-test-service-user --file tests/functional/services/user/Dockerfile . &
+docker build --tag pysoa-test-test --file tests/functional/docker/Dockerfile-test . &
+wait
 docker build --tag pysoa-test-service-echo-double-import-trap \
     --file tests/functional/services/echo/Dockerfile-double-import-trap .
-docker build --tag pysoa-test-service-meta --file tests/functional/services/meta/Dockerfile .
-docker build --tag pysoa-test-service-user --file tests/functional/services/user/Dockerfile .
-docker build --tag pysoa-test-test --file tests/functional/docker/Dockerfile-test .
 
 set +ex
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist =
     py{27,35,36,37,38}
     py35-pyinotify
-    py36-currint{16,20}
+    py38-currint{16,20}
     py27-attrs{18,19}
     py37-attrs{18,19}
-    py37-pytest{46,51}
+    py{35,37}-pytest{46,51,53}
     py{27,37}-flake8
 #    py27-conformity_branch
 #    py37-conformity_branch
@@ -22,8 +22,9 @@ deps =
     pyinotify: pyinotify~=0.9
     currint16: currint~=1.6
     currint20: currint~=2.0
-    pytest46: pytest~=4.6.4
-    pytest51: pytest~=5.1.0
+    pytest46: pytest~=4.6.9
+    pytest51: pytest~=5.1.3
+    pytest53: pytest~=5.3.5
 #    ipdb
 commands =
 #    conformity_branch: pip uninstall -y conformity


### PR DESCRIPTION
Attempt to make Travis builds faster by consolidating the two Python 3.7 stages, eliminating the Python 3.6 stage, making functional tests start first, and running Docker builds in Parallel.