### PR TITLE
[MINOR] Allow Server subclasses to set a custom introspection action

### DIFF
--- a/pysoa/server/action/introspection.py
+++ b/pysoa/server/action/introspection.py
@@ -18,7 +18,6 @@ from typing import (
 from conformity import fields
 import six
 
-from pysoa import server
 from pysoa.common.constants import ERROR_CODE_INVALID
 from pysoa.common.errors import Error
 from pysoa.server.action.base import Action
@@ -26,6 +25,7 @@ from pysoa.server.action.status import BaseStatusAction
 from pysoa.server.action.switched import SwitchedAction
 from pysoa.server.errors import ActionError
 from pysoa.server.internal.types import get_switch
+from pysoa.server.server import Server
 from pysoa.server.types import (
     ActionType,
     EnrichedActionRequest,
@@ -113,7 +113,7 @@ class IntrospectionAction(Action):
         optional_keys=('documentation', ),
     )
 
-    def __init__(self, server):  # type: (server.server.Server) -> None
+    def __init__(self, server):  # type: (Server) -> None
         """
         Construct a new introspection action. Unlike its base class, which accepts a server settings object, this
         must be passed a `Server` object, from which it will obtain a settings object. The `Server` code that calls
@@ -121,7 +121,7 @@ class IntrospectionAction(Action):
 
         :param server: A PySOA server instance
         """
-        if not isinstance(server, server.server.Server):
+        if not isinstance(server, Server):
             raise TypeError('First argument (server) must be a Server instance')
 
         super(IntrospectionAction, self).__init__(server.settings)

--- a/pysoa/server/action/introspection.py
+++ b/pysoa/server/action/introspection.py
@@ -18,6 +18,7 @@ from typing import (
 from conformity import fields
 import six
 
+from pysoa import server
 from pysoa.common.constants import ERROR_CODE_INVALID
 from pysoa.common.errors import Error
 from pysoa.server.action.base import Action
@@ -25,7 +26,6 @@ from pysoa.server.action.status import BaseStatusAction
 from pysoa.server.action.switched import SwitchedAction
 from pysoa.server.errors import ActionError
 from pysoa.server.internal.types import get_switch
-from pysoa.server.server import Server
 from pysoa.server.types import (
     ActionType,
     EnrichedActionRequest,
@@ -113,7 +113,7 @@ class IntrospectionAction(Action):
         optional_keys=('documentation', ),
     )
 
-    def __init__(self, server):  # type: (Server) -> None
+    def __init__(self, server):  # type: (server.server.Server) -> None
         """
         Construct a new introspection action. Unlike its base class, which accepts a server settings object, this
         must be passed a `Server` object, from which it will obtain a settings object. The `Server` code that calls
@@ -121,7 +121,7 @@ class IntrospectionAction(Action):
 
         :param server: A PySOA server instance
         """
-        if not isinstance(server, Server):
+        if not isinstance(server, server.server.Server):
             raise TypeError('First argument (server) must be a Server instance')
 
         super(IntrospectionAction, self).__init__(server.settings)

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -154,7 +154,7 @@ class Server(object):
     action_class_map = {}  # type: Mapping[six.text_type, ActionType]
 
     # Allow a server to specify a custom introspection action
-    introspection_action = None  # type: ActionType
+    introspection_action = None  # type: Callable[['Server'], Callable[[EnrichedActionRequest], ActionResponse]]
 
     def __init__(self, settings, forked_process_id=None):
         # type: (ServerSettings, Optional[int]) -> None

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -563,7 +563,7 @@ class Server(object):
                 elif action_request.action == 'introspect':
                     # If set, use custom introspection action. Use default otherwise.
                     if self.introspection_action is not None:
-                        action = self.introspection_action(server=self)
+                        action = self.introspection_action(self)
                     else:
                         from pysoa.server.action.introspection import IntrospectionAction
                         action = IntrospectionAction(server=self)

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -65,6 +65,7 @@ from pysoa.common.types import (
     UnicodeKeysDict,
 )
 from pysoa.server import middleware
+from pysoa.server.action.introspection import IntrospectionAction
 from pysoa.server.django.database import (
     django_close_old_database_connections,
     django_reset_database_queries,
@@ -148,6 +149,8 @@ class Server(object):
     settings_class = ServerSettings  # type: Type[ServerSettings]
     request_class = EnrichedActionRequest  # type: Type[EnrichedActionRequest]
     client_class = Client  # type: Type[Client]
+
+    introspection_action = IntrospectionAction  # type: ActionType
 
     use_django = False  # type: bool
     service_name = None  # type: Optional[six.text_type]
@@ -557,8 +560,7 @@ class Server(object):
                 if action_in_class_map:
                     action = self.action_class_map[action_request.action](self.settings)
                 elif action_request.action == 'introspect':
-                    from pysoa.server.action.introspection import IntrospectionAction
-                    action = IntrospectionAction(server=self)
+                    action = self.introspection_action(server=self)
                 else:
                     if not self._default_status_action_class:
                         from pysoa.server.action.status import make_default_status_action_class

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -80,6 +80,7 @@ from pysoa.server.types import (
     ActionType,
     EnrichedActionRequest,
     EnrichedJobRequest,
+    IntrospectionActionType,
 )
 import pysoa.version
 
@@ -154,7 +155,7 @@ class Server(object):
     action_class_map = {}  # type: Mapping[six.text_type, ActionType]
 
     # Allow a server to specify a custom introspection action
-    introspection_action = None  # type: Callable[['Server'], Callable[[EnrichedActionRequest], ActionResponse]]
+    introspection_action = None  # type: Optional[IntrospectionActionType]
 
     def __init__(self, settings, forked_process_id=None):
         # type: (ServerSettings, Optional[int]) -> None

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -227,3 +227,10 @@ ActionType = Union[
     Callable[[Optional[ServerSettings]], Callable[[EnrichedActionRequest], ActionResponse]],
 ]
 """A type used for annotating attributes and arguments that represent any valid action class or callable."""
+
+
+IntrospectionActionType = Callable[['Server'], Callable[[EnrichedActionRequest], ActionResponse]]
+"""
+A type used for annotating attributes and arguments that represent any valid
+introspection action class or callable.
+"""

--- a/pysoa/server/types.py
+++ b/pysoa/server/types.py
@@ -10,6 +10,7 @@ from typing import (
     Iterable,
     Optional,
     SupportsInt,
+    TYPE_CHECKING,
     Type,
     Union,
 )
@@ -47,6 +48,12 @@ try:
     RunCoroutineType = Callable[[pysoa.server.coroutine.Coroutine], concurrent.futures.Future]
 except (ImportError, SyntaxError):
     RunCoroutineType = None  # type: ignore
+
+if TYPE_CHECKING:
+    from pysoa.server.server import Server
+else:
+    class Server:
+        pass
 
 
 __all__ = (
@@ -229,7 +236,7 @@ ActionType = Union[
 """A type used for annotating attributes and arguments that represent any valid action class or callable."""
 
 
-IntrospectionActionType = Callable[['Server'], Callable[[EnrichedActionRequest], ActionResponse]]
+IntrospectionActionType = Callable[[Server], Callable[[EnrichedActionRequest], ActionResponse]]
 """
 A type used for annotating attributes and arguments that represent any valid
 introspection action class or callable.


### PR DESCRIPTION
Currently, it is more difficult than it needs to be to add information to the `introspect` action responses. This change allows a service implementer to easily override the default introspection action.