### PR TITLE
[MINOR] EB-207224 -- fixed unicode serialization issue

### DIFF
--- a/pysoa/common/serializer/msgpack_serializer.py
+++ b/pysoa/common/serializer/msgpack_serializer.py
@@ -94,7 +94,7 @@ class MsgpackSerializer(BaseSerializer):
         if not isinstance(data_dict, dict):
             raise ValueError('Input must be a dict')
         try:
-            return msgpack.packb(data_dict, default=self._default, use_bin_type=True, unicode_errors='replace')
+            return msgpack.packb(data_dict, default=self._default, use_bin_type=True, unicode_errors='surrogatepass')
         except TypeError as e:
             raise InvalidField(
                 "Can't serialize message due to {}: {}".format(str(type(e).__name__), str(e)),

--- a/pysoa/common/serializer/msgpack_serializer.py
+++ b/pysoa/common/serializer/msgpack_serializer.py
@@ -94,7 +94,7 @@ class MsgpackSerializer(BaseSerializer):
         if not isinstance(data_dict, dict):
             raise ValueError('Input must be a dict')
         try:
-            return msgpack.packb(data_dict, default=self._default, use_bin_type=True)
+            return msgpack.packb(data_dict, default=self._default, use_bin_type=True, unicode_errors='replace')
         except TypeError as e:
             raise InvalidField(
                 "Can't serialize message due to {}: {}".format(str(type(e).__name__), str(e)),

--- a/tests/unit/common/test_serializers.py
+++ b/tests/unit/common/test_serializers.py
@@ -204,7 +204,7 @@ class TestMsgpackSerializer(object):
 
     def test_invalid_utf8(self):
         serializer = MsgpackSerializer()
-        input_value =  u'value \ud83d'
-        expected_value = 'value ?'
+        input_value =  {'v': u'value \ud83d'}
+        expected_bytes = b'\x81\xa1v\xa9value \xed\xa0\xbd'
 
-        assert serializer.blob_to_dict(serializer.dict_to_blob({'v': input_value}))['v'] == expected_value
+        assert serializer.dict_to_blob(input_value) == expected_bytes

--- a/tests/unit/common/test_serializers.py
+++ b/tests/unit/common/test_serializers.py
@@ -201,3 +201,10 @@ class TestMsgpackSerializer(object):
     def test_currint(self, value):
         serializer = MsgpackSerializer()
         assert serializer.blob_to_dict(serializer.dict_to_blob({'v': value}))['v'] == value
+
+    def test_invalid_utf8(self):
+        serializer = MsgpackSerializer()
+        input_value =  u'value \ud83d'
+        expected_value = 'value ?'
+
+        assert serializer.blob_to_dict(serializer.dict_to_blob({'v': input_value}))['v'] == expected_value


### PR DESCRIPTION
This PR should fix [incident 617](https://eventbrite.slack.com/archives/C04FMN96BDY) that is being caused due to invalid utf-8 characters being returned from some service calls.