### PR TITLE
[MINOR] Pass instance index into transport.

### DIFF
--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -63,11 +63,12 @@ class Transport(object):
     attributes.
     """
 
-    def __init__(self, service_name, metrics=noop_metrics):
-        # type: (six.text_type, MetricsRecorder) -> None
+    def __init__(self, service_name, instance_index, metrics=noop_metrics):
+        # type: (six.text_type, int, MetricsRecorder) -> None
         """
         :param service_name: The name of the service to which this transport will send requests (and from which it will
                              receive responses)
+        :param instance_index: The 1-based index of this process, identifying it among multiple forked processes
         :param metrics: The optional metrics recorder
         """
         if not isinstance(service_name, six.text_type):
@@ -76,6 +77,7 @@ class Transport(object):
             raise ValueError('metrics must be a MetricsRecorder')
 
         self.service_name = service_name
+        self.instance_index = instance_index
         self.metrics = metrics
 
 

--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -77,6 +77,7 @@ class LocalClientTransport(ClientTransport, ServerTransport):
     def __init__(
         self,
         service_name,  # type: six.text_type
+        instance_index,  # type: int
         metrics,  # type: MetricsRecorder
         server_class,  # type: Union[six.text_type, Type[Server]]
         server_settings  # type: Union[six.text_type, Dict[six.text_type, Any]]
@@ -88,7 +89,7 @@ class LocalClientTransport(ClientTransport, ServerTransport):
         :param server_class: The server class for which this transport will serve as a client
         :param server_settings: The server settings that will be passed to the server class on instantiation
         """
-        super(LocalClientTransport, self).__init__(service_name, metrics)
+        super(LocalClientTransport, self).__init__(service_name, instance_index, metrics)
 
         # If the server is specified as a path, resolve it to a class
         if isinstance(server_class, six.string_types):

--- a/pysoa/common/transport/redis_gateway/client.py
+++ b/pysoa/common/transport/redis_gateway/client.py
@@ -49,17 +49,18 @@ from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 ))
 class RedisClientTransport(ClientTransport):
 
-    def __init__(self, service_name, metrics, **kwargs):
+    def __init__(self, service_name, instance_index, metrics, **kwargs):
         # type: (six.text_type, MetricsRecorder, **Any) -> None
         """
-        In addition to the two named positional arguments, this constructor expects keyword arguments abiding by the
+        In addition to the named positional arguments, this constructor expects keyword arguments abiding by the
         Redis transport settings schema.
 
         :param service_name: The name of the service to which this transport will send requests (and from which it will
                              receive responses)
+        :param instance_index: The 1-based index of this process among multiple forks
         :param metrics: The optional metrics recorder
         """
-        super(RedisClientTransport, self).__init__(service_name, metrics)
+        super(RedisClientTransport, self).__init__(service_name, instance_index, metrics)
 
         self.client_id = uuid.uuid4().hex
         self._send_queue_name = make_redis_queue_name(service_name)

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -29,16 +29,17 @@ from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 @fields.ClassConfigurationSchema.provider(RedisServerTransportSchema)
 class RedisServerTransport(ServerTransport):
 
-    def __init__(self, service_name, metrics, **kwargs):
+    def __init__(self, service_name, instance_index, metrics, **kwargs):
         # type: (six.text_type, MetricsRecorder, **Any) -> None
         """
-        In addition to the two named positional arguments, this constructor expects keyword arguments abiding by the
+        In addition to the named positional arguments, this constructor expects keyword arguments abiding by the
         Redis transport settings schema.
 
         :param service_name: The name of the service for which this transport will receive requests and send responses
+        :param instance_index: The 1-based index of this process among multiple forks
         :param metrics: The optional metrics recorder
         """
-        super(RedisServerTransport, self).__init__(service_name, metrics)
+        super(RedisServerTransport, self).__init__(service_name, instance_index, metrics)
 
         self._receive_queue_name = make_redis_queue_name(service_name)
         # noinspection PyArgumentList

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -182,12 +182,15 @@ class Server(object):
                 elif publisher.get('kwargs', {}):
                     _replace_fid(publisher['kwargs'], fid)
 
+        instance_index = forked_process_id or 1
+
         # Create the metrics recorder and transport
         self.metrics = self.settings['metrics']['object'](
             **self.settings['metrics'].get('kwargs', {})
         )  # type: MetricsRecorder
         self.transport = self.settings['transport']['object'](
             self.service_name,
+            instance_index,
             self.metrics,
             **self.settings['transport'].get('kwargs', {})
         )  # type: ServerTransport

--- a/pysoa/test/stub_service.py
+++ b/pysoa/test/stub_service.py
@@ -219,6 +219,7 @@ class StubClientTransport(LocalClientTransport):
     def __init__(
         self,
         service_name='test',  # type: six.text_type
+        instance_index=1,  # type: int
         metrics=None,  # type: Optional[MetricsRecorder]
         action_map=None,  # type: Optional[Mapping[six.text_type, Mapping[six.text_type, Any]]]
     ):
@@ -228,6 +229,7 @@ class StubClientTransport(LocalClientTransport):
         action mapping provided.
 
         :param service_name: The service name.
+        :param instance_index: The 1-based index of this process among multiple forks
         :param metrics: You can omit this, but if you really want, override the default `NoOpMetricsRecorder`.
         :param action_map: Dictionary of `{action_name: {'body': action_body, 'errors': action_errors}}` where
                            `action_body` is a dictionary and `action_errors` is a list.
@@ -244,7 +246,8 @@ class StubClientTransport(LocalClientTransport):
             (StubServer,),
             dict(service_name=service_name, action_class_map=action_class_map),
         ))
-        super(StubClientTransport, self).__init__(service_name, metrics or noop_metrics, server_class, {})
+        super(StubClientTransport, self).__init__(service_name, instance_index,
+                                                  metrics or noop_metrics, server_class, {})
 
     def stub_action(self, action, body=None, errors=None):
         # type: (six.text_type, Optional[Body], Optional[Errors]) -> None

--- a/tests/unit/common/transport/redis_gateway/test_server.py
+++ b/tests/unit/common/transport/redis_gateway/test_server.py
@@ -17,7 +17,7 @@ from pysoa.test.compatibility import mock
 class TestServerTransport(unittest.TestCase):
     @staticmethod
     def _get_transport(service='my_service', **kwargs):
-        return RedisServerTransport(service, noop_metrics, **kwargs)
+        return RedisServerTransport(service, 1, noop_metrics, **kwargs)
 
     def test_core_args(self, mock_core):
         transport = self._get_transport(hello='world', goodbye='earth')

--- a/tests/unit/common/transport/redis_gateway/test_threading.py
+++ b/tests/unit/common/transport/redis_gateway/test_threading.py
@@ -106,6 +106,7 @@ class TestThreadSafety(unittest.TestCase):
 
         server_transport = RedisServerTransport(
             'threaded',
+            1,  # instance index
             noop_metrics,
             backend_type=REDIS_BACKEND_TYPE_STANDARD,
         )
@@ -113,6 +114,7 @@ class TestThreadSafety(unittest.TestCase):
 
         client_transport = RedisClientTransport(
             'threaded',
+            1,  # instance index
             noop_metrics,
             backend_type=REDIS_BACKEND_TYPE_STANDARD,
         )


### PR DESCRIPTION
This will allow the transport to know which forked process it is,
which is necessary if transport instances are sharing resources
like ports.