### PR TITLE
[PATCH] Fix #251: Replace use of Django's close_old_connections

### DIFF
--- a/pysoa/server/django/database.py
+++ b/pysoa/server/django/database.py
@@ -1,0 +1,59 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import logging
+
+
+__all__ = (
+    'django_close_old_database_connections',
+    'django_reset_database_queries',
+)
+
+
+_logger = logging.getLogger(__name__)
+
+
+try:
+    from django.conf import settings
+    from django.db import (
+        connections as _connections,
+        reset_queries as _django_reset_queries,
+    )
+    from django.db.utils import DatabaseError
+
+    try:
+        # noinspection PyPackageRequirements
+        from _pytest.outcomes import Failed
+    except ImportError:
+        class Failed(Exception):  # type: ignore
+            pass
+
+    def django_close_old_database_connections():  # type: () -> None
+        if getattr(settings, 'DATABASES'):
+            _logger.debug('Cleaning Django connections')
+            for connection in _connections.all():
+                try:
+                    if connection.get_autocommit():
+                        connection.close_if_unusable_or_obsolete()
+                except DatabaseError:
+                    # Sometimes old connections won't close because they have already been interrupted (timed out,
+                    # server moved, etc.). There's no reason to interrupt server processes for this problem. We can
+                    # continue on without issue.
+                    pass
+                except Failed:
+                    # `get_autocommit` fails under PyTest without `pytest.mark.django_db`, so we ignore that specific
+                    # error, because this is just a test.
+                    pass
+
+    def django_reset_database_queries():  # type: () -> None
+        if getattr(settings, 'DATABASES'):
+            _logger.debug('Resetting Django query log')
+            _django_reset_queries()
+except ImportError:
+    def django_close_old_database_connections():  # type: () -> None
+        pass
+
+    def django_reset_database_queries():  # type: () -> None
+        pass


### PR DESCRIPTION
Django's built-in `close_old_connections` can fail to close old or unstable connections if an error occurs with one database in a multi-database environment. Additionally, `close_old_connections` is just not really suited for use directly in PySOA. This change moves Django database maintenance tasks into a new module and calls those from the `Server` class, and it replaces the use of `close_old_connections` with a new function that performs extensive error checking.