### PR TITLE
[PATCH] Fix handling of empty structures in `get_all_paths`

### DIFF
--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -682,7 +682,7 @@ class Server(object):
             threads.setdefault(thread_id, {'name': thread_id})['traceback'] = stack
 
         extra = {'data': {'thread_status': {
-            t['name']: [l.rstrip() for l in t['traceback']] for t in threads.values()
+            t['name']: [l.rstrip() for l in t['traceback']] for t in threads.values()  # noqa: E741
         }}}
         details = 'Current thread status at harakiri trigger:\n{}'.format('\n'.join((
             'Thread {}:\n{}'.format(t['name'], '\n'.join(t['traceback'])) for t in threads.values()

--- a/pysoa/test/plan/grammar/tools.py
+++ b/pysoa/test/plan/grammar/tools.py
@@ -121,7 +121,11 @@ def path_get(data, path):
 
 def get_all_paths(data, current_path=''):
     # type: (Union[Mapping, List, Tuple, AbstractSet], six.text_type) -> List[six.text_type]
+    if current_path and not data:
+        return [current_path]  # explicit path to empty structure
+
     paths = []
+
     if isinstance(data, Mapping):
         for k, v in six.iteritems(data):
             if isinstance(k, six.string_types) and (k.isdigit() or '.' in k):

--- a/tests/integration/test/plan/first_fixtures/003_globals.pysoa
+++ b/tests/integration/test/plan/first_fixtures/003_globals.pysoa
@@ -25,6 +25,7 @@ stubbed_out: expect: no errors
 echo: input: drink: oceans
 echo: input: username: [[STUBBED_OUT.user.username]]
 echo: job context input str: locale: en_US
+echo: job context input int: switches.0: 5
 echo: job context input int: switches.1: 8
 echo: job context input int: switches.2: 15
 echo: job control input str: remote_control: pause


### PR DESCRIPTION
Fixes https://github.com/eventbrite/pysoa/issues/255

if [_global_directives are filled](https://github.com/eventbrite/pysoa/blob/236ac4147b9cd3ff96150e80bf2bcbcf0283c2b5/pysoa/test/plan/parser.py#L273) is used `get_all_paths` to recursively define where put each value detailed on the current test_case.
The iterable-like types are traveled for each item but for empty cases `{}` or `[]` this doesn't happen.
We'll check before doing the iteration block if are truth-ty values and if not return the current_path value.