### PR TITLE
[MINOR] Pass instance index into transport.

### DIFF
--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -119,7 +119,17 @@ class ClientTransport(Transport):
 class ServerTransport(Transport):
     """
     The base server transport defining the interface for transacting PySOA payloads on the server side.
+
+    :param service_name: The name of the service for which this transport will receive requests and send responses
+    :param instance_index: The 1-based index of this process among multiple forks
+    :param metrics: The optional metrics recorder
     """
+
+    def __init__(self, service_name, instance_index, metrics=noop_metrics):
+        # type: (six.text_type, int, MetricsRecorder) -> None
+        super(ServerTransport, self).__init__(service_name, metrics)
+
+        self.instance_index = instance_index
 
     @abc.abstractmethod
     def receive_request_message(self):

--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -125,7 +125,7 @@ class ServerTransport(Transport):
     :param metrics: The optional metrics recorder
     """
 
-    def __init__(self, service_name, instance_index, metrics=noop_metrics):
+    def __init__(self, service_name, instance_index=1, metrics=noop_metrics):
         # type: (six.text_type, int, MetricsRecorder) -> None
         super(ServerTransport, self).__init__(service_name, metrics)
 

--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -126,7 +126,7 @@ class ServerTransport(Transport):
     """
 
     def __init__(self, service_name, metrics=noop_metrics, instance_index=1):
-        # type: (six.text_type, int, MetricsRecorder) -> None
+        # type: (six.text_type, MetricsRecorder, int) -> None
         super(ServerTransport, self).__init__(service_name, metrics)
 
         self.instance_index = instance_index

--- a/pysoa/common/transport/base.py
+++ b/pysoa/common/transport/base.py
@@ -121,11 +121,11 @@ class ServerTransport(Transport):
     The base server transport defining the interface for transacting PySOA payloads on the server side.
 
     :param service_name: The name of the service for which this transport will receive requests and send responses
-    :param instance_index: The 1-based index of this process among multiple forks
     :param metrics: The optional metrics recorder
+    :param instance_index: The 1-based index of this process among multiple forks
     """
 
-    def __init__(self, service_name, instance_index=1, metrics=noop_metrics):
+    def __init__(self, service_name, metrics=noop_metrics, instance_index=1):
         # type: (six.text_type, int, MetricsRecorder) -> None
         super(ServerTransport, self).__init__(service_name, metrics)
 

--- a/pysoa/common/transport/local.py
+++ b/pysoa/common/transport/local.py
@@ -88,7 +88,7 @@ class LocalClientTransport(ClientTransport, ServerTransport):
         :param server_class: The server class for which this transport will serve as a client
         :param server_settings: The server settings that will be passed to the server class on instantiation
         """
-        super(LocalClientTransport, self).__init__(service_name, metrics)
+        super(LocalClientTransport, self).__init__(service_name, metrics)  # type: ignore
 
         # If the server is specified as a path, resolve it to a class
         if isinstance(server_class, six.string_types):

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -29,17 +29,17 @@ from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 @fields.ClassConfigurationSchema.provider(RedisServerTransportSchema)
 class RedisServerTransport(ServerTransport):
 
-    def __init__(self, service_name, instance_index, metrics, **kwargs):
+    def __init__(self, service_name, metrics, instance_index, **kwargs):
         # type: (six.text_type, int, MetricsRecorder, **Any) -> None
         """
         In addition to the named positional arguments, this constructor expects keyword arguments abiding by the
         Redis transport settings schema.
 
         :param service_name: The name of the service for which this transport will receive requests and send responses
-        :param instance_index: The 1-based index of this process among multiple forks
         :param metrics: The optional metrics recorder
+        :param instance_index: The 1-based index of this process among multiple forks
         """
-        super(RedisServerTransport, self).__init__(service_name, instance_index, metrics)
+        super(RedisServerTransport, self).__init__(service_name, metrics, instance_index)
 
         self._receive_queue_name = make_redis_queue_name(service_name)
         # noinspection PyArgumentList

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -30,7 +30,7 @@ from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 class RedisServerTransport(ServerTransport):
 
     def __init__(self, service_name, metrics, instance_index, **kwargs):
-        # type: (six.text_type, int, MetricsRecorder, **Any) -> None
+        # type: (six.text_type, MetricsRecorder, int, **Any) -> None
         """
         In addition to the named positional arguments, this constructor expects keyword arguments abiding by the
         Redis transport settings schema.

--- a/pysoa/common/transport/redis_gateway/server.py
+++ b/pysoa/common/transport/redis_gateway/server.py
@@ -29,16 +29,17 @@ from pysoa.common.transport.redis_gateway.utils import make_redis_queue_name
 @fields.ClassConfigurationSchema.provider(RedisServerTransportSchema)
 class RedisServerTransport(ServerTransport):
 
-    def __init__(self, service_name, metrics, **kwargs):
-        # type: (six.text_type, MetricsRecorder, **Any) -> None
+    def __init__(self, service_name, instance_index, metrics, **kwargs):
+        # type: (six.text_type, int, MetricsRecorder, **Any) -> None
         """
-        In addition to the two named positional arguments, this constructor expects keyword arguments abiding by the
+        In addition to the named positional arguments, this constructor expects keyword arguments abiding by the
         Redis transport settings schema.
 
         :param service_name: The name of the service for which this transport will receive requests and send responses
