### PR TITLE
Capture stubs to autogenerate schemas for contract testing

### DIFF
--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -690,7 +690,7 @@ class Server(object):
             threads.setdefault(thread_id, {'name': thread_id})['traceback'] = stack
 
         extra = {'data': {'thread_status': {
-            t['name']: [l.rstrip() for l in t['traceback']] for t in threads.values()  # noqa: E741
+            t['name']: [line.rstrip() for line in t['traceback']] for t in threads.values()
         }}}
         details = 'Current thread status at harakiri trigger:\n{}'.format('\n'.join((
             'Thread {}:\n{}'.format(t['name'], '\n'.join(t['traceback'])) for t in threads.values()

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -290,7 +290,7 @@ _global_stub_action_request_counter = _StubActionRequestCounter()
 
 class _StubActionContractRegistry(object):
     def __init__(self):  # type: () -> None
-        self.contracts = []
+        self.contracts = []  # type: List[dict]
 
     def add(self, service, action, body):  # type: (six.text_type, six.text_type, Body) -> None
         self.contracts.append({
@@ -424,7 +424,7 @@ class stub_action(object):
         action,  # type: six.text_type
         body=None,  # type: Optional[Body]
         errors=None,  # type: Optional[Errors]
-        side_effect=None,  # type: _StubActionSideEffect,
+        side_effect=None,  # type: _StubActionSideEffect
         register_response_schema_contract=True,  # type: bool
         register_request_schema_contract=True,  # type: bool
     ):  # type: (...) -> None

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -552,7 +552,7 @@ class stub_action(object):
                 if mock_response:
                     ordered_actions_for_merging[i] = mock_response
                     job_response.actions.append(mock_response)
-                    if self.register_response_schema_contract and mock_response.body:
+                    if self.register_response_schema_contract and hasattr(mock_response, 'body'):
                         _global_stub_action_response_registry.add(self.service, self.action, mock_response.body)
                     if not continue_on_error and mock_response.errors:
                         break


### PR DESCRIPTION
Register stub responses and requests in stub_action for use in prototype contract testing