### PR TITLE
[MINOR] chore: migrate coverage upload to qlty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,12 @@ matrix:
       python: "3.7"
       script:
         - tox -e py37-attrs18,py37-attrs19,py37-attrs20,py37-attrs21,py37-pytest46,py37-flake8,coverage,py37-mypy
+      after_script:
+        - |
+          if [ -f coverage.xml ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+            curl https://qlty.sh/install.sh | sh
+            $HOME/.qlty/bin/qlty coverage publish coverage.xml --format cobertura || true
+          fi
       dist: xenial
     # Lunatic-python-universal seems incompatible with Python 3.8
     # - stage: build

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ deps = coverage~=4.5
 commands =
     coverage combine
     coverage report
+    coverage xml -o coverage.xml
 
 [testenv:py27-coverage]
 skip_install = true


### PR DESCRIPTION
# Migrate Coverage Upload to QLTY

## Summary

This PR migrates coverage reporting from local-only to QLTY Cloud. Changes were made by AI and may contain mistakes - please review carefully.

## Changes Made

1. **Added XML coverage report generation** in `tox.ini`:
   - Added `coverage xml -o coverage.xml` to the `coverage` environment
   - This generates a Cobertura XML file that QLTY can consume

2. **Added QLTY coverage upload** to `.travis.yml`:
   - Installs QLTY CLI in `after_script` section
   - Uploads `coverage.xml` to QLTY when running on `master` branch
   - Uses `|| true` to prevent CI failures if upload fails

## Setup Required

1. **Set QLTY_COVERAGE_TOKEN** in Travis CI environment variables:
   - Go to: https://qlty.sh/gh/eventbrite/pysoa/settings/coverage/reports
   - Copy the coverage token
   - Add it as `QLTY_COVERAGE_TOKEN` in Travis CI project settings

2. **Verify coverage upload**:
   - After merging, check that coverage appears in QLTY dashboard
   - Coverage upload only runs on `master` branch (default branch requirement)

## Testing

- Coverage generation tested via existing tox configuration
- QLTY upload will be validated in CI after token is configured
- **Note**: Travis CI is deprecated - consider migrating to GitHub Actions or CircleCI in the future

## Coverage Details

- **Format**: Cobertura XML (`coverage.xml`)
- **Location**: Repository root
- **Generated by**: `tox -e coverage` environment
- **Upload trigger**: Push to `master` branch

