### PR TITLE
[MINOR] Treat UTC datetime strings as datetimes in test plans

### DIFF
--- a/pysoa/test/plan/grammar/data_types.py
+++ b/pysoa/test/plan/grammar/data_types.py
@@ -73,6 +73,9 @@ def get_all_data_type_names():  # type: () -> List[six.text_type]
 
 DataTypeGrammar = oneOf(get_all_data_type_names())('data_type')
 
+DATETIME_RE = re.compile(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z')
+DATE_RE = re.compile(r'\d{4}-\d{2}-\d{2}')
+
 
 class AnyValue(object):
     def __init__(self, data_type, permit_none=False):  # type: (six.text_type, bool) -> None
@@ -97,6 +100,32 @@ class AnyValue(object):
         if self.data_type == 'int':
             # For Python 2+3 compatibility, any int OR long value is permitted to satisfy an int AnyValue
             return isinstance(other, six.integer_types)
+
+        if (
+                self.data_type == 'datetime' and
+                type(other) == datetime.datetime
+        ):
+            return True
+
+        if (
+                self.data_type == 'datetime' and
+                isinstance(other, six.string_types) and
+                DATETIME_RE.match(other)
+        ):
+            return True
+
+        if (
+                self.data_type == 'date' and
+                type(other) == datetime.date
+        ):
+            return True
+
+        if (
+                self.data_type == 'date' and
+                isinstance(other, six.string_types) and
+                DATE_RE.match(other)
+        ):
+            return True
 
         if self.data_type == type(other).__name__:
             return True

--- a/tests/unit/test/plan/grammar/test_data_types.py
+++ b/tests/unit/test/plan/grammar/test_data_types.py
@@ -46,6 +46,11 @@ class TestAnyValue(unittest.TestCase):
         self.assertEqual(copy.copy(data_types.AnyValue('str')), 'Hello')
         self.assertEqual(copy.deepcopy(data_types.AnyValue('str')), 'Hello')
 
+    def test_datetime(self):
+        self.assertEqual(data_types.AnyValue('datetime'), '2018-09-01T00:00:00Z')
+        self.assertNotEqual(data_types.AnyValue('datetime'), 'Hello')
+        self.assertNotEqual(data_types.AnyValue('datetime'), 15)
+
 
 class TestRegexValue(unittest.TestCase):
     def test_not_string(self):

--- a/tests/unit/test/plan/grammar/test_data_types.py
+++ b/tests/unit/test/plan/grammar/test_data_types.py
@@ -51,6 +51,11 @@ class TestAnyValue(unittest.TestCase):
         self.assertNotEqual(data_types.AnyValue('datetime'), 'Hello')
         self.assertNotEqual(data_types.AnyValue('datetime'), 15)
 
+    def test_date(self):
+        self.assertEqual(data_types.AnyValue('date'), '2018-09-01')
+        self.assertNotEqual(data_types.AnyValue('date'), 'Bye')
+        self.assertNotEqual(data_types.AnyValue('date'), 51)
+
 
 class TestRegexValue(unittest.TestCase):
     def test_not_string(self):


### PR DESCRIPTION
# Description

As part of feature parity with our deprecated library of test-plans, we need to support for date-times represented as strings for `expect any` grammar ([related code in Legacy SOA](https://github.com/eventbrite/soa/blob/7.34.4/service/test/test_plan/data_types.py#L75-L99)).