### PR TITLE
Reduce redis calls by 25%

### DIFF
--- a/pysoa/common/transport/redis_gateway/backend/base.py
+++ b/pysoa/common/transport/redis_gateway/backend/base.py
@@ -46,15 +46,20 @@ class LuaRedisCommand(object):
 
 class SendMessageToQueueCommand(LuaRedisCommand):
     # KEYS[1] = queue key
-    # ARGV[1] = expiry
-    # ARGV[2] = queue capacity
+    # ARGV[1] = expiry (only applied to response queues, identified by '!' in key name)
+    # ARGV[2] = queue capacity (only enforced for request queues, i.e. no '!' in key name)
     # ARGV[3] = message
     _script = """
-if redis.call('llen', KEYS[1]) >= tonumber(ARGV[2]) then
-    return redis.error_reply("queue full")
+local is_response_queue = string.find(KEYS[1], '!', 1, true)
+if not is_response_queue then
+    if redis.call('llen', KEYS[1]) >= tonumber(ARGV[2]) then
+        return redis.error_reply("queue full")
+    end
 end
 redis.call('rpush', KEYS[1], ARGV[3])
-redis.call('expire', KEYS[1], ARGV[1])
+if is_response_queue then
+    redis.call('expire', KEYS[1], ARGV[1])
+end
 """
 
     def __call__(

--- a/tests/unit/common/transport/redis_gateway/backend/test_sentinel.py
+++ b/tests/unit/common/transport/redis_gateway/backend/test_sentinel.py
@@ -262,3 +262,49 @@ class TestSentinelRedisChannelClient(unittest.TestCase):
 
         self.assertIsNotNone(message)
         self.assertEqual(payload3, msgpack.unpackb(message, raw=False))
+
+    @mock.patch('redis.sentinel.Sentinel', new=MockSentinel)
+    def test_request_queue_has_no_expire(self):
+        client = self._set_up_client()
+        connection = client.get_connection('test_request_queue_has_no_expire')
+
+        client.send_message_to_queue(
+            queue_key='test_request_queue_has_no_expire',
+            message=msgpack.packb({'test': 'value'}, use_bin_type=True),
+            expiry=10,
+            capacity=10,
+            connection=connection,
+        )
+
+        self.assertEqual(-1, connection.ttl('test_request_queue_has_no_expire'))
+
+    @mock.patch('redis.sentinel.Sentinel', new=MockSentinel)
+    def test_response_queue_has_expire(self):
+        client = self._set_up_client()
+        connection = client.get_connection('test_response_queue_has_expire!')
+
+        client.send_message_to_queue(
+            queue_key='test_response_queue_has_expire!',
+            message=msgpack.packb({'test': 'value'}, use_bin_type=True),
+            expiry=30,
+            capacity=10,
+            connection=connection,
+        )
+
+        self.assertGreater(connection.ttl('test_response_queue_has_expire!'), 0)
+
+    @mock.patch('redis.sentinel.Sentinel', new=MockSentinel)
+    def test_response_queue_ignores_capacity(self):
+        client = self._set_up_client()
+        connection = client.get_connection('test_response_queue_ignores_capacity!')
+
+        for i in range(5):
+            client.send_message_to_queue(
+                queue_key='test_response_queue_ignores_capacity!',
+                message=msgpack.packb({'index': i}, use_bin_type=True),
+                expiry=10,
+                capacity=3,
+                connection=connection,
+            )
+
+        self.assertEqual(5, connection.llen('test_response_queue_ignores_capacity!'))

--- a/tests/unit/common/transport/redis_gateway/backend/test_standard.py
+++ b/tests/unit/common/transport/redis_gateway/backend/test_standard.py
@@ -280,3 +280,46 @@ class TestStandardRedisClient(unittest.TestCase):
 
         self.assertIsNotNone(message)
         self.assertEqual(payload, msgpack.unpackb(message, raw=False))
+
+    def test_request_queue_has_no_expire(self):
+        client = self._set_up_client()
+        connection = client.get_connection('test_request_queue_has_no_expire')
+
+        client.send_message_to_queue(
+            queue_key='test_request_queue_has_no_expire',
+            message=msgpack.packb({'test': 'value'}, use_bin_type=True),
+            expiry=10,
+            capacity=10,
+            connection=connection,
+        )
+
+        self.assertEqual(-1, connection.ttl('test_request_queue_has_no_expire'))
+
+    def test_response_queue_has_expire(self):
+        client = self._set_up_client()
+        connection = client.get_connection('test_response_queue_has_expire!')
+
+        client.send_message_to_queue(
+            queue_key='test_response_queue_has_expire!',
+            message=msgpack.packb({'test': 'value'}, use_bin_type=True),
+            expiry=30,
+            capacity=10,
+            connection=connection,
+        )
+
+        self.assertGreater(connection.ttl('test_response_queue_has_expire!'), 0)
+
+    def test_response_queue_ignores_capacity(self):
+        client = self._set_up_client()
+        connection = client.get_connection('test_response_queue_ignores_capacity!')
+
+        for i in range(5):
+            client.send_message_to_queue(
+                queue_key='test_response_queue_ignores_capacity!',
+                message=msgpack.packb({'index': i}, use_bin_type=True),
+                expiry=10,
+                capacity=3,
+                connection=connection,
+            )
+
+        self.assertEqual(5, connection.llen('test_response_queue_ignores_capacity!'))


### PR DESCRIPTION
## Reduce Redis CPU by optimizing request/response queue Lua script

### Background
At high request throughput, every Redis command counts. The existing Lua script
executed on every `send_message_to_queue` call performs three Redis operations
unconditionally for all queue types:

llen [calculate queue capacity to determine whether to reject the message] → rpush [enqueue message] → expire [delete stale queues]

and then calls blpop to wait.

The insight here is that request queues are per-service, and thus never _need_ to expire. And response queue size doesn't matter, as it can just fill up indefinitely and get deleted when it is stale with the expire call. So we can remove the expire call on the request, and the llen call on the response

### What changed

The Lua script in `SendMessageToQueueCommand` now differentiates between
**request queues** and **response queues** using the `!` specifier already
present in response queue key names, and applies only the operations each type
actually needs:

| Queue type | Before | After |
|---|---|---|
| Request queue (no `!`) | `llen` + `rpush` + `expire` | `llen` + `rpush` |
| Response queue (has `!`) | `llen` + `rpush` + `expire` | `rpush` + `expire` |

**Remove `expire` from request queues** — Request queues are permanent
per-service constructs. The `expire` was resetting the TTL on every push anyway,
so the queue key never expired in normal operation. When idle, an empty key
expiring vs. not expiring makes no functional difference: `blpop` blocks on
non-existent keys just as well as existing empty ones, and the next `rpush`
recreates the key regardless. The message-level `__expiry__` check in Python
meta continues to handle stale message detection correctly.
**Remove `llen` from response queues** — Response queues are single-use: the
server pushes one response (or one set of chunks), the client immediately pops
it. They will never meaningfully approach their capacity limit. The `llen` call
here was pure overhead.
**Net savings: ~25% reduction in total Redis command volume.

### Why this approach
- **No protocol or message format changes** — purely a Redis-side optimization.
- **Single change point** — the Lua script is the only place that needs updating.
  No changes to Python send/receive logic, settings schema, or client/server APIs.
- **Self-contained queue type detection** — the `!` specifier is already the
  canonical signal used throughout the codebase to distinguish response queues
  from request queues (connection routing, consistent hashing). Reusing it in
  the Lua script keeps the logic consistent.

### Backwards compatibility
**Fully backwards compatible. No deploy sequencing required.**
The sender and receiver are decoupled — receivers (`blpop`) don't inspect
anything the sender's Lua script did to the key before the push. During a
rolling deploy, all mixed-version combinations are safe:
- **Old client → new server**: Old client sets `expire` on request queue. New
  server `blpop`s from it. No issue.
- **New client → old server**: New client sends without `expire`. Old server
  `blpop`s. No issue — the server never inspects the key's TTL.
- **Old server → new client**: Old server checks `llen` before responding. New
  client reads response. No issue.
- **New server → old client**: New server skips `llen` on response queue. Old
  client reads response. No issue.

### Deployment

#### Rolling deploy (recommended)
Deploy normally with no special sequencing. Old and new instances can coexist
indefinitely during rollout because:
1. Redis caches Lua scripts by SHA1 (`EVALSHA`). The old and new scripts have
   different SHAs and coexist in Redis's script cache without conflict. Old
   instances keep using the old SHA; new instances register and use the new SHA.
2. No message format changes, no handshake, no version negotiation required.

#### Post-deploy
- **Redis key count**: Idle request queue keys previously expired from Redis
  after `message_expiry_in_seconds` (default 60s) of inactivity. They now
  persist indefinitely. This is operationally harmless (empty lists are a few
  bytes), but if you have `DBSIZE`-based alerts or Redis memory dashboards,
  expect the key count to stabilize slightly higher once services that were
  previously cycling through TTL expiry no longer do.
- **Script cache cleanup** (optional): After all instances are on the new
  version, the old Lua SHA remains in Redis's script cache but is no longer
  used. If you want to reclaim it, `SCRIPT FLUSH` clears all cached scripts;
  redis-py transparently re-registers scripts on next use.

#### Rollback
Rollback is safe at any point — reverting to the old code simply means those
instances start using the old Lua SHA again, which is still cached in Redis.