### PR TITLE
[PATCH] Prevent creation of empty sequences when global structures ar…

### DIFF
--- a/pysoa/test/plan/grammar/tools.py
+++ b/pysoa/test/plan/grammar/tools.py
@@ -119,9 +119,9 @@ def path_get(data, path):
     return path_get(new_data, path_rest)
 
 
-def get_all_paths(data, current_path=''):
-    # type: (Union[Mapping, List, Tuple, AbstractSet], six.text_type) -> List[six.text_type]
-    if current_path and not data:
+def get_all_paths(data, current_path='', allow_blank=False):
+    # type: (Union[Mapping, List, Tuple, AbstractSet], six.text_type, bool) -> List[six.text_type]
+    if allow_blank and current_path and not data:
         return [current_path]  # explicit path to empty structure
 
     paths = []
@@ -130,12 +130,12 @@ def get_all_paths(data, current_path=''):
         for k, v in six.iteritems(data):
             if isinstance(k, six.string_types) and (k.isdigit() or '.' in k):
                 k = '{{{}}}'.format(k)
-            paths.extend(get_all_paths(v, _dot_join(current_path, k)))
+            paths.extend(get_all_paths(v, _dot_join(current_path, k), allow_blank=allow_blank))
     elif isinstance(data, (list, tuple, AbstractSet)):  # do not use Sequence, definitely causes infinite recursion
         if isinstance(data, AbstractSet):
             data = sorted(list(data))
         for i, v in enumerate(data):
-            paths.extend(get_all_paths(v, _dot_join(current_path, i)))
+            paths.extend(get_all_paths(v, _dot_join(current_path, i), allow_blank=allow_blank))
     else:
         return [current_path]
     return paths

--- a/pysoa/test/plan/parser.py
+++ b/pysoa/test/plan/parser.py
@@ -274,16 +274,17 @@ class ServiceTestPlanFixtureParser(object):
             # merge, but make sure current overlays global where there is conflict
             test_case = {}  # type: TestCase
 
-            for path in get_all_paths(self._global_directives):
+            for path in get_all_paths(self._global_directives, allow_blank=True):
                 try:
-                    path_put(test_case, path, path_get(self._global_directives, path))
+                    value = path_get(self._global_directives, path)
+                    path_put(test_case, path, copy.copy(value))
                 except (KeyError, IndexError):
                     raise FixtureSyntaxError(
                         'Invalid path: `{}`'.format(path),
                         file_name=self._fixture_file_name,
                         line_number=line_number,
                     )
-            for path in get_all_paths(self._working_test_case):
+            for path in get_all_paths(self._working_test_case, allow_blank=True):
                 try:
                     path_put(test_case, path, path_get(self._working_test_case, path))
                 except (KeyError, IndexError):

--- a/tests/unit/test/plan/grammar/test_tools.py
+++ b/tests/unit/test/plan/grammar/test_tools.py
@@ -189,7 +189,7 @@ class TestPathAccessors(unittest.TestCase):
             },
         }
 
-        actual = get_all_paths(data)
+        actual = get_all_paths(data, allow_blank=True)
 
         expected = [
             'foo.aba_bar.0',


### PR DESCRIPTION
…e parsed

Fixes:
https://github.com/eventbrite/pysoa/issues/259

Provide a flag to check when we want to allow empty structures to return from get_all_paths. 
Also, do a copy of global_directives to prevent overwriting of actions fields