+        :param instance_index: The 1-based index of this process among multiple forks
         :param metrics: The optional metrics recorder
         """
-        super(RedisServerTransport, self).__init__(service_name, metrics)
+        super(RedisServerTransport, self).__init__(service_name, instance_index, metrics)
 
         self._receive_queue_name = make_redis_queue_name(service_name)
         # noinspection PyArgumentList

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -182,12 +182,15 @@ class Server(object):
                 elif publisher.get('kwargs', {}):
                     _replace_fid(publisher['kwargs'], fid)
 
+        instance_index = forked_process_id or 1
+
         # Create the metrics recorder and transport
         self.metrics = self.settings['metrics']['object'](
             **self.settings['metrics'].get('kwargs', {})
         )  # type: MetricsRecorder
         self.transport = self.settings['transport']['object'](
             self.service_name,
+            instance_index,
             self.metrics,
             **self.settings['transport'].get('kwargs', {})
         )  # type: ServerTransport

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -182,15 +182,13 @@ class Server(object):
                 elif publisher.get('kwargs', {}):
                     _replace_fid(publisher['kwargs'], fid)
 
-        instance_index = forked_process_id or 1
-
         # Create the metrics recorder and transport
         self.metrics = self.settings['metrics']['object'](
             **self.settings['metrics'].get('kwargs', {})
         )  # type: MetricsRecorder
         self.transport = self.settings['transport']['object'](
             self.service_name,
-            instance_index,
+            forked_process_id or 1,  # If no forking, there's only 1 instance
             self.metrics,
             **self.settings['transport'].get('kwargs', {})
         )  # type: ServerTransport

--- a/pysoa/server/server.py
+++ b/pysoa/server/server.py
@@ -188,8 +188,8 @@ class Server(object):
         )  # type: MetricsRecorder
         self.transport = self.settings['transport']['object'](
             self.service_name,
-            forked_process_id or 1,  # If no forking, there's only 1 instance
             self.metrics,
+            forked_process_id or 1,  # If no forking, there's only 1 instance
             **self.settings['transport'].get('kwargs', {})
         )  # type: ServerTransport
 

--- a/tests/unit/common/transport/redis_gateway/test_server.py
+++ b/tests/unit/common/transport/redis_gateway/test_server.py
@@ -17,7 +17,7 @@ from pysoa.test.compatibility import mock
 class TestServerTransport(unittest.TestCase):
     @staticmethod
     def _get_transport(service='my_service', **kwargs):
-        return RedisServerTransport(service, noop_metrics, **kwargs)
+        return RedisServerTransport(service, 1, noop_metrics, **kwargs)
 
     def test_core_args(self, mock_core):
         transport = self._get_transport(hello='world', goodbye='earth')

--- a/tests/unit/common/transport/redis_gateway/test_server.py
+++ b/tests/unit/common/transport/redis_gateway/test_server.py
@@ -17,7 +17,7 @@ from pysoa.test.compatibility import mock
 class TestServerTransport(unittest.TestCase):
     @staticmethod
     def _get_transport(service='my_service', **kwargs):
-        return RedisServerTransport(service, 1, noop_metrics, **kwargs)
+        return RedisServerTransport(service, noop_metrics, 1, **kwargs)
 
     def test_core_args(self, mock_core):
         transport = self._get_transport(hello='world', goodbye='earth')

--- a/tests/unit/common/transport/redis_gateway/test_threading.py
+++ b/tests/unit/common/transport/redis_gateway/test_threading.py
@@ -106,6 +106,7 @@ class TestThreadSafety(unittest.TestCase):
 
         server_transport = RedisServerTransport(
             'threaded',
+            1,
             noop_metrics,
             backend_type=REDIS_BACKEND_TYPE_STANDARD,
         )

--- a/tests/unit/common/transport/redis_gateway/test_threading.py
+++ b/tests/unit/common/transport/redis_gateway/test_threading.py
@@ -106,8 +106,8 @@ class TestThreadSafety(unittest.TestCase):
 
         server_transport = RedisServerTransport(
             'threaded',
-            1,
             noop_metrics,
+            1,
             backend_type=REDIS_BACKEND_TYPE_STANDARD,
         )
         server_transport.core._backend_layer = backend  # type: ignore

--- a/tests/unit/server/test_server/test_handle_next_request.py
+++ b/tests/unit/server/test_server/test_handle_next_request.py
@@ -45,7 +45,7 @@ class TestProcessNextRequests(TestCase):
         """
         settings = factories.ServerSettingsFactory()
         server = HandleNextRequestServer(settings=settings)
-        server.transport = SimplePassthroughServerTransport(server.service_name)
+        server.transport = SimplePassthroughServerTransport(server.service_name, instance_index=1)
 
         server.transport.set_request({})
         server.handle_next_request()

--- a/tests/unit/server/test_server/test_handle_next_request.py
+++ b/tests/unit/server/test_server/test_handle_next_request.py
@@ -45,7 +45,7 @@ class TestProcessNextRequests(TestCase):
         """
         settings = factories.ServerSettingsFactory()
         server = HandleNextRequestServer(settings=settings)
-        server.transport = SimplePassthroughServerTransport(server.service_name, instance_index=1)
+        server.transport = SimplePassthroughServerTransport(server.service_name)
 
         server.transport.set_request({})
         server.handle_next_request()


### PR DESCRIPTION
This will allow the transport to know which forked process it is,
which is necessary if transport instances are sharing resources
like ports.