### PR TITLE
[PATCH] Document race condition on chunk + parallel actions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -344,11 +344,14 @@ Methods
     responses, allowing you to send requests asynchronously, perform other work, and then use the future object to
     retrieve the expected responses.
 
-.. DANGER:: If you know that the server response is potentially going
-   to be chunked, do not use ``call_actions_parallel`` or
-   ``call_jobs_parallel`` (or any ``future`` variant) as there is a
-   bug that is going to make the request fail under due to a race
-   condition.
++--------------------------------------------------------------------+
+|**Warning: Chunking and parallel actions**                          |
++====================================================================+
+|If you know that the server response is potentially going to be     |
+|chunked, do not use ``call_actions_parallel`` or                    |
+|``call_jobs_parallel`` (or any ``future`` variant) as there is a bug|
+|that is going to make the request fail due to a race condition.     |
++--------------------------------------------------------------------+
 
 Client configuration
 ********************

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -344,6 +344,11 @@ Methods
     responses, allowing you to send requests asynchronously, perform other work, and then use the future object to
     retrieve the expected responses.
 
+.. DANGER:: If you know that the server response is potentially going
+   to be chunked, do not use ``call_actions_parallel`` or
+   ``call_jobs_parallel`` (or any ``future`` variant) as there is a
+   bug that is going to make the request fail under due to a race
+   condition.
 
 Client configuration
 ********************

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -345,7 +345,7 @@ Methods
     retrieve the expected responses.
 
 +--------------------------------------------------------------------+
-|Warning: Chunking and parallel action's call                        |
+|Warning: Chunking and parallel action's calls                       |
 +====================================================================+
 |If you know that the server response is potentially going to be     |
 |chunked, do not use ``call_actions_parallel`` or                    |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -345,7 +345,7 @@ Methods
     retrieve the expected responses.
 
 +--------------------------------------------------------------------+
-|**Warning: Chunking and parallel actions**                          |
+|Warning: Chunking and parallel action's call                        |
 +====================================================================+
 |If you know that the server response is potentially going to be     |
 |chunked, do not use ``call_actions_parallel`` or                    |

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -246,14 +246,14 @@ The serialized envelope pieces from each chunk will be reassembled in order and 
 nature of the Redis transport and distributed workers, only responses can be chunked. Requests cannot be chunked, and
 it is not even possible to configure chunking in the client transport.)
 
-==============================
-**Chunking and parallel actions**
-==============================
-If you know that the server response is potentially going to be
-chunked, do not use ``call_actions_parallel`` or
-``call_jobs_parallel`` (or any ``future`` variant) as there is a bug
-that is going to make the request fail due to a race condition.
-==============================
++--------------------------------------------------------------------+
+|**Chunking and parallel actions**                                   |
++====================================================================+
+|If you know that the server response is potentially going to be     |
+|chunked, do not use ``call_actions_parallel`` or                    |
+|``call_jobs_parallel`` (or any ``future`` variant) as there is a bug|
+|that is going to make the request fail due to a race condition.     |
++--------------------------------------------------------------------+
 
 The response envelope is very similar to the request envelope::
 

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -247,7 +247,7 @@ nature of the Redis transport and distributed workers, only responses can be chu
 it is not even possible to configure chunking in the client transport.)
 
 +--------------------------------------------------------------------+
-|**Warning: Chunking and parallel actions**                          |
+|Warning: Chunking and parallel action's calls                       |
 +====================================================================+
 |If you know that the server response is potentially going to be     |
 |chunked, do not use ``call_actions_parallel`` or                    |

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -247,7 +247,7 @@ nature of the Redis transport and distributed workers, only responses can be chu
 it is not even possible to configure chunking in the client transport.)
 
 +--------------------------------------------------------------------+
-|**Chunking and parallel actions**                                   |
+|**Warning: Chunking and parallel actions**                          |
 +====================================================================+
 |If you know that the server response is potentially going to be     |
 |chunked, do not use ``call_actions_parallel`` or                    |

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -246,6 +246,11 @@ The serialized envelope pieces from each chunk will be reassembled in order and 
 nature of the Redis transport and distributed workers, only responses can be chunked. Requests cannot be chunked, and
 it is not even possible to configure chunking in the client transport.)
 
+.. DANGER:: If you know that the server response is potentially going
+   to be chunked, do not use ``call_actions_parallel`` or
+   ``call_jobs_parallel`` (or any ``future`` variant) as there is a
+   bug that is going to make the request fail due to a race condition.
+
 The response envelope is very similar to the request envelope::
 
     {

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -246,10 +246,14 @@ The serialized envelope pieces from each chunk will be reassembled in order and 
 nature of the Redis transport and distributed workers, only responses can be chunked. Requests cannot be chunked, and
 it is not even possible to configure chunking in the client transport.)
 
-.. DANGER:: If you know that the server response is potentially going
-   to be chunked, do not use ``call_actions_parallel`` or
-   ``call_jobs_parallel`` (or any ``future`` variant) as there is a
-   bug that is going to make the request fail due to a race condition.
+==============================
+**Chunking and parallel actions**
+==============================
+If you know that the server response is potentially going to be
+chunked, do not use ``call_actions_parallel`` or
+``call_jobs_parallel`` (or any ``future`` variant) as there is a bug
+that is going to make the request fail due to a race condition.
+==============================
 
 The response envelope is very similar to the request envelope::
 


### PR DESCRIPTION
Document that ``chunking`` is not compatible with ``parallel`` call
variants.