### PR TITLE
Use Ubuntu 20.04 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
         git \
         liblua5.1-0-dev \
         lua5.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
@@ -17,18 +19,21 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
         python3.5-dev \
         python3.6 \
         python3.6-dev \
+        python3.6-distutils \
         python3.7 \
         python3.7-dev \
+        python3.7-distutils \
         python3.8 \
         python3.8-distutils \
         python3.8-dev
 
+RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py -O /tmp/get-pip-36.py
 RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
 # RUN python2.7 /tmp/get-pip.py --disable-pip-version-check --disable-pip-version-check "pip==19.3.1" && \
 #     mv -v "$(which pip)" "$(which pip)2.7"
 # RUN python3.5 /tmp/get-pip.py --disable-pip-version-check --disable-pip-version-check "pip==19.3.1" && \
 #     mv -v "$(which pip)" "$(which pip)3.5"
-RUN python3.6 /tmp/get-pip.py --disable-pip-version-check --disable-pip-version-check "pip==19.3.1" && \
+RUN python3.6 /tmp/get-pip-36.py --disable-pip-version-check --disable-pip-version-check "pip==19.3.1" && \
     mv -v "$(which pip)" "$(which pip)3.6"
 RUN python3.7 /tmp/get-pip.py --disable-pip-version-check --disable-pip-version-check "pip==19.3.1" && \
     mv -v "$(which pip)" "$(which pip)3.7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM ubuntu:20.04
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y \
         git \
         liblua5.1-0-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ test_plan_requirements = test_helper_requirements + [
 ]
 
 mypy_require = [
-    'mypy~=0.740;python_version>"3.4"',
+    'mypy~=0.740,<=0.910;python_version>"3.4"',
     'types-six~=0.1.7;python_version>"3.4"',
     'types-setuptools~=57.0.0;python_version>"3.4"',
     'types-mock~=0.1.3;python_version>"3.4"',

--- a/tests/functional/docker/Dockerfile-mysql
+++ b/tests/functional/docker/Dockerfile-mysql
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:5.7-debian
 
 RUN apt-get update && apt-get install -y locales locales-all tzdata && apt-get clean
 

--- a/tests/functional/docker/docker-compose.yaml
+++ b/tests/functional/docker/docker-compose.yaml
@@ -5,7 +5,9 @@ networks:
 
 services:
   mysql:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile-mysql
     image: "pysoa-test-mysql"
     networks:
       pysoa:
@@ -352,7 +354,9 @@ services:
 
   # Services and test container
   echo_service:
-    build: .
+    build:
+      context: .
+      dockerfile: ../services/echo/Dockerfile
     image: "pysoa-test-service-echo"
     init: true
     stop_grace_period: 15s
@@ -368,7 +372,9 @@ services:
       redis6-standalone:
         condition: service_healthy
   echo_service_double_import_trap:
-    build: .
+    build:
+      context: .
+      dockerfile: ../services/echo/Dockerfile-double-import-trap
     image: "pysoa-test-service-echo-double-import-trap"
     init: true
     stop_grace_period: 15s
@@ -384,7 +390,9 @@ services:
       redis6-standalone:
         condition: service_healthy
   meta_service:
-    build: .
+    build:
+      context: .
+      dockerfile: ../services/meta/Dockerfile
     image: "pysoa-test-service-meta"
     init: true
     stop_grace_period: 15s
@@ -398,7 +406,9 @@ services:
       redis5-sentinel1:
         condition: service_healthy
   user_service:
-    build: .
+    build:
+      context: .
+      dockerfile: ../services/user/Dockerfile
     image: "pysoa-test-service-user"
     init: true
     stop_grace_period: 15s
@@ -416,7 +426,9 @@ services:
       meta_service:
         condition: service_started
   test:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile-test
     image: "pysoa-test-test"
     init: true
     networks:

--- a/tests/functional/docker/docker-compose.yaml
+++ b/tests/functional/docker/docker-compose.yaml
@@ -5,6 +5,7 @@ networks:
 
 services:
   mysql:
+    build: .
     image: "pysoa-test-mysql"
     networks:
       pysoa:
@@ -351,6 +352,7 @@ services:
 
   # Services and test container
   echo_service:
+    build: .
     image: "pysoa-test-service-echo"
     init: true
     stop_grace_period: 15s
@@ -366,6 +368,7 @@ services:
       redis6-standalone:
         condition: service_healthy
   echo_service_double_import_trap:
+    build: .
     image: "pysoa-test-service-echo-double-import-trap"
     init: true
     stop_grace_period: 15s
@@ -381,6 +384,7 @@ services:
       redis6-standalone:
         condition: service_healthy
   meta_service:
+    build: .
     image: "pysoa-test-service-meta"
     init: true
     stop_grace_period: 15s
@@ -394,6 +398,7 @@ services:
       redis5-sentinel1:
         condition: service_healthy
   user_service:
+    build: .
     image: "pysoa-test-service-user"
     init: true
     stop_grace_period: 15s
@@ -411,6 +416,7 @@ services:
       meta_service:
         condition: service_started
   test:
+    build: .
     image: "pysoa-test-test"
     init: true
     networks:


### PR DESCRIPTION
Tests were not working anymore because they were using a deprecated Ubuntu version (16.04).

This PR updates the Dockerfile to use the newest available (22.04 was not an option because [it does not support Python 3.5 anymore](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)).

I needed to make some adjustments to make everything work with the new Ubuntu version:

In the Dockerfile:
- `ENV DEBIAN_FRONTEND=noninteractive` to avoid showing [this prompt](https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai)
- `python3.6-distutils` and `python3.7-distutils` seems to not be core python packages anymore in new Ubuntu versions.
- Regular `get-pip.py` doesn't support Python 3.6 anymore, you need to fetch it separately

Some other changes:
- `mypy<=0.910`. I ran it locally and it start complaining above some of the pysoa files with versions above that one.
- "mysql:5.7-debian" because the default one now is Oracle's, which does not have apt-get.
- Local build in the docker-compose file. Since docker-compose 1.25.1 docker will display a warning when trying to get a remote image, so I needed to explicit state that the build is local. _[Docker Compose now reports images that cannot be pulled, however, are required to be built.](https://docs.docker.com/compose/release-notes/#1251)